### PR TITLE
Fixing Spark 3 compatibility

### DIFF
--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/SparkBigQueryConnectorModule.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/SparkBigQueryConnectorModule.java
@@ -57,7 +57,7 @@ public class SparkBigQueryConnectorModule implements Module {
   @Provides
   public SparkBigQueryConfig provideSparkBigQueryConfig() {
     return SparkBigQueryConfig.from(
-        options,
+        options.asMap(),
         ImmutableMap.copyOf(mapAsJavaMap(spark.conf().getAll())),
         spark.sparkContext().hadoopConfiguration(),
         spark.sparkContext().defaultParallelism(),

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
@@ -21,6 +21,7 @@ import com.google.cloud.bigquery.TableDefinition.Type.{MATERIALIZED_VIEW, TABLE,
 import com.google.cloud.bigquery.connector.common.BigQueryUtil
 import com.google.cloud.bigquery.{BigQuery, TableDefinition}
 import com.google.cloud.spark.bigquery.direct.DirectBigQueryRelation
+import com.google.common.collect.ImmutableMap
 import org.apache.spark.sql.execution.streaming.Sink
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.streaming.OutputMode
@@ -129,8 +130,8 @@ class BigQueryRelationProvider(
   def createSparkBigQueryConfig(sqlContext: SQLContext,
                                  parameters: Map[String, String],
                                  schema: Option[StructType] = None): SparkBigQueryConfig = {
-    SparkBigQueryConfig.fromV1(parameters.asJava,
-      sqlContext.getAllConfs.asJava,
+    SparkBigQueryConfig.from(parameters.asJava,
+      ImmutableMap.copyOf(sqlContext.getAllConfs.asJava),
       sqlContext.sparkContext.hadoopConfiguration,
       sqlContext.sparkContext.defaultParallelism,
       sqlContext.sparkSession.sessionState.conf,

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -45,7 +45,7 @@ public class SparkBigQueryConfigTest {
     DataSourceOptions options = new DataSourceOptions(defaultOptions);
     SparkBigQueryConfig config =
         SparkBigQueryConfig.from(
-            options,
+            options.asMap(),
             ImmutableMap.of(),
             hadoopConfiguration,
             DEFAULT_PARALLELISM,
@@ -102,7 +102,7 @@ public class SparkBigQueryConfigTest {
                 .build());
     SparkBigQueryConfig config =
         SparkBigQueryConfig.from(
-            options,
+            options.asMap(),
             ImmutableMap.of(),
             hadoopConfiguration,
             DEFAULT_PARALLELISM,


### PR DESCRIPTION
PR #240 has unified the use of `SparkBigQueryConfig` also for the original DataSource v1 implementation, used in Spark 3. This implementation relies on `org.apache.spark.sql.sources.v2.DataSourceOptions` which does not exist in Spark 3 due to the massive DataSource API change it had.

This PR addresses that by:
* Removing `DataSourceOptions` from `SparkBigQueryConfig`
* Adding acceptance test for Dataproc image 2.0 (currently in preview), with Spark 3