### PR TITLE
Spark streaming real time

### DIFF
--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/BackoffImpl.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/BackoffImpl.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spark.bigquery
+
+import java.util.concurrent.TimeUnit
+
+import com.google.api.client.util.BackOff
+
+import scala.concurrent.duration.Duration
+
+/**
+ * Backoff implementation ported from Beam BigQuery connector
+ * @param backoffConfig
+ */
+case class BackoffImpl(backoffConfig: FluentBackoff) extends BackOff {
+  // Current state
+  private var currentCumulativeBackoff: Duration = null
+  private var currentRetry: Int = 0
+  private val DEFAULT_RANDOMIZATION_FACTOR = 0.5
+
+  override def reset(): Unit = {
+    currentRetry = 0
+    currentCumulativeBackoff = Duration.Zero
+  }
+
+  override def nextBackOffMillis(): Long = {
+    // Maximum number of retries reached.
+    if (currentRetry >= backoffConfig.maxRetries) {
+      return BackOff.STOP
+    }
+    // Maximum cumulative backoff reached.
+    if (currentCumulativeBackoff.compareTo(backoffConfig.maxCumulativeBackoff) >= 0) {
+      return BackOff.STOP
+    }
+
+    val currentIntervalMillis = Math.min(
+      backoffConfig.initialBackoff.toMillis * Math.pow(backoffConfig.exponent, currentRetry),
+      backoffConfig.maxBackoff.toMillis)
+    val randomOffset = (Math.random * 2 - 1) *
+      DEFAULT_RANDOMIZATION_FACTOR *
+      currentIntervalMillis
+    var nextBackoffMillis = currentIntervalMillis + randomOffset.round
+
+    // Cap to limit on cumulative backoff
+    val remainingCumulative = backoffConfig.maxCumulativeBackoff.minus(currentCumulativeBackoff)
+    nextBackoffMillis = Math.min(nextBackoffMillis, remainingCumulative.toMillis)
+
+    // Update state and return backoff.
+    currentCumulativeBackoff = currentCumulativeBackoff.plus(
+      Duration.create(nextBackoffMillis, TimeUnit.MILLISECONDS))
+    currentRetry += 1
+    nextBackoffMillis.toLong
+  }
+}

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryInsertService.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryInsertService.scala
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spark.bigquery
+
+import java.io.IOException
+import java.util.concurrent.{Callable, ExecutorService, Executors, FutureTask, TimeUnit}
+
+import com.google.api.client.util.{BackOff, Sleeper}
+import com.google.api.services.bigquery.model.TableRow
+import com.google.cloud.bigquery.InsertAllRequest.RowToInsert
+import com.google.cloud.bigquery._
+import org.apache.spark.internal.Logging
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+import scala.concurrent.duration.Duration
+import scala.util.control.Breaks._
+
+/**
+ * Class to make insertAll calls to BigQuery for streaming inserts
+ * Breaks the list of table rows into chunks of
+ * MAX_STREAMING_BATCH_SIZE or MAX_STREAMING_ROWS_TO_BATCH.
+ * Throws exception if retries are exhausted, and all records are not yet inserted.
+ * BackOff is applied if API calls fail
+ * @param executor
+ * @param sleeper
+ * @param insertRetryPolicy
+ */
+private[bigquery] class BigQueryInsertService(executor: ExecutorService,
+                            sleeper: Sleeper,
+                            insertRetryPolicy: InsertRetryPolicy) extends Logging {
+  @throws[IOException]
+  def insertAll(ref: TableId,
+                rowList: List[TableRow],
+                insertIds: List[String] = null,
+                backoff: BackOff = FluentBackoff().backoff(),
+                ignoreInsertIds: Boolean = true,
+                client: BigQuery
+               ): Long = {
+    var retTotalDataSize: Long = 0
+    val allErrors: ListBuffer[BigQueryError] =
+      new ListBuffer[BigQueryError]
+
+    var rowsToPublish: List[TableRow] = rowList
+    var insertIdsToPublish: List[String] = insertIds
+
+    // Don't ignore insert ids going forward
+    var done: Boolean = false
+    while (!done) {
+      val retryRows: ListBuffer[TableRow] = new ListBuffer[TableRow]
+      val retryIds: ListBuffer[String] = new ListBuffer[String]
+
+      val rows: ListBuffer[RowToInsert] =
+        new ListBuffer[RowToInsert]
+      var dataSize: Long = 0
+      var i: Int = 0
+      val futures: ListBuffer[FutureTask[InsertAllResponse]] =
+        new ListBuffer[FutureTask[InsertAllResponse]]
+
+      // val responses: ListBuffer[InsertAllResponse] = new ListBuffer[InsertAllResponse]
+
+      for (row: TableRow <- rowsToPublish) {
+        i += 1
+        var out: RowToInsert = {
+          if (ignoreInsertIds) {
+            RowToInsert.of(row.getUnknownKeys)
+          } else {
+            RowToInsert.of(insertIdsToPublish.apply(i-1), row.getUnknownKeys)
+          }
+        }: RowToInsert
+        rows += out
+
+        dataSize += EncodeUtils.getEncodedElementByteSize(row)
+
+        if (dataSize >= BigQueryInsertService.MAX_STREAMING_BATCH_SIZE ||
+          rows.size >= BigQueryInsertService.MAX_STREAMING_ROWS_TO_BATCH ||
+          i == rowsToPublish.size) {
+          val request = InsertAllRequest.newBuilder(ref)
+            .setRows(rows.toList.asJava)
+            .setIgnoreUnknownValues(true)
+            .setSkipInvalidRows(true)
+
+          val task =
+            new FutureTask[InsertAllResponse](new Callable[InsertAllResponse]() {
+            def call(): InsertAllResponse = {
+
+              val backoff: BackOff = BigQueryInsertService.RATE_LIMIT_BACKOFF_FACTORY.backoff()
+              var returnValue: InsertAllResponse = null
+              breakable {
+                while (true) {
+                  try {
+                    returnValue = client.insertAll(request.build())
+                    break
+                  } catch {
+                    case e: IOException =>
+                      logWarning(
+                        String.format(
+                          "BigQuery insertAll error, retrying: %s", e.getMessage
+                        ))
+                      try sleeper.sleep(backoff.nextBackOffMillis()) catch {
+                        case e: InterruptedException =>
+                          throw new IOException(
+                            "Interrupted while waiting before retrying insertAll");
+                      }
+                  }
+                }
+              }
+              // responses.+=(returnValue)
+              returnValue
+            }
+          })
+
+          futures += task
+          executor.execute(task)
+          retTotalDataSize += dataSize
+          dataSize = 0
+          rows.clear()
+        }
+      }
+      // Wait on responses
+      try {
+        for (task <- futures) {
+        // for (response: InsertAllResponse <- responses) {
+          val response: InsertAllResponse = task.get()
+          if (response.hasErrors) {
+            val errorMap: mutable.Map[java.lang.Long, java.util.List[BigQueryError]] =
+              response.getInsertErrors.asScala
+            for ((index, jErrorList) <- errorMap) {
+              // Add table rows to retry list and reset input collections if enabled
+              val errorList: List[BigQueryError] = jErrorList.asScala.toList
+              if (insertRetryPolicy.shouldRetry(errorList)) {
+                // Retry the error
+                allErrors.++=(errorList)
+                val indexInt: Int = index.toInt
+                retryRows += rowsToPublish.apply(indexInt)
+                retryIds += insertIdsToPublish.apply(indexInt)
+              }
+            }
+          }
+        }
+      } catch {
+        case e: InterruptedException =>
+          Thread.currentThread().interrupt()
+          throw new IOException("Interrupted while inserting " + rowsToPublish)
+      }
+      if (allErrors.isEmpty) {
+        done = true
+      } else {
+        val nextBackoffMilis = backoff.nextBackOffMillis()
+        done = (nextBackoffMilis == BackOff.STOP)
+
+        if (!done) {
+          try {
+            sleeper.sleep(nextBackoffMilis)
+          } catch {
+            case e: InterruptedException =>
+              Thread.currentThread().interrupt()
+              throw new IOException("Interrupted while waiting before retrying insert of "
+                + retryRows)
+          }
+          rowsToPublish = retryRows.toList
+          insertIdsToPublish = retryIds.toList
+          allErrors.clear()
+          logWarning("Retrying " + rowsToPublish.size + " failed inserts to BigQuery")
+        }
+      }
+    }
+    if (!allErrors.isEmpty) {
+      throw new IOException("Insert failed: " + allErrors)
+    }
+    retTotalDataSize
+  }
+}
+
+private[bigquery] object BigQueryInsertService {
+  /**
+   * Maximum data size in one insertAll batch
+   */
+  val MAX_STREAMING_BATCH_SIZE: Long = 64L * 1024L
+  /**
+   * The maximum number of rows to batch in a single streaming insertAll to BigQuery
+   */
+  val MAX_STREAMING_ROWS_TO_BATCH: Long = 500
+  /** The given number of maximum concurrent threads will be used to insert
+   * rows from one bundle to BigQuery service with streaming insert API
+   */
+  val INSERT_BUNDLE_PARALLELISM: Int = 2
+
+  private val executor: ExecutorService =
+    Executors.newFixedThreadPool(INSERT_BUNDLE_PARALLELISM)
+  private val RATE_LIMIT_BACKOFF_FACTORY =
+    FluentBackoff(maxBackoff = Duration.create(2, TimeUnit.MINUTES))
+
+  def apply(executor: ExecutorService = executor,
+            sleeper: Sleeper = Sleeper.DEFAULT,
+            insertRetryPolicy: InsertRetryPolicy = RetryTransientErrorsPolicy):
+  BigQueryInsertService = new BigQueryInsertService(
+    executor,
+    sleeper,
+    insertRetryPolicy
+  )
+}

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryStreamWriter.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryStreamWriter.scala
@@ -16,15 +16,23 @@
 
 package com.google.cloud.spark.bigquery
 
+import com.google.api.services.bigquery.model.TableRow
 import com.google.cloud.bigquery.BigQuery
+import com.google.cloud.bigquery.InsertAllRequest.RowToInsert
+import com.google.gson.Gson
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
+import org.apache.spark.sql.execution.QueryExecution
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row, SQLContext, SaveMode}
 
+import scala.collection.mutable.ListBuffer
+
 private[bigquery] object BigQueryStreamWriter extends Logging {
+  private val INSERT_ID_COLUMN_NAME: String = "insertId"
 
   /**
    * Convert streaming dataframe to fixed dataframe by
@@ -56,10 +64,81 @@ private[bigquery] object BigQueryStreamWriter extends Logging {
   }
 
   /**
+   * Use insertAll API for streaming to BigQuery
+   *
+   * @param data
+   * @param sqlContext
+   * @param outputMode
+   * @param opts
+   */
+  def writeStream(data: DataFrame,
+                  sqlContext: SQLContext,
+                  outputMode: OutputMode,
+                  opts: SparkBigQueryOptions): Unit = {
+    val queryExecution = data.queryExecution
+    val schema = data.schema
+
+    val rdd: RDD[InternalRow] = queryExecution.toRdd
+
+    logDebug("Schema: " + new Gson().toJson(schema))
+    logDebug("Partitions: " + rdd.getNumPartitions)
+    logInfo("Count: " + rdd.count())
+
+    val insertIdOrdinal: Int = if (!opts.ignoreInsertIds) {
+      getInsertIdOrdinal(schema)
+    } else {
+      -1
+    }
+
+    /**
+     * Convert row objects into TableRows per partition
+     * Collect each partition as a list and write BigQuery
+     */
+
+    rdd.foreachPartition(iter =>
+      if (!iter.isEmpty) {
+        val client: BigQuery = BigQueryRelationProvider.createBigQuery(opts)
+        val tableRowList: ListBuffer[TableRow] = ListBuffer[TableRow]()
+        val insertIdListBuffer: ListBuffer[String] = ListBuffer[String]()
+        val rowConvertor: RowConverter = RowConverter(schema)
+
+        while (iter.hasNext) {
+          val row: InternalRow = iter.next()
+          if (!opts.ignoreInsertIds) {
+            insertIdListBuffer += row.getString(insertIdOrdinal)
+          }
+          val tr: TableRow = rowConvertor.convert(row)
+          if (!opts.ignoreInsertIds) {
+            tr.remove(INSERT_ID_COLUMN_NAME)
+          }
+          tableRowList += tr
+        }
+
+        logInfo("Got rows: " + tableRowList)
+        val outRowsBuffer: ListBuffer[RowToInsert] = ListBuffer[RowToInsert]()
+        for (row: TableRow <- tableRowList) {
+          outRowsBuffer += RowToInsert.of(row.getUnknownKeys)
+        }
+
+        val insertService: BigQueryInsertService = BigQueryInsertService()
+        insertService.insertAll(ref = opts.tableId,
+          rowList = tableRowList.toList,
+          insertIds = insertIdListBuffer.toList,
+          backoff = FluentBackoff().backoff(),
+          ignoreInsertIds = opts.ignoreInsertIds,
+          client = client
+        )
+      }
+    )
+  }
+
+
+  /**
    * Convert Output mode to save mode
-   *  Complete => Truncate
-   *  Append => Append (Default)
-   *  Update => Not yet supported
+   * Complete => Truncate
+   * Append => Append (Default)
+   * Update => Not yet supported
+   *
    * @param outputMode
    * @throws NotImplementedError
    * @return SaveMode
@@ -73,6 +152,17 @@ private[bigquery] object BigQueryStreamWriter extends Logging {
     } else {
       SaveMode.Append
     }
+  }
+
+  private def getInsertIdOrdinal(schema: StructType): Int = {
+    var ordinal: Int = 0
+    for (name: String <- schema.fieldNames) {
+      if (name == INSERT_ID_COLUMN_NAME) {
+        return ordinal
+      }
+      ordinal += 1
+    }
+    -1
   }
 }
 

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryStreamingSink.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryStreamingSink.scala
@@ -49,7 +49,11 @@ case class BigQueryStreamingSink(
       logWarning("Skipping as already committed batch " + batchId)
     } else {
       logDebug(s"addBatch($batchId)")
-      BigQueryStreamWriter.writeBatch(data, sqlContext, outputMode, opts, client)
+      if (!opts.realTime) {
+        BigQueryStreamWriter.writeBatch(data, sqlContext, outputMode, opts, client)
+      } else {
+        BigQueryStreamWriter.writeStream(data, sqlContext, outputMode, opts)
+      }
     }
     latestBatchId = batchId
   }

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/EncodeUtils.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/EncodeUtils.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spark.bigquery
+
+import com.fasterxml.jackson.databind.{ObjectMapper, SerializationFeature}
+import com.google.api.services.bigquery.model.TableRow
+import com.google.common.base.Utf8
+
+/**
+ * Get API object sizes
+ * Ported from Beam SDK
+ */
+object EncodeUtils {
+  private val MAPPER: ObjectMapper =
+    new ObjectMapper().disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+
+  private def convertIntToLongNoSignExtend(v: Int) = v & 0xFFFFFFFFL
+
+  def getLength(v: Long): Int = {
+    var result = 0
+    var input: Long = v
+    do {
+      result += 1
+      input = input.>>>(7)
+    } while ( {
+      input != 0
+    })
+    result
+  }
+
+  def getEncodedElementByteSize(value: TableRow): Long = {
+    val strValue = MAPPER.writeValueAsString(value)
+    val size: Int = Utf8.encodedLength(strValue)
+    getLength(convertIntToLongNoSignExtend(size)) + size
+  }
+}

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/FluentBackoff.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/FluentBackoff.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spark.bigquery
+
+import java.util.concurrent.TimeUnit
+
+import com.google.api.client.util.BackOff
+
+import scala.concurrent.duration.Duration
+
+/**
+ * Backoff base class
+ * Ported from Beam BigQuery connector
+ * @param exponent
+ * @param initialBackoff
+ * @param maxBackoff
+ * @param maxCumulativeBackoff
+ * @param maxRetries
+ */
+case class FluentBackoff(exponent: Double,
+                         initialBackoff: Duration,
+                         maxBackoff: Duration,
+                         maxCumulativeBackoff: Duration,
+                         maxRetries: Int) {
+
+  def backoff() : BackOff = {
+    BackoffImpl(this)
+  }
+}
+
+object FluentBackoff {
+  private val DEFAULT_EXPONENT = 1.5
+  private val DEFAULT_MIN_BACKOFF = Duration.create(1, TimeUnit.SECONDS)
+  private val DEFAULT_MAX_BACKOFF = Duration.create(1000, TimeUnit.DAYS)
+  private val DEFAULT_MAX_RETRIES = Integer.MAX_VALUE
+  private val DEFAULT_MAX_CUM_BACKOFF = Duration.create(1000, TimeUnit.DAYS)
+
+  def apply(initialBackoff: Duration = DEFAULT_MIN_BACKOFF,
+            maxBackoff: Duration = DEFAULT_MAX_BACKOFF,
+            maxCumulativeBackoff: Duration = DEFAULT_MAX_CUM_BACKOFF,
+            maxRetries: Int = DEFAULT_MAX_RETRIES): FluentBackoff = new FluentBackoff(
+    DEFAULT_EXPONENT,
+    initialBackoff,
+    maxBackoff,
+    maxCumulativeBackoff,
+    maxRetries)
+}

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/InsertRetryPolicy.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/InsertRetryPolicy.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spark.bigquery
+
+import com.google.cloud.bigquery.BigQueryError
+
+/**
+ * Realtime streaming inserts retry policy
+ */
+trait InsertRetryPolicy {
+  // A list of known persistent errors for which retrying never helps.
+  val PERSISTENT_ERRORS: Set[String] =
+    Set[String]("invalid", "invalidQuery", "notImplemented")
+  def shouldRetry(errors: List[BigQueryError]): Boolean = {
+    if (errors != null) {
+      for (error: BigQueryError <- errors) {
+        if (error.getReason != null && PERSISTENT_ERRORS.contains(error.getReason)) {
+          return false
+        }
+      }
+    }
+    true
+  }
+}
+
+object AllwaysRetryInsertPolicy extends InsertRetryPolicy {
+  override def shouldRetry(errors: List[BigQueryError]): Boolean = true
+}
+
+object NeverRetryInsertPolicy extends InsertRetryPolicy {
+  override def shouldRetry(errors: List[BigQueryError]): Boolean = false
+}
+
+object RetryTransientErrorsPolicy extends InsertRetryPolicy

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/RowConverter.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/RowConverter.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spark.bigquery
+
+import java.sql.Timestamp
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+import com.google.api.services.bigquery.model.TableRow
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.encoders.{ExpressionEncoder, RowEncoder}
+import org.apache.spark.sql.types._
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
+
+/**
+ * Convert Spark row to BigQuery TableRow object
+ * @param schema
+ */
+case class RowConverter(schema: StructType) {
+  private val DEFAULT_TYPES: Set[String] =
+    Set("integer",
+      "float",
+      "double",
+      "long",
+      "boolean",
+      "string")
+
+  /**
+   * Convert InternalRow to Row
+   */
+  private val expressionEncoder: ExpressionEncoder[Row] = RowEncoder(schema).resolveAndBind()
+
+  def convertToRow(internalRow: InternalRow): Row = {
+    expressionEncoder.fromRow(internalRow)
+  }
+
+  def convert(internalRow: InternalRow): TableRow = {
+    convert(convertToRow(internalRow))
+  }
+
+  /**
+   * Convert Spark SQL row to TableRow
+   * @param row
+   * @return
+   */
+  def convert(row: Row): TableRow = {
+    val tableRow: TableRow = new TableRow()
+
+    for (field <- row.schema.fields) {
+      if (field.dataType.typeName == getName(Array)) {
+        // Handle array
+        val convertedVal: List[Any] =
+          convertRepeatedField(field.dataType, row.getAs[List[Any]](field.name))
+        tableRow.set(field.name, convertedVal.asJava)
+      } else {
+        // Handle other fields
+
+        val convertedVal = convertField(field.dataType, row.getAs[Any](field.name))
+        tableRow.set(field.name, convertedVal)
+      }
+    }
+    tableRow
+  }
+
+  /**
+   * Iterate over repeated fields and convert them
+   * @param dataType
+   * @param value
+   * @return
+   */
+  private def convertRepeatedField(dataType: DataType, value: Any): List[Any] = {
+    val convertedValues: ListBuffer[Any] = ListBuffer[Any]()
+    val values = value.asInstanceOf[mutable.WrappedArray[Any]]
+    if (values != null && values.length > 0) {
+      val childFieldType = dataType.asInstanceOf[ArrayType].elementType
+      for (toConvertValue: Any <- values) {
+        convertedValues += convertField(childFieldType, toConvertValue)
+      }
+    }
+    convertedValues.toList
+  }
+
+  /**
+   * Handle all datatypes here
+   * @param dataType
+   * @param value
+   * @return
+   */
+  private def convertField(dataType: DataType, value: Any): Any = {
+    var convertedField: Any = None
+    if (dataType.typeName == TimestampType.typeName) {
+      convertedField = (value.asInstanceOf[Timestamp].getTime / 1000).toInt
+    } else if (dataType.typeName == BinaryType.typeName) {
+      convertedField = java.util.Base64.getEncoder.encode(
+        value.asInstanceOf[Array[Byte]])
+    } else if (dataType.typeName == getName(DecimalType)) {
+      // String for now...
+      convertedField = value.asInstanceOf[java.math.BigDecimal].toString
+    } else if (DEFAULT_TYPES.contains(dataType.typeName)) {
+      convertedField = value
+    } else if (dataType.typeName == getName(StructType)) {
+      convertedField = convert(value.asInstanceOf[Row])
+    } else if (dataType.typeName == getName(DateType)) {
+
+      val localDate: LocalDate = LocalDate.from(value.asInstanceOf[java.sql.Date].toInstant)
+      convertedField = localDate.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+    } else {
+      throw new UnsupportedOperationException(
+        "Unexpected BigQuery field schema type " + dataType.typeName)
+    }
+    convertedField
+  }
+
+  private def getName(klass: Any): String = {
+    klass.getClass.getSimpleName
+      .stripSuffix("$").stripSuffix("Type")
+      .stripSuffix("UDT").toLowerCase(Locale.ROOT)
+  }
+}

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/SparkBigQueryOptions.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/SparkBigQueryOptions.scala
@@ -61,6 +61,8 @@ import scala.util.Properties
     optimizedEmptyProjection: Boolean = true,
     accessToken: Option[String] = None,
     loadSchemaUpdateOptions: java.util.List[JobInfo.SchemaUpdateOption] = ImmutableList.of(),
+    realTime: Boolean = false,
+    ignoreInsertIds: Boolean = true,
     viewExpirationTimeInHours: Int = 24,
     maxReadRowsRetries: Int = 3
   ) {
@@ -186,13 +188,19 @@ object SparkBigQueryOptions {
       loadSchemaUpdateOptions += JobInfo.SchemaUpdateOption.ALLOW_FIELD_RELAXATION
     }
 
+    val realtime: Boolean = getAnyBooleanOption(
+      normalizedAllConf, parameters, "realtime", false)
+    val ignoreInsertIds: Boolean = getAnyBooleanOption(
+      normalizedAllConf, parameters, "ignoreInsertId", true)
+
     SparkBigQueryOptions(tableId, parentProject, credsParam, credsFileParam,
       filter, schema, maxParallelism, temporaryGcsBucket, persistentGcsBucket,
       persistentGcsPath, intermediateFormat, readDataFormat,
       combinePushedDownFilters, viewsEnabled, materializationProject,
       materializationDataset, partitionField, partitionExpirationMs,
       partitionRequireFilter, partitionType, clusteredFields, createDisposition,
-      optimizedEmptyProjection, accessToken, loadSchemaUpdateOptions.asJava)
+      optimizedEmptyProjection, accessToken, loadSchemaUpdateOptions.asJava,
+      realtime, ignoreInsertIds)
   }
 
   // could not load the spark-avro data source


### PR DESCRIPTION
Use BigQuery insertAll API to stream a DataFrame
Retry and exponential backoff while calling the API