### PR TITLE
Update the connector to use BigQuery Storage API v1beta2.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ lazy val connector = (project in file("connector"))
 
 // Keep com.google.cloud dependencies in sync
       "com.google.cloud" % "google-cloud-bigquery" % "1.103.0",
-      "com.google.cloud" % "google-cloud-bigquerystorage" % "0.120.1-beta",
+      "com.google.cloud" % "google-cloud-bigquerystorage" % "0.122.0-beta",
       // Keep in sync with com.google.cloud
       "io.grpc" % "grpc-netty-shaded" % "1.25.0",
       "com.google.api" % "gax-grpc" % "1.52.0",

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryUtil.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryUtil.scala
@@ -96,7 +96,7 @@ object BigQueryUtil {
     cause match {
       case sse: StatusRuntimeException =>
         sse.getStatus.getCode == Status.Code.INTERNAL &&
-        InternalErrorMessages.exists(errorMsg => cause.getMessage.contains(errorMsg))    
+        InternalErrorMessages.exists(errorMsg => cause.getMessage.contains(errorMsg))
       case _ => false
     }
   }

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/MockResponsesBatch.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/MockResponsesBatch.java
@@ -15,8 +15,7 @@
  */
 package com.google.cloud.spark.bigquery;
 
-import com.google.cloud.bigquery.storage.v1beta1.Storage.ReadRowsResponse;
-import com.google.protobuf.Message;
+import com.google.cloud.bigquery.storage.v1beta2.ReadRowsResponse;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Queue;

--- a/connector/src/test/scala/com/google/cloud/spark/bigquery/ReadRowsSuite.scala
+++ b/connector/src/test/scala/com/google/cloud/spark/bigquery/ReadRowsSuite.scala
@@ -15,8 +15,7 @@
  */
 package com.google.cloud.spark.bigquery
 
-import com.google.cloud.bigquery.storage.v1beta1.Storage
-import com.google.cloud.bigquery.storage.v1beta1.Storage.{ReadRowsRequest, ReadRowsResponse}
+import com.google.cloud.bigquery.storage.v1beta2.{ReadRowsRequest, ReadRowsResponse}
 import com.google.cloud.spark.bigquery.direct.{ReadRowsClient, ReadRowsHelper}
 import io.grpc.{Status, StatusRuntimeException}
 import org.mockito.Mockito._
@@ -27,9 +26,7 @@ class ReadRowsSuite extends AnyFunSuite with Matchers {
 
   val client = mock(classOf[ReadRowsClient])
 
-  val request = ReadRowsRequest.newBuilder().setReadPosition(
-    Storage.StreamPosition.newBuilder().setStream(
-      Storage.Stream.newBuilder().setName("test")))
+  val request = ReadRowsRequest.newBuilder().setReadStream("test")
 
   test("no failures") {
     val batch1 = new MockResponsesBatch


### PR DESCRIPTION
This change switches the BigQuery Spark connector to use the BigQuery Storage API latest beta version, v1beta2.

The location of the v1beta2 client is:
https://github.com/googleapis/java-bigquerystorage/tree/master/google-cloud-bigquerystorage/src/main/java/com/google/cloud/bigquery/storage/v1beta2

Service protos:
https://github.com/googleapis/googleapis/tree/master/google/cloud/bigquery/storage/v1beta2

Verified locally by running integraion tests and the Python example 'shakespeare.py'.