### PR TITLE
Ensuring that BigQuery client will have the proper project id

### DIFF
--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
@@ -120,7 +120,7 @@ class BigQueryRelationProvider(
   }
 
   private def getOrCreateBigQuery(options: SparkBigQueryOptions) =
-    getBigQuery().getOrElse(BigQueryRelationProvider.createBigQuery(options))
+    getBigQuery().getOrElse(BigQueryUtil.createBigQuery(options))
 
   def createSparkBigQueryOptions(sqlContext: SQLContext,
                                  parameters: Map[String, String],
@@ -134,25 +134,6 @@ class BigQueryRelationProvider(
   }
 
   override def shortName: String = "bigquery"
-}
-
-object BigQueryRelationProvider {
-
-  def createBigQuery(options: SparkBigQueryOptions): BigQuery =
-    options.createCredentials.fold(
-      BigQueryOptions.getDefaultInstance.getService
-    )(bigQueryWithCredentials(options.parentProject, _))
-
-  private def bigQueryWithCredentials(parentProject: String,
-                                      credentials: Credentials): BigQuery = {
-    BigQueryOptions
-      .newBuilder()
-      .setProjectId(parentProject)
-      .setCredentials(credentials)
-      .build()
-      .getService
-  }
-
 }
 
 // DefaultSource is required for spark.read.format("com.google.cloud.spark.bigquery")

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
@@ -43,7 +43,7 @@ private[bigquery] class DirectBigQueryRelation(
     getClient: SparkBigQueryOptions => BigQueryReadClient =
          DirectBigQueryRelation.createReadClient,
     bigQueryClient: SparkBigQueryOptions => BigQuery =
-         DirectBigQueryRelation.createBigQueryClient)
+         BigQueryUtil.createBigQuery)
     (@transient override val sqlContext: SQLContext)
     extends BigQueryRelation(options, table)(sqlContext)
         with TableScan with PrunedScan with PrunedFilteredScan {
@@ -354,14 +354,6 @@ object DirectBigQueryRelation {
     }
 
     BigQueryReadClient.create(clientSettings.build)
-  }
-
-  def createBigQueryClient(options: SparkBigQueryOptions): BigQuery = {
-    val BigQueryOptionsBuilder = BigQueryOptions.newBuilder()
-      .setHeaderProvider(headerProvider)
-    // set credentials of provided
-    options.createCredentials.foreach(BigQueryOptionsBuilder.setCredentials)
-    BigQueryOptionsBuilder.build.getService
   }
 
   private def headerProvider =


### PR DESCRIPTION
For some reason the BigQuery client was created by two scala methods, one was setting the parentProject and one was not. This has caused issue when the parent project was different from the cluster or the data projects.