### PR TITLE
Bug Fixes and some cleanups

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## 0.12.0-beta - ???
 * Issue #72: Moved the shaded jar name from classifier to a new artifact name
+* Issues #73, #87: Added better logging to help understand which columns and filters
+  are asked by spark, and which are passed down to BigQuery
+* Issue #107: The connector will now alert when is is used with the wrong scala version
 
 ## 0.11.0-beta - 2019-12-18
 * Upgrade version of google-cloud-bigquery library to 1.102.0

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 lazy val scala211Version = "2.11.12"
-lazy val scala212Version = "2.12.7"
+lazy val scala212Version = "2.12.10"
 lazy val sparkVersion = "2.4.0"
 
 lazy val commonSettings = Seq(
@@ -38,8 +38,11 @@ lazy val connector = (project in file("connector"))
       "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
       "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
       "org.slf4j" % "slf4j-api" % "1.7.25" % "provided",
+      "org.codehaus.jackson" % "jackson-core-asl" % "1.9.13" % "provided",
+      "org.codehaus.jackson" % "jackson-mapper-asl" % "1.9.13" % "provided",
 
-      // Keep com.google.cloud dependencies in sync
+
+// Keep com.google.cloud dependencies in sync
       "com.google.cloud" % "google-cloud-bigquery" % "1.103.0",
       "com.google.cloud" % "google-cloud-bigquerystorage" % "0.120.1-beta",
       // Keep in sync with com.google.cloud
@@ -48,7 +51,9 @@ lazy val connector = (project in file("connector"))
       "com.google.guava" % "guava" % "28.1-jre",
 
       // runtime
-      "com.google.cloud.bigdataoss" % "gcs-connector" % "hadoop2-2.0.0" % "runtime",
+      // scalastyle:off
+      "com.google.cloud.bigdataoss" % "gcs-connector" % "hadoop2-2.0.0" % "runtime" classifier("shaded"),
+      // scalastyle:on
 
       // test
       "org.scalatest" %% "scalatest" % "3.1.0" % "test",
@@ -107,8 +112,6 @@ val excludedOrgs = Seq(
   "javax.annotation",
   // Spark Uses 2.9.9 google-cloud-core uses 2.9.2
   "joda-time",
-  // All use jackson-core-asl:1.9.13
-  "org.codehaus.jackson",
   "com.sun.jdmk",
   "com.sun.jmx",
   "javax.activation",

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
@@ -30,6 +30,8 @@ class BigQueryRelationProvider(
     with SchemaRelationProvider
     with DataSourceRegister {
 
+  BigQueryUtil.validateScalaVersionCompatibility
+
   override def createRelation(sqlContext: SQLContext,
                               parameters: Map[String, String]): BaseRelation = {
     createRelationInternal(sqlContext, parameters)

--- a/connector/src/test/scala/com/google/cloud/spark/bigquery/it/SparkBigQueryEndToEndITSuite.scala
+++ b/connector/src/test/scala/com/google/cloud/spark/bigquery/it/SparkBigQueryEndToEndITSuite.scala
@@ -181,7 +181,7 @@ class SparkBigQueryEndToEndITSuite extends FunSuite
 
   test("balanced partitions") {
     import com.google.cloud.spark.bigquery._
-    failAfter(60 seconds) {
+    failAfter(120 seconds) {
       // Select first partition
       val df = spark.read
           .option("parallelism", 5)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/maven/"
 
-addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.6")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 

--- a/project/project/assembly.sbt
+++ b/project/project/assembly.sbt
@@ -1,2 +1,1 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 


### PR DESCRIPTION
* Issue #72: Moved the shaded jar name from classifier to a new artifact name
* Issues #73, #87: Added better logging to help understand which columns and filters
  are asked by spark, and which are passed down to BigQuery
* Issue #107: The connector will now alert when is is used with the wrong scala version
