### PR TITLE
Do filter push down when reading from views

### DIFF
--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
@@ -275,7 +275,7 @@ private[bigquery] class DirectBigQueryRelation(
   def getNumBytes(tableDefinition: TableDefinition): Long = {
     val tableType = tableDefinition.getType
     if (options.viewsEnabled && TableDefinition.Type.VIEW == tableType) {
-      0
+      sqlContext.sparkSession.sessionState.conf.defaultSizeInBytes
     } else {
       tableDefinition.asInstanceOf[StandardTableDefinition].getNumBytes
     }


### PR DESCRIPTION
Here's a fix for filter push down for views. I've moved temp table creation to the moment when "buildScan" is invoked. The defaultTableDefinition type is changed to "TableDefinition" and a separate method "getNumBytes" is created to calculate the size of the table. The "getNumBytes" returns zero bytes for views, and that should be fine as the important part is that the connector calculates the number of partitions after the temp table is generated and by that time the getNumBytes will be called on the temp table, not the view.