### PR TITLE
Changing the refernce of the public data sets to bigquery-public-data

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The connector uses the cross language [Spark SQL Data Source API](https://spark.
 ```
 df = spark.read
   .format("bigquery")
-  .option("table", "publicdata.samples.shakespeare")
+  .option("table", "bigquery-public-data.samples.shakespeare")
   .load()
 ```
 
@@ -111,7 +111,7 @@ or the Scala only implicit API:
 
 ```
 import com.google.cloud.spark.bigquery._
-val df = spark.read.bigquery("publicdata.samples.shakespeare")
+val df = spark.read.bigquery("bigquery-public-data.samples.shakespeare")
 ```
 
 See [Shakespeare.scala](src/main/scala/com/google/cloud/spark/bigquery/examples/Shakespeare.scala) and [shakespeare.py](examples/python/shakespeare.py) for more information.
@@ -462,7 +462,7 @@ When casting to Timestamp TIME have the same TimeZone issues as DATETIME
 The connector automatically computes column and pushdown filters the DataFrame's `SELECT` statement e.g.
 
 ```
-spark.read.bigquery("publicdata:samples.shakespeare")
+spark.read.bigquery("bigquery-public-data:samples.shakespeare")
   .select("word")
   .where("word = 'Hamlet' or word = 'Claudius'")
   .collect()
@@ -474,7 +474,7 @@ filters to the column `word`  and pushed down the predicate filter `word = 'haml
 If you do not wish to make multiple read requests to BigQuery, you can cache the DataFrame before filtering e.g.:
 
 ```
-val cachedDF = spark.read.bigquery("publicdata:samples.shakespeare").cache()
+val cachedDF = spark.read.bigquery("bigquery-public-data:samples.shakespeare").cache()
 val rows = cachedDF.select("word")
   .where("word = 'Hamlet'")
   .collect()

--- a/build.sbt
+++ b/build.sbt
@@ -44,12 +44,13 @@ lazy val connector = (project in file("connector"))
       "org.codehaus.jackson" % "jackson-mapper-asl" % "1.9.13" % "provided",
 
 
-// Keep com.google.cloud dependencies in sync
+      // Keep com.google.cloud dependencies in sync
       "com.google.cloud" % "google-cloud-bigquery" % "1.110.0",
       "com.google.cloud" % "google-cloud-bigquerystorage" % "0.126.0-beta",
       // Keep in sync with com.google.cloud
-      "io.grpc" % "grpc-netty-shaded" % "1.27.0",
-      "com.google.api" % "gax-grpc" % "1.54.0",
+      "io.grpc" % "grpc-alts" % "1.28.1",
+      "io.grpc" % "grpc-netty-shaded" % "1.28.1",
+      "com.google.api" % "gax-grpc" % "1.55.0",
       "com.google.guava" % "guava" % "28.2-jre",
 
       // runtime

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/examples/JavaShakespeare.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/examples/JavaShakespeare.java
@@ -34,7 +34,7 @@ public class JavaShakespeare {
 
     // Load data in from BigQuery.
     Dataset<Row> wordsDF = spark.read().format("bigquery")
-        .option("table", "publicdata.samples.shakespeare").load().cache();
+        .option("table", "bigquery-public-data.samples.shakespeare").load().cache();
     wordsDF.show();
     wordsDF.printSchema();
     wordsDF.createOrReplaceTempView("words");

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/examples/Shakespeare.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/examples/Shakespeare.scala
@@ -31,7 +31,7 @@ object Shakespeare {
     spark.conf.set("temporaryGcsBucket", bucket)
 
     // Load data in from BigQuery.
-    val wordsDF = spark.read.bigquery("publicdata.samples.shakespeare").cache()
+    val wordsDF = spark.read.bigquery("bigquery-public-data.samples.shakespeare").cache()
     wordsDF.show()
     wordsDF.printSchema()
     wordsDF.createOrReplaceTempView("words")

--- a/connector/src/test/scala/com/google/cloud/spark/bigquery/it/SparkBigQueryEndToEndITSuite.scala
+++ b/connector/src/test/scala/com/google/cloud/spark/bigquery/it/SparkBigQueryEndToEndITSuite.scala
@@ -197,7 +197,7 @@ class SparkBigQueryEndToEndITSuite extends FunSuite
     test("test optimized count(*). Data Format %s".format(dataFormat)) {
       DirectBigQueryRelation.emptyRowRDDsCreated = 0
       val oldMethodCount = spark.read.format("bigquery")
-        .option("table", "publicdata.samples.shakespeare")
+        .option("table", "bigquery-public-data.samples.shakespeare")
         .option("readDataFormat", dataFormat)
         .option("optimizedEmptyProjection", "false")
         .load()
@@ -208,7 +208,7 @@ class SparkBigQueryEndToEndITSuite extends FunSuite
 
       assertResult(oldMethodCount) {
         spark.read.format("bigquery")
-          .option("table", "publicdata.samples.shakespeare")
+          .option("table", "bigquery-public-data.samples.shakespeare")
           .option("readDataFormat", dataFormat)
           .load()
           .count()
@@ -219,7 +219,7 @@ class SparkBigQueryEndToEndITSuite extends FunSuite
     test("test optimized count(*) with filter. Data Format %s".format(dataFormat)) {
       DirectBigQueryRelation.emptyRowRDDsCreated = 0
       val oldMethodCount = spark.read.format("bigquery")
-        .option("table", "publicdata.samples.shakespeare")
+        .option("table", "bigquery-public-data.samples.shakespeare")
         .option("optimizedEmptyProjection", "false")
         .option("readDataFormat", dataFormat)
         .load()
@@ -231,7 +231,7 @@ class SparkBigQueryEndToEndITSuite extends FunSuite
 
       assertResult(oldMethodCount) {
         spark.read.format("bigquery")
-          .option("table", "publicdata.samples.shakespeare")
+          .option("table", "bigquery-public-data.samples.shakespeare")
           .option("readDataFormat", dataFormat)
           .load()
           .where("corpus_date > 0")
@@ -243,7 +243,7 @@ class SparkBigQueryEndToEndITSuite extends FunSuite
     test("keeping filters behaviour. Data Format %s".format(dataFormat)) {
       val newBehaviourWords = extractWords(
         spark.read.format("bigquery")
-          .option("table", "publicdata.samples.shakespeare")
+          .option("table", "bigquery-public-data.samples.shakespeare")
           .option("filter", "length(word) = 1")
           .option("combinePushedDownFilters", "true")
           .option("readDataFormat", dataFormat)
@@ -251,7 +251,7 @@ class SparkBigQueryEndToEndITSuite extends FunSuite
 
       val oldBehaviourWords = extractWords(
         spark.read.format("bigquery")
-          .option("table", "publicdata.samples.shakespeare")
+          .option("table", "bigquery-public-data.samples.shakespeare")
           .option("filter", "length(word) = 1")
           .option("combinePushedDownFilters", "false")
           .option("readDataFormat", dataFormat)
@@ -264,13 +264,13 @@ class SparkBigQueryEndToEndITSuite extends FunSuite
   test("OR across columns with Arrow") {
 
     val avroResults = spark.read.format("bigquery")
-      .option("table", "publicdata.samples.shakespeare")
+      .option("table", "bigquery-public-data.samples.shakespeare")
       .option("filter", "word_count = 1 OR corpus_date = 0")
       .option("readDataFormat", "AVRO")
       .load().collect()
 
     val arrowResults = spark.read.format("bigquery")
-      .option("table", "publicdata.samples.shakespeare")
+      .option("table", "bigquery-public-data.samples.shakespeare")
       .option("readDataFormat", "ARROW")
       .load().where("word_count = 1 OR corpus_date = 0")
       .collect()
@@ -281,13 +281,13 @@ class SparkBigQueryEndToEndITSuite extends FunSuite
   test("Count with filters - Arrow") {
 
     val countResults = spark.read.format("bigquery")
-      .option("table", "publicdata.samples.shakespeare")
+      .option("table", "bigquery-public-data.samples.shakespeare")
       .option("readDataFormat", "ARROW")
       .load().where("word_count = 1 OR corpus_date = 0")
       .count()
 
     val countAfterCollect = spark.read.format("bigquery")
-      .option("table", "publicdata.samples.shakespeare")
+      .option("table", "bigquery-public-data.samples.shakespeare")
       .option("readDataFormat", "ARROW")
       .load().where("word_count = 1 OR corpus_date = 0")
       .collect().size

--- a/examples/notebooks/Top words in Shakespeare by work.ipynb
+++ b/examples/notebooks/Top words in Shakespeare by work.ipynb
@@ -36,7 +36,7 @@
    "source": [
     "df = spark.read \\\n",
     "  .format('bigquery') \\\n",
-    "  .option('table', 'publicdata.samples.shakespeare') \\\n",
+    "  .option('table', 'bigquery-public-data.samples.shakespeare') \\\n",
     "  .load()"
    ]
   },

--- a/examples/python/shakespeare.py
+++ b/examples/python/shakespeare.py
@@ -19,7 +19,7 @@ from pyspark.sql import SparkSession
 
 spark = SparkSession.builder.appName('Shakespeare WordCount').getOrCreate()
 
-table = 'publicdata.samples.shakespeare'
+table = 'bigquery-public-data.samples.shakespeare'
 df = spark.read.format('bigquery').option('table', table).load()
 # Only these columns will be read
 df = df.select('word', 'word_count')


### PR DESCRIPTION
The old reference we've used (`pubblicdata`) is causing internal errors on the server side