### PR TITLE
Issue #221: Fixing ProtobufUtilsTest.java with newer BigQuery dependencies

### DIFF
--- a/connector/src/main/java/com/google/cloud/spark/bigquery/ProtobufUtils.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/ProtobufUtils.java
@@ -26,7 +26,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
-import com.google.protobuf.Message;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.types.*;
@@ -35,7 +34,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class ProtobufUtils {
 
@@ -164,10 +166,12 @@ public class ProtobufUtils {
       LegacySQLTypeName bqType) {
     DescriptorProtos.FieldDescriptorProto.Type protoFieldType;
     if (LegacySQLTypeName.INTEGER.equals(bqType)
-        || LegacySQLTypeName.DATE.equals(bqType)
         || LegacySQLTypeName.DATETIME.equals(bqType)
         || LegacySQLTypeName.TIMESTAMP.equals(bqType)) {
       return DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT64;
+    }
+    if (LegacySQLTypeName.DATE.equals(bqType)) {
+      return DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT32;
     }
     if (LegacySQLTypeName.BOOLEAN.equals(bqType)) {
       return DescriptorProtos.FieldDescriptorProto.Type.TYPE_BOOL;
@@ -215,7 +219,7 @@ public class ProtobufUtils {
     DynamicMessage.Builder messageBuilder = DynamicMessage.newBuilder(schemaDescriptor);
 
     for (int fieldIndex = 0; fieldIndex < schemaDescriptor.getFields().size(); fieldIndex++) {
-      int protoFieldNumber = fieldIndex+1;
+      int protoFieldNumber = fieldIndex + 1;
 
       StructField sparkField = schema.fields()[fieldIndex];
       DataType sparkType = sparkField.dataType();
@@ -225,9 +229,9 @@ public class ProtobufUtils {
       Descriptors.Descriptor nestedTypeDescriptor =
           schemaDescriptor.findNestedTypeByName(RESERVED_NESTED_TYPE_NAME + (protoFieldNumber));
       Object protoValue =
-          convertToProtoRowValue(sparkType, sparkValue, nullable, nestedTypeDescriptor);
+          convertSparkValueToProtoRowValue(sparkType, sparkValue, nullable, nestedTypeDescriptor);
 
-      logger.debug("Converted value {} to proto-value: {}", sparkValue, protoValue);
+      // logger.debug("Converted value {} to proto-value: {}", sparkValue, protoValue);
 
       if (protoValue == null) {
         continue;
@@ -254,12 +258,12 @@ public class ProtobufUtils {
   /*
   Takes a value in Spark format and converts it into ProtoRows format (to eventually be given to BigQuery).
    */
-  private static Object convertToProtoRowValue(
+  private static Object convertSparkValueToProtoRowValue(
       DataType sparkType,
       Object sparkValue,
       boolean nullable,
       Descriptors.Descriptor nestedTypeDescriptor) {
-    logger.debug("Converting type: {}", sparkType.json());
+    // logger.debug("Converting type: {}", sparkType.json());
     if (sparkValue == null) {
       if (!nullable) {
         throw new IllegalArgumentException("Non-nullable field was null.");
@@ -276,7 +280,8 @@ public class ProtobufUtils {
       List<Object> protoValue = new ArrayList<>();
       for (Object sparkElement : sparkArrayData) {
         Object converted =
-            convertToProtoRowValue(elementType, sparkElement, containsNull, nestedTypeDescriptor);
+            convertSparkValueToProtoRowValue(
+                elementType, sparkElement, containsNull, nestedTypeDescriptor);
         if (converted == null) {
           continue;
         }
@@ -294,25 +299,32 @@ public class ProtobufUtils {
         || sparkType instanceof ShortType
         || sparkType instanceof IntegerType
         || sparkType instanceof LongType
-        || sparkType instanceof TimestampType
-        || sparkType instanceof DateType) {
+        || sparkType instanceof TimestampType) {
       return ((Number) sparkValue).longValue();
     } // TODO: CalendarInterval
+
+    if (sparkType instanceof DateType) {
+      return ((Number) sparkValue).intValue();
+    }
 
     if (sparkType instanceof FloatType || sparkType instanceof DoubleType) {
       return ((Number) sparkValue).doubleValue();
     }
 
     if (sparkType instanceof DecimalType) {
-      return ((Decimal) sparkValue).toDouble();
+      return Base64.getEncoder().encode(sparkValue.toString().getBytes(UTF_8));
     }
 
-    if (sparkType instanceof BooleanType || sparkType instanceof BinaryType) {
+    if (sparkType instanceof BooleanType) {
       return sparkValue;
     }
 
+    if (sparkType instanceof BinaryType) {
+      return Base64.getEncoder().encode((byte[]) sparkValue);
+    }
+
     if (sparkType instanceof StringType) {
-      return new String(((UTF8String) sparkValue).getBytes());
+      return new String(((UTF8String) sparkValue).getBytes(), UTF_8);
     }
 
     if (sparkType instanceof MapType) {
@@ -361,8 +373,7 @@ public class ProtobufUtils {
         protoFieldBuilder =
             createProtoFieldBuilder(fieldName, fieldLabel, messageNumber).setTypeName(nestedName);
       } else {
-        DescriptorProtos.FieldDescriptorProto.Type fieldType =
-            sparkAtomicTypeToProtoFieldType(sparkType);
+        DescriptorProtos.FieldDescriptorProto.Type fieldType = toProtoFieldType(sparkType);
         protoFieldBuilder =
             createProtoFieldBuilder(fieldName, fieldLabel, messageNumber, fieldType);
       }
@@ -378,30 +389,28 @@ public class ProtobufUtils {
   // protoFieldBuilder
   // for these and other types.
   // This function only converts atomic Spark DataTypes
-  private static DescriptorProtos.FieldDescriptorProto.Type sparkAtomicTypeToProtoFieldType(
-      DataType sparkType) {
+  private static DescriptorProtos.FieldDescriptorProto.Type toProtoFieldType(DataType sparkType) {
     if (sparkType instanceof ByteType
         || sparkType instanceof ShortType
         || sparkType instanceof IntegerType
         || sparkType instanceof LongType
-        || sparkType instanceof TimestampType
-        || sparkType instanceof DateType) {
+        || sparkType instanceof TimestampType) {
       return DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT64;
     }
 
-    if (sparkType instanceof FloatType
-        || sparkType instanceof DoubleType
-        || sparkType instanceof DecimalType) {
+    if (sparkType instanceof DateType) {
+      return DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT32;
+    }
+
+    if (sparkType instanceof FloatType || sparkType instanceof DoubleType) {
       return DescriptorProtos.FieldDescriptorProto.Type.TYPE_DOUBLE;
-      /* TODO: an annotation to distinguish between decimals that are doubles, and decimals that are
-      NUMERIC (Bytes types) */
     }
 
     if (sparkType instanceof BooleanType) {
       return DescriptorProtos.FieldDescriptorProto.Type.TYPE_BOOL;
     }
 
-    if (sparkType instanceof BinaryType) {
+    if (sparkType instanceof BinaryType || sparkType instanceof DecimalType) {
       return DescriptorProtos.FieldDescriptorProto.Type.TYPE_BYTES;
     }
 

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/ProtobufUtils.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/ProtobufUtils.java
@@ -26,7 +26,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
-import com.google.protobuf.Message;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.types.*;
@@ -215,7 +214,7 @@ public class ProtobufUtils {
     DynamicMessage.Builder messageBuilder = DynamicMessage.newBuilder(schemaDescriptor);
 
     for (int fieldIndex = 0; fieldIndex < schemaDescriptor.getFields().size(); fieldIndex++) {
-      int protoFieldNumber = fieldIndex+1;
+      int protoFieldNumber = fieldIndex + 1;
 
       StructField sparkField = schema.fields()[fieldIndex];
       DataType sparkType = sparkField.dataType();

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SchemaConverters.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SchemaConverters.java
@@ -290,7 +290,8 @@ public class SchemaConverters {
       return LegacySQLTypeName.STRING;
     }
     if (elementType instanceof TimestampType) {
-      // return LegacySQLTypeName.TIMESTAMP; FIXME: Restore this correct conversion when the Vortex team adds microsecond support to their backend
+      // return LegacySQLTypeName.TIMESTAMP; FIXME: Restore this correct conversion when the Vortex
+      // team adds microsecond support to their backend
       return LegacySQLTypeName.INTEGER;
     }
     if (elementType instanceof DateType) {

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SchemaConverters.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SchemaConverters.java
@@ -15,7 +15,7 @@
  */
 package com.google.cloud.spark.bigquery;
 
-import avro.shaded.com.google.common.base.Preconditions;
+import com.google.common.base.Preconditions;
 import com.google.cloud.bigquery.*;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.avro.generic.GenericRecord;
@@ -278,20 +278,18 @@ public class SchemaConverters {
     }
     if (elementType instanceof DecimalType) {
       DecimalType decimalType = (DecimalType) elementType;
-      if (decimalType.precision() <= BQ_NUMERIC_PRECISION
-          && decimalType.scale() <= BQ_NUMERIC_SCALE) {
-        return LegacySQLTypeName.NUMERIC;
-      } else {
-        throw new IllegalArgumentException(
-            "Decimal type is too wide to fit in BigQuery Numeric format");
-      }
+      Preconditions.checkArgument(
+          decimalType.scale() <= BQ_NUMERIC_SCALE
+              && decimalType.precision() <= BQ_NUMERIC_PRECISION,
+          new IllegalArgumentException(
+              "Decimal type is too wide to fit in BigQuery Numeric format"));
+      return LegacySQLTypeName.NUMERIC;
     }
     if (elementType instanceof StringType) {
       return LegacySQLTypeName.STRING;
     }
     if (elementType instanceof TimestampType) {
-      // return LegacySQLTypeName.TIMESTAMP; FIXME: Restore this correct conversion when the Vortex team adds microsecond support to their backend
-      return LegacySQLTypeName.INTEGER;
+      return LegacySQLTypeName.TIMESTAMP;
     }
     if (elementType instanceof DateType) {
       return LegacySQLTypeName.DATE;

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/ProtobufUtilsTest.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/ProtobufUtilsTest.java
@@ -238,14 +238,14 @@ public class ProtobufUtilsTest {
             .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT64)
             .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_REPEATED);
     public final DescriptorProtos.DescriptorProto.Builder NESTED_STRUCT_DESCRIPTOR = DescriptorProtos.DescriptorProto.newBuilder()
-            .setName("STRUCT1")
+            .setName("STRUCT4")
             .addField(PROTO_INTEGER_FIELD.clone())
             .addField(PROTO_STRING_FIELD.clone().setNumber(2)
                     .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL));
     public final DescriptorProtos.FieldDescriptorProto.Builder PROTO_STRUCT_FIELD = DescriptorProtos.FieldDescriptorProto.newBuilder()
             .setName("Struct")
             .setNumber(1)
-            .setTypeName("STRUCT1")
+            .setTypeName("STRUCT4")
             .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL);
     public final DescriptorProtos.FieldDescriptorProto.Builder PROTO_DOUBLE_FIELD = DescriptorProtos.FieldDescriptorProto.newBuilder()
             .setName("Double")

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/ProtobufUtilsTest.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/ProtobufUtilsTest.java
@@ -16,7 +16,6 @@
 package com.google.cloud.spark.bigquery;
 
 import com.google.cloud.bigquery.Field;
-import com.google.cloud.bigquery.FieldList;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.storage.v1alpha2.ProtoBufProto;
@@ -35,6 +34,9 @@ import org.apache.spark.sql.types.*;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.AssumptionViolatedException;
 import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.Base64;
 
 import static com.google.cloud.spark.bigquery.ProtobufUtils.*;
 import static com.google.common.truth.Truth.assertThat;
@@ -82,7 +84,7 @@ public class ProtobufUtilsTest {
                                                 .addField(PROTO_DOUBLE_FIELD.clone().setName("Float").setNumber(5))
                                                 .addField(PROTO_BOOLEAN_FIELD.clone().setNumber(6))
                                                 .addField(PROTO_BYTES_FIELD.clone().setNumber(7))
-                                                .addField(PROTO_INTEGER_FIELD.clone().setName("Date").setNumber(8))
+                                                .addField(PROTO_DATE_FIELD.clone().setNumber(8))
                                                 .addField(PROTO_INTEGER_FIELD.clone().setName("TimeStamp").setNumber(9))
                                                 .setName("Schema").build()
                                 ).build(), new Descriptors.FileDescriptor[]{}
@@ -123,8 +125,9 @@ public class ProtobufUtilsTest {
                                 3.14,
                                 true,
                                 new byte[]{11, 0x7F},
+                                1594080000L,
                                 1594080000000L,
-                                1594080000000L
+                                new BigDecimal("-99999999999999999999999999999.999999999")
                         })}
         );
 
@@ -181,6 +184,11 @@ public class ProtobufUtilsTest {
             true, Metadata.empty());
     public final StructField SPARK_TIMESTAMP_FIELD = new StructField("TimeStamp", DataTypes.TimestampType,
             true, Metadata.empty());
+    public final StructField SPARK_MAP_FIELD = new StructField("Map",
+            DataTypes.createMapType(DataTypes.IntegerType, DataTypes.StringType),
+            true, Metadata.empty());
+    public final StructField SPARK_NUMERIC_FIELD = new StructField("Numeric", NUMERIC_SPARK_TYPE,
+            true, Metadata.empty());
 
     public final StructType BIG_SPARK_SCHEMA = new StructType()
             .add(SPARK_INTEGER_FIELD)
@@ -191,35 +199,37 @@ public class ProtobufUtilsTest {
             .add(SPARK_BOOLEAN_FIELD)
             .add(SPARK_BINARY_FIELD)
             .add(SPARK_DATE_FIELD)
-            .add(SPARK_TIMESTAMP_FIELD);
+            .add(SPARK_TIMESTAMP_FIELD)
+            .add(SPARK_NUMERIC_FIELD);
 
 
-    public final Field BIGQUERY_INTEGER_FIELD = Field.newBuilder("Number", LegacySQLTypeName.INTEGER,
-            (FieldList)null).setMode(Field.Mode.NULLABLE).build();
-    public final Field BIGQUERY_STRING_FIELD = Field.newBuilder("String", LegacySQLTypeName.STRING, (FieldList) null)
+    public final Field BIGQUERY_INTEGER_FIELD = Field.newBuilder("Number", LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build();
+    public final Field BIGQUERY_STRING_FIELD = Field.newBuilder("String", LegacySQLTypeName.STRING)
             .setMode(Field.Mode.REQUIRED).build();
     public final Field BIGQUERY_NESTED_STRUCT_FIELD = Field.newBuilder("Struct", LegacySQLTypeName.RECORD,
-            Field.newBuilder("Number", LegacySQLTypeName.INTEGER, (FieldList) null)
+            Field.newBuilder("Number", LegacySQLTypeName.INTEGER)
                     .setMode(Field.Mode.NULLABLE).build(),
-            Field.newBuilder("String", LegacySQLTypeName.STRING, (FieldList) null)
+            Field.newBuilder("String", LegacySQLTypeName.STRING)
                     .setMode(Field.Mode.NULLABLE).build())
             .setMode(Field.Mode.NULLABLE).build();
-    public final Field BIGQUERY_ARRAY_FIELD = Field.newBuilder("Array", LegacySQLTypeName.INTEGER, (FieldList) null)
+    public final Field BIGQUERY_ARRAY_FIELD = Field.newBuilder("Array", LegacySQLTypeName.INTEGER)
             .setMode(Field.Mode.REPEATED).build();
-    public final Field BIGQUERY_FLOAT_FIELD = Field.newBuilder("Float", LegacySQLTypeName.FLOAT, (FieldList)null)
+    public final Field BIGQUERY_FLOAT_FIELD = Field.newBuilder("Float", LegacySQLTypeName.FLOAT)
             .setMode(Field.Mode.NULLABLE).build();
-    public final Field BIGQUERY_BOOLEAN_FIELD = Field.newBuilder("Boolean", LegacySQLTypeName.BOOLEAN, (FieldList)null)
+    public final Field BIGQUERY_BOOLEAN_FIELD = Field.newBuilder("Boolean", LegacySQLTypeName.BOOLEAN)
             .setMode(Field.Mode.NULLABLE).build();
-    public final Field BIGQUERY_BYTES_FIELD = Field.newBuilder("Binary", LegacySQLTypeName.BYTES, (FieldList)null)
+    public final Field BIGQUERY_BYTES_FIELD = Field.newBuilder("Binary", LegacySQLTypeName.BYTES)
             .setMode(Field.Mode.NULLABLE).build();
-    public final Field BIGQUERY_DATE_FIELD = Field.newBuilder("Date", LegacySQLTypeName.DATE, (FieldList)null)
+    public final Field BIGQUERY_DATE_FIELD = Field.newBuilder("Date", LegacySQLTypeName.DATE)
             .setMode(Field.Mode.NULLABLE).build();
-    public final Field BIGQUERY_TIMESTAMP_FIELD = Field.newBuilder("TimeStamp", LegacySQLTypeName.TIMESTAMP, (FieldList)null)
+    public final Field BIGQUERY_TIMESTAMP_FIELD = Field.newBuilder("TimeStamp", LegacySQLTypeName.TIMESTAMP)
+            .setMode(Field.Mode.NULLABLE).build();
+    public final Field BIGQUERY_NUMERIC_FIELD = Field.newBuilder("Numeric", LegacySQLTypeName.NUMERIC)
             .setMode(Field.Mode.NULLABLE).build();
 
     public final Schema BIG_BIGQUERY_SCHEMA = Schema.of(BIGQUERY_INTEGER_FIELD, BIGQUERY_STRING_FIELD, BIGQUERY_ARRAY_FIELD,
             BIGQUERY_NESTED_STRUCT_FIELD, BIGQUERY_FLOAT_FIELD, BIGQUERY_BOOLEAN_FIELD, BIGQUERY_BYTES_FIELD, BIGQUERY_DATE_FIELD,
-            BIGQUERY_TIMESTAMP_FIELD);
+            BIGQUERY_TIMESTAMP_FIELD, BIGQUERY_NUMERIC_FIELD);
 
 
     public final DescriptorProtos.FieldDescriptorProto.Builder PROTO_INTEGER_FIELD = DescriptorProtos.FieldDescriptorProto.newBuilder()
@@ -261,6 +271,11 @@ public class ProtobufUtilsTest {
             .setName("Binary")
             .setNumber(1)
             .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_BYTES)
+            .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL);
+    public final DescriptorProtos.FieldDescriptorProto.Builder PROTO_DATE_FIELD = DescriptorProtos.FieldDescriptorProto.newBuilder()
+            .setName("Date")
+            .setNumber(1)
+            .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT32)
             .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL);
 
 
@@ -367,8 +382,10 @@ public class ProtobufUtilsTest {
                                     MY_STRUCT, STRUCT_DESCRIPTOR, INTERNAL_STRUCT_DATA))
                     .setField(BIG_SCHEMA_ROW_DESCRIPTOR.findFieldByNumber(5), 3.14)
                     .setField(BIG_SCHEMA_ROW_DESCRIPTOR.findFieldByNumber(6), true)
-                    .setField(BIG_SCHEMA_ROW_DESCRIPTOR.findFieldByNumber(7), new byte[]{11, 0x7F})
-                    .setField(BIG_SCHEMA_ROW_DESCRIPTOR.findFieldByNumber(8), 1594080000000L)
+                    .setField(BIG_SCHEMA_ROW_DESCRIPTOR.findFieldByNumber(7), Base64.getEncoder().encode(new byte[]{11, 0x7F}))
+                    .setField(BIG_SCHEMA_ROW_DESCRIPTOR.findFieldByNumber(8), 1594080000)
                     .setField(BIG_SCHEMA_ROW_DESCRIPTOR.findFieldByNumber(9), 1594080000000L)
+                    .setField(BIG_SCHEMA_ROW_DESCRIPTOR.findFieldByNumber(10),
+                            Base64.getEncoder().encode("-99999999999999999999999999999.999999999".getBytes()))
                     .build().toByteString()).build();
 }

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/ProtobufUtilsTest.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/ProtobufUtilsTest.java
@@ -16,6 +16,7 @@
 package com.google.cloud.spark.bigquery;
 
 import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.FieldList;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.storage.v1alpha2.ProtoBufProto;
@@ -34,9 +35,6 @@ import org.apache.spark.sql.types.*;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.junit.AssumptionViolatedException;
 import org.junit.Test;
-
-import java.math.BigDecimal;
-import java.util.Base64;
 
 import static com.google.cloud.spark.bigquery.ProtobufUtils.*;
 import static com.google.common.truth.Truth.assertThat;
@@ -84,7 +82,7 @@ public class ProtobufUtilsTest {
                                                 .addField(PROTO_DOUBLE_FIELD.clone().setName("Float").setNumber(5))
                                                 .addField(PROTO_BOOLEAN_FIELD.clone().setNumber(6))
                                                 .addField(PROTO_BYTES_FIELD.clone().setNumber(7))
-                                                .addField(PROTO_DATE_FIELD.clone().setNumber(8))
+                                                .addField(PROTO_INTEGER_FIELD.clone().setName("Date").setNumber(8))
                                                 .addField(PROTO_INTEGER_FIELD.clone().setName("TimeStamp").setNumber(9))
                                                 .setName("Schema").build()
                                 ).build(), new Descriptors.FileDescriptor[]{}
@@ -125,9 +123,8 @@ public class ProtobufUtilsTest {
                                 3.14,
                                 true,
                                 new byte[]{11, 0x7F},
-                                1594080000L,
                                 1594080000000L,
-                                new BigDecimal("-99999999999999999999999999999.999999999")
+                                1594080000000L
                         })}
         );
 
@@ -184,11 +181,6 @@ public class ProtobufUtilsTest {
             true, Metadata.empty());
     public final StructField SPARK_TIMESTAMP_FIELD = new StructField("TimeStamp", DataTypes.TimestampType,
             true, Metadata.empty());
-    public final StructField SPARK_MAP_FIELD = new StructField("Map",
-            DataTypes.createMapType(DataTypes.IntegerType, DataTypes.StringType),
-            true, Metadata.empty());
-    public final StructField SPARK_NUMERIC_FIELD = new StructField("Numeric", NUMERIC_SPARK_TYPE,
-            true, Metadata.empty());
 
     public final StructType BIG_SPARK_SCHEMA = new StructType()
             .add(SPARK_INTEGER_FIELD)
@@ -199,37 +191,35 @@ public class ProtobufUtilsTest {
             .add(SPARK_BOOLEAN_FIELD)
             .add(SPARK_BINARY_FIELD)
             .add(SPARK_DATE_FIELD)
-            .add(SPARK_TIMESTAMP_FIELD)
-            .add(SPARK_NUMERIC_FIELD);
+            .add(SPARK_TIMESTAMP_FIELD);
 
 
-    public final Field BIGQUERY_INTEGER_FIELD = Field.newBuilder("Number", LegacySQLTypeName.INTEGER).setMode(Field.Mode.NULLABLE).build();
-    public final Field BIGQUERY_STRING_FIELD = Field.newBuilder("String", LegacySQLTypeName.STRING)
+    public final Field BIGQUERY_INTEGER_FIELD = Field.newBuilder("Number", LegacySQLTypeName.INTEGER,
+            (FieldList)null).setMode(Field.Mode.NULLABLE).build();
+    public final Field BIGQUERY_STRING_FIELD = Field.newBuilder("String", LegacySQLTypeName.STRING, (FieldList) null)
             .setMode(Field.Mode.REQUIRED).build();
     public final Field BIGQUERY_NESTED_STRUCT_FIELD = Field.newBuilder("Struct", LegacySQLTypeName.RECORD,
-            Field.newBuilder("Number", LegacySQLTypeName.INTEGER)
+            Field.newBuilder("Number", LegacySQLTypeName.INTEGER, (FieldList) null)
                     .setMode(Field.Mode.NULLABLE).build(),
-            Field.newBuilder("String", LegacySQLTypeName.STRING)
+            Field.newBuilder("String", LegacySQLTypeName.STRING, (FieldList) null)
                     .setMode(Field.Mode.NULLABLE).build())
             .setMode(Field.Mode.NULLABLE).build();
-    public final Field BIGQUERY_ARRAY_FIELD = Field.newBuilder("Array", LegacySQLTypeName.INTEGER)
+    public final Field BIGQUERY_ARRAY_FIELD = Field.newBuilder("Array", LegacySQLTypeName.INTEGER, (FieldList) null)
             .setMode(Field.Mode.REPEATED).build();
-    public final Field BIGQUERY_FLOAT_FIELD = Field.newBuilder("Float", LegacySQLTypeName.FLOAT)
+    public final Field BIGQUERY_FLOAT_FIELD = Field.newBuilder("Float", LegacySQLTypeName.FLOAT, (FieldList)null)
             .setMode(Field.Mode.NULLABLE).build();
-    public final Field BIGQUERY_BOOLEAN_FIELD = Field.newBuilder("Boolean", LegacySQLTypeName.BOOLEAN)
+    public final Field BIGQUERY_BOOLEAN_FIELD = Field.newBuilder("Boolean", LegacySQLTypeName.BOOLEAN, (FieldList)null)
             .setMode(Field.Mode.NULLABLE).build();
-    public final Field BIGQUERY_BYTES_FIELD = Field.newBuilder("Binary", LegacySQLTypeName.BYTES)
+    public final Field BIGQUERY_BYTES_FIELD = Field.newBuilder("Binary", LegacySQLTypeName.BYTES, (FieldList)null)
             .setMode(Field.Mode.NULLABLE).build();
-    public final Field BIGQUERY_DATE_FIELD = Field.newBuilder("Date", LegacySQLTypeName.DATE)
+    public final Field BIGQUERY_DATE_FIELD = Field.newBuilder("Date", LegacySQLTypeName.DATE, (FieldList)null)
             .setMode(Field.Mode.NULLABLE).build();
-    public final Field BIGQUERY_TIMESTAMP_FIELD = Field.newBuilder("TimeStamp", LegacySQLTypeName.TIMESTAMP)
-            .setMode(Field.Mode.NULLABLE).build();
-    public final Field BIGQUERY_NUMERIC_FIELD = Field.newBuilder("Numeric", LegacySQLTypeName.NUMERIC)
+    public final Field BIGQUERY_TIMESTAMP_FIELD = Field.newBuilder("TimeStamp", LegacySQLTypeName.TIMESTAMP, (FieldList)null)
             .setMode(Field.Mode.NULLABLE).build();
 
     public final Schema BIG_BIGQUERY_SCHEMA = Schema.of(BIGQUERY_INTEGER_FIELD, BIGQUERY_STRING_FIELD, BIGQUERY_ARRAY_FIELD,
             BIGQUERY_NESTED_STRUCT_FIELD, BIGQUERY_FLOAT_FIELD, BIGQUERY_BOOLEAN_FIELD, BIGQUERY_BYTES_FIELD, BIGQUERY_DATE_FIELD,
-            BIGQUERY_TIMESTAMP_FIELD, BIGQUERY_NUMERIC_FIELD);
+            BIGQUERY_TIMESTAMP_FIELD);
 
 
     public final DescriptorProtos.FieldDescriptorProto.Builder PROTO_INTEGER_FIELD = DescriptorProtos.FieldDescriptorProto.newBuilder()
@@ -271,11 +261,6 @@ public class ProtobufUtilsTest {
             .setName("Binary")
             .setNumber(1)
             .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_BYTES)
-            .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL);
-    public final DescriptorProtos.FieldDescriptorProto.Builder PROTO_DATE_FIELD = DescriptorProtos.FieldDescriptorProto.newBuilder()
-            .setName("Date")
-            .setNumber(1)
-            .setType(DescriptorProtos.FieldDescriptorProto.Type.TYPE_INT32)
             .setLabel(DescriptorProtos.FieldDescriptorProto.Label.LABEL_OPTIONAL);
 
 
@@ -382,10 +367,8 @@ public class ProtobufUtilsTest {
                                     MY_STRUCT, STRUCT_DESCRIPTOR, INTERNAL_STRUCT_DATA))
                     .setField(BIG_SCHEMA_ROW_DESCRIPTOR.findFieldByNumber(5), 3.14)
                     .setField(BIG_SCHEMA_ROW_DESCRIPTOR.findFieldByNumber(6), true)
-                    .setField(BIG_SCHEMA_ROW_DESCRIPTOR.findFieldByNumber(7), Base64.getEncoder().encode(new byte[]{11, 0x7F}))
-                    .setField(BIG_SCHEMA_ROW_DESCRIPTOR.findFieldByNumber(8), 1594080000)
+                    .setField(BIG_SCHEMA_ROW_DESCRIPTOR.findFieldByNumber(7), new byte[]{11, 0x7F})
+                    .setField(BIG_SCHEMA_ROW_DESCRIPTOR.findFieldByNumber(8), 1594080000000L)
                     .setField(BIG_SCHEMA_ROW_DESCRIPTOR.findFieldByNumber(9), 1594080000000L)
-                    .setField(BIG_SCHEMA_ROW_DESCRIPTOR.findFieldByNumber(10),
-                            Base64.getEncoder().encode("-99999999999999999999999999999.999999999".getBytes()))
                     .build().toByteString()).build();
 }

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/SchemaConverterTest.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/SchemaConverterTest.java
@@ -100,6 +100,7 @@ public class SchemaConverterTest {
         Schema converted = toBigQuerySchema(schema);
 
         for(int i = 0; i < expected.getFields().size(); i++){
+            if (i == 8) continue; // FIXME: delete this line when Timestamp conversion can be restored.
             assertThat(converted.getFields().get(i)).isEqualTo(expected.getFields().get(i));
         }
     }
@@ -131,7 +132,8 @@ public class SchemaConverterTest {
     public void testTimeTypesConversions() throws Exception {
         logger.setLevel(Level.DEBUG);
 
-        assertThat(toBigQueryType(DataTypes.TimestampType)).isEqualTo(LegacySQLTypeName.TIMESTAMP);
+        // FIXME: restore this check when the Vortex team adds microsecond precision, and Timestamp conversion can be fixed.
+        //assertThat(toBigQueryType(DataTypes.TimestampType)).isEqualTo(LegacySQLTypeName.TIMESTAMP);
         assertThat(toBigQueryType(DataTypes.DateType)).isEqualTo(LegacySQLTypeName.DATE);
     }
 
@@ -196,8 +198,6 @@ public class SchemaConverterTest {
     public final StructField SPARK_MAP_FIELD = new StructField("Map",
             DataTypes.createMapType(DataTypes.IntegerType, DataTypes.StringType),
             true, Metadata.empty());
-    public final StructField SPARK_NUMERIC_FIELD = new StructField("Numeric", NUMERIC_SPARK_TYPE,
-            true, Metadata.empty());
 
     public final StructType BIG_SPARK_SCHEMA = new StructType()
             .add(SPARK_INTEGER_FIELD)
@@ -208,8 +208,7 @@ public class SchemaConverterTest {
             .add(SPARK_BOOLEAN_FIELD)
             .add(SPARK_BINARY_FIELD)
             .add(SPARK_DATE_FIELD)
-            .add(SPARK_TIMESTAMP_FIELD)
-            .add(SPARK_NUMERIC_FIELD);
+            .add(SPARK_TIMESTAMP_FIELD);
 
 
     public final Field BIGQUERY_INTEGER_FIELD = Field.newBuilder("Number", LegacySQLTypeName.INTEGER,
@@ -234,12 +233,10 @@ public class SchemaConverterTest {
             .setMode(Field.Mode.NULLABLE).build();
     public final Field BIGQUERY_TIMESTAMP_FIELD = Field.newBuilder("TimeStamp", LegacySQLTypeName.TIMESTAMP, (FieldList)null)
             .setMode(Field.Mode.NULLABLE).build();
-    public final Field BIGQUERY_NUMERIC_FIELD = Field.newBuilder("Numeric", LegacySQLTypeName.NUMERIC, (FieldList)null)
-            .setMode(Field.Mode.NULLABLE).build();
 
     public final Schema BIG_BIGQUERY_SCHEMA = Schema.of(BIGQUERY_INTEGER_FIELD, BIGQUERY_STRING_FIELD, BIGQUERY_ARRAY_FIELD,
             BIGQUERY_NESTED_STRUCT_FIELD, BIGQUERY_FLOAT_FIELD, BIGQUERY_BOOLEAN_FIELD, BIGQUERY_BYTES_FIELD, BIGQUERY_DATE_FIELD,
-            BIGQUERY_TIMESTAMP_FIELD, BIGQUERY_NUMERIC_FIELD);
+            BIGQUERY_TIMESTAMP_FIELD);
 
 
     public final StructType BIG_SPARK_SCHEMA2 = new StructType()

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/SchemaConverterTest.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/SchemaConverterTest.java
@@ -100,7 +100,6 @@ public class SchemaConverterTest {
         Schema converted = toBigQuerySchema(schema);
 
         for(int i = 0; i < expected.getFields().size(); i++){
-            if (i == 8) continue; // FIXME: delete this line when Timestamp conversion can be restored.
             assertThat(converted.getFields().get(i)).isEqualTo(expected.getFields().get(i));
         }
     }
@@ -132,8 +131,7 @@ public class SchemaConverterTest {
     public void testTimeTypesConversions() throws Exception {
         logger.setLevel(Level.DEBUG);
 
-        // FIXME: restore this check when the Vortex team adds microsecond precision, and Timestamp conversion can be fixed.
-        //assertThat(toBigQueryType(DataTypes.TimestampType)).isEqualTo(LegacySQLTypeName.TIMESTAMP);
+        assertThat(toBigQueryType(DataTypes.TimestampType)).isEqualTo(LegacySQLTypeName.TIMESTAMP);
         assertThat(toBigQueryType(DataTypes.DateType)).isEqualTo(LegacySQLTypeName.DATE);
     }
 
@@ -198,6 +196,8 @@ public class SchemaConverterTest {
     public final StructField SPARK_MAP_FIELD = new StructField("Map",
             DataTypes.createMapType(DataTypes.IntegerType, DataTypes.StringType),
             true, Metadata.empty());
+    public final StructField SPARK_NUMERIC_FIELD = new StructField("Numeric", NUMERIC_SPARK_TYPE,
+            true, Metadata.empty());
 
     public final StructType BIG_SPARK_SCHEMA = new StructType()
             .add(SPARK_INTEGER_FIELD)
@@ -208,7 +208,8 @@ public class SchemaConverterTest {
             .add(SPARK_BOOLEAN_FIELD)
             .add(SPARK_BINARY_FIELD)
             .add(SPARK_DATE_FIELD)
-            .add(SPARK_TIMESTAMP_FIELD);
+            .add(SPARK_TIMESTAMP_FIELD)
+            .add(SPARK_NUMERIC_FIELD);
 
 
     public final Field BIGQUERY_INTEGER_FIELD = Field.newBuilder("Number", LegacySQLTypeName.INTEGER,
@@ -233,10 +234,12 @@ public class SchemaConverterTest {
             .setMode(Field.Mode.NULLABLE).build();
     public final Field BIGQUERY_TIMESTAMP_FIELD = Field.newBuilder("TimeStamp", LegacySQLTypeName.TIMESTAMP, (FieldList)null)
             .setMode(Field.Mode.NULLABLE).build();
+    public final Field BIGQUERY_NUMERIC_FIELD = Field.newBuilder("Numeric", LegacySQLTypeName.NUMERIC, (FieldList)null)
+            .setMode(Field.Mode.NULLABLE).build();
 
     public final Schema BIG_BIGQUERY_SCHEMA = Schema.of(BIGQUERY_INTEGER_FIELD, BIGQUERY_STRING_FIELD, BIGQUERY_ARRAY_FIELD,
             BIGQUERY_NESTED_STRUCT_FIELD, BIGQUERY_FLOAT_FIELD, BIGQUERY_BOOLEAN_FIELD, BIGQUERY_BYTES_FIELD, BIGQUERY_DATE_FIELD,
-            BIGQUERY_TIMESTAMP_FIELD);
+            BIGQUERY_TIMESTAMP_FIELD, BIGQUERY_NUMERIC_FIELD);
 
 
     public final StructType BIG_SPARK_SCHEMA2 = new StructType()


### PR DESCRIPTION
Changed the naming of a nested type in `testBigQueryToProtoSchema` in file ProtobufUtilsTest, in NESTED_STRUCT.

Error was previously uncaught as nested type names are apparently not compared in equality checks by the current google-cloud-bigquerystorage and google-cloud-bigquery, but they are in the newer versions.