### PR TITLE
Use access token for the Authorisation

### DIFF
--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/SparkBigQueryOptions.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/SparkBigQueryOptions.scala
@@ -90,7 +90,7 @@ object SparkBigQueryOptions {
   private val PermittedIntermediateFormats = Set(FormatOptions.orc(), FormatOptions.parquet())
   private val PermittedReadDataFormats = Set(DataFormat.ARROW.toString, DataFormat.AVRO.toString)
 
-  val GcsAccessToken = "spark.gcpAccessToken"
+  val GcsAccessToken = "gcpAccessToken"
 
   def apply(
              parameters: Map[String, String],

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/SparkBigQueryOptions.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/SparkBigQueryOptions.scala
@@ -90,7 +90,7 @@ object SparkBigQueryOptions {
   private val PermittedIntermediateFormats = Set(FormatOptions.orc(), FormatOptions.parquet())
   private val PermittedReadDataFormats = Set(DataFormat.ARROW.toString, DataFormat.AVRO.toString)
 
-  val GcsAccessToken = "spark.gcs.user.accessToken"
+  val GcsAccessToken = "spark.gcpAccessToken"
 
   def apply(
              parameters: Map[String, String],

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/SparkBigQueryOptions.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/SparkBigQueryOptions.scala
@@ -46,9 +46,9 @@ case class SparkBigQueryOptions(
     partitionType: Option[String] = None,
     createDisposition: Option[CreateDisposition] = None,
     optimizedEmptyProjection: Boolean = true,
+    accessToken: Option[String] = None,
     viewExpirationTimeInHours: Int = 24,
-    maxReadRowsRetries: Int = 3,
-    accessToken: Option[String] = None
+    maxReadRowsRetries: Int = 3
   ) {
 
   def createCredentials: Option[Credentials] =
@@ -79,7 +79,7 @@ object SparkBigQueryOptions {
   val DefaultFormat: FormatOptions = FormatOptions.parquet()
   private val PermittedIntermediateFormats = Set(FormatOptions.orc(), FormatOptions.parquet())
 
-  val GcsAccessTokenConfig = "spark.gcs.user.accessToken"
+  val GcsAccessToken = "spark.gcs.user.accessToken"
 
   def apply(
              parameters: Map[String, String],
@@ -132,14 +132,14 @@ object SparkBigQueryOptions {
 
     val optimizedEmptyProjection = getAnyBooleanOption(
       allConf, parameters, "optimizedEmptyProjection", true)
-    val accessToken = getAnyOption(allConf, parameters, GcsAccessTokenConfig)
+    val accessToken = getAnyOption(allConf, parameters, GcsAccessToken)
 
     SparkBigQueryOptions(tableId, parentProject, credsParam, credsFileParam,
       filter, schema, maxParallelism, temporaryGcsBucket, intermediateFormat,
       combinePushedDownFilters, viewsEnabled, materializationProject,
       materializationDataset, partitionField, partitionExpirationMs,
       partitionRequireFilter, partitionType, createDisposition,
-      optimizedEmptyProjection, accessToken = accessToken)
+      optimizedEmptyProjection, accessToken)
   }
 
   private def defaultBilledProject = () =>


### PR DESCRIPTION
With this change, the user can pass the access token to the spark with conf `spark.gcs.user.accessToken` and the same will be used for the authorization of the big-query resources.

This change still does not support refreshing the access token on expiry which would become an issue for the long-running spark applications.

I am currently thinking of this approach to solve this - 
1. User passes the refresh token, client ID and client secret to Spark along with the access token if she wants to auto-refresh the access token.
2. When the BigQueryRelation gets created, on the driver,  generate the access token if not already available. 
3. Broadcast the generated access token so that each executor has access to it.
4. Run a daemon thread on the driver which asynchronously refreshes the access token before the expiry so that each executor always has the valid access token. ( I will have to research a bit on this part to update the value of the already broadcasted conf).

Let me know if this sounds workable or if there is some simpler approach to do this. 
