### PR TITLE
Convert filters on BigQuery dates and timestamp fields using the right type

### DIFF
--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SparkFilterUtils.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SparkFilterUtils.java
@@ -268,8 +268,11 @@ public class SparkFilterUtils {
     if (value instanceof String) {
       return "'" + escape((String) value) + "'";
     }
-    if (value instanceof Timestamp || value instanceof Date) {
-      return "'" + value + "'";
+    if (value instanceof Date) {
+      return "DATE '" + value + "'";
+    }
+    if (value instanceof Timestamp) {
+      return "TIMESTAMP '" + value + "'";
     }
     if (value instanceof Object[]) {
       return Arrays.stream((Object[]) value)

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
@@ -460,8 +460,8 @@ object DirectBigQueryRelation {
   private def compileValue(value: Any): Any = value match {
     case null => "null"
     case stringValue: String => s"'${stringValue.replace("'", "\\'")}'"
-    case timestampValue: Timestamp => "'" + timestampValue + "'"
-    case dateValue: Date => "'" + dateValue + "'"
+    case timestampValue: Timestamp => "TIMESTAMP '" + timestampValue + "'"
+    case dateValue: Date => "DATE '" + dateValue + "'"
     case arrayValue: Array[Any] => arrayValue.map(compileValue).mkString("[", ", ", "]")
     case _ => value
   }

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/SparkFilterUtilsTest.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/SparkFilterUtilsTest.java
@@ -20,6 +20,9 @@ import com.google.common.collect.ImmutableList;
 import org.apache.spark.sql.sources.*;
 import org.junit.Test;
 
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.text.ParseException;
 import java.util.Optional;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -165,5 +168,24 @@ public class SparkFilterUtilsTest {
         .isEqualTo("(`foo` IS NULL) OR (`bar` IS NOT NULL)");
     assertThat(SparkFilterUtils.compileFilter(Not.apply(IsNull.apply("foo"))))
         .isEqualTo("(NOT (`foo` IS NULL))");
+  }
+
+  @Test
+  public void testDateFilters() throws ParseException {
+    assertThat(
+            SparkFilterUtils.compileFilter(
+                In.apply(
+                    "datefield",
+                    new Object[] {Date.valueOf("2020-09-01"), Date.valueOf("2020-11-03")})))
+        .isEqualTo("`datefield` IN UNNEST([DATE '2020-09-01', DATE '2020-11-03'])");
+  }
+
+  @Test
+  public void testTimestampFilters() throws ParseException {
+    Timestamp ts1 = Timestamp.valueOf("2008-12-25 15:30:00");
+    Timestamp ts2 = Timestamp.valueOf("2020-01-25 02:10:10");
+    assertThat(SparkFilterUtils.compileFilter(In.apply("tsfield", new Object[] {ts1, ts2})))
+        .isEqualTo(
+            "`tsfield` IN UNNEST([TIMESTAMP '2008-12-25 15:30:00.0', TIMESTAMP '2020-01-25 02:10:10.0'])");
   }
 }

--- a/connector/src/test/scala/com/google/cloud/spark/bigquery/DirectBigQueryRelationSuite.scala
+++ b/connector/src/test/scala/com/google/cloud/spark/bigquery/DirectBigQueryRelationSuite.scala
@@ -15,7 +15,7 @@
  */
 package com.google.cloud.spark.bigquery
 
-import java.util.Optional
+import java.sql.{Date, Timestamp}
 
 import com.google.cloud.bigquery._
 import com.google.cloud.bigquery.storage.v1.DataFormat
@@ -27,7 +27,6 @@ import org.mockito.Mockito._
 import org.mockito.{Mock, MockitoAnnotations}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.{BeforeAndAfter, Matchers}
-
 
 class DirectBigQueryRelationSuite
   extends AnyFunSuite with BeforeAndAfter with Matchers {
@@ -189,6 +188,16 @@ class DirectBigQueryRelationSuite
     val r = new DirectBigQueryRelation(
       defaultOptions, TABLE)(sqlCtx)
     checkFilters(r, "", Array(GreaterThan("a", 2)), "(a > 2)")
+  }
+
+  test("filter on date and timestamp fields") {
+    val options = defaultOptions
+    val r = new DirectBigQueryRelation(options, TABLE)(sqlCtx)
+    val inFilter = In("datefield", Array(Date.valueOf("2020-09-01"), Date.valueOf("2020-11-03")))
+    val equalFilter = EqualTo("tsField", Timestamp.valueOf("2020-01-25 02:10:10"))
+    checkFilters(r, "", Array(inFilter, equalFilter),
+      "(`datefield` IN UNNEST([DATE '2020-09-01', DATE '2020-11-03']) AND " +
+        "`tsField` = TIMESTAMP '2020-01-25 02:10:10.0')")
   }
 
   def checkFilters(


### PR DESCRIPTION
This fixes the query failures similar to TPCDS query# 83. Without this fix, BigQuery read API complains that the pushed down filter is invalid. The fix is done for both the v1 and v2 code paths.

Testing: unit testing and tested with TPCDS query# 83