### PR TITLE
Fixing external configuration regression bug

### DIFF
--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -104,13 +104,15 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
   @VisibleForTesting
   public static SparkBigQueryConfig from(
       Map<String, String> options,
-      ImmutableMap<String, String> globalOptions,
+      ImmutableMap<String, String> originalGlobalOptions,
       Configuration hadoopConfiguration,
       int defaultParallelism,
       SQLConf sqlConf,
       String sparkVersion,
       Optional<StructType> schema) {
     SparkBigQueryConfig config = new SparkBigQueryConfig();
+
+    ImmutableMap<String, String> globalOptions = normalizeConf(originalGlobalOptions);
 
     String tableParam =
         getOptionFromMultipleParams(options, ImmutableList.of("table", "path"), DEFAULT_FALLBACK)
@@ -290,7 +292,7 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
     return getAnyOption(globalOptions, options, name).transform(Boolean::valueOf).or(defaultValue);
   }
 
-  static Map<String, String> normalizeConf(Map<String, String> conf) {
+  static ImmutableMap<String, String> normalizeConf(Map<String, String> conf) {
     Map<String, String> normalizeConf =
         conf.entrySet().stream()
             .filter(e -> e.getKey().startsWith(CONF_PREFIX))

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.spark.bigquery;
 
-import com.google.cloud.bigquery.FormatOptions;
 import com.google.cloud.bigquery.JobInfo;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.storage.v1.DataFormat;
@@ -132,5 +131,29 @@ public class SparkBigQueryConfigTest {
                 JobInfo.SchemaUpdateOption.ALLOW_FIELD_RELAXATION));
     assertThat(config.getViewExpirationTimeInHours()).isEqualTo(24);
     assertThat(config.getMaxReadRowsRetries()).isEqualTo(3);
+  }
+
+  @Test
+  public void testConfigFromGlobalOptions() {
+    Configuration hadoopConfiguration = new Configuration();
+    DataSourceOptions options =
+        new DataSourceOptions(
+            ImmutableMap.<String, String>builder().put("table", "dataset.table").build());
+    ImmutableMap<String, String> globalOptions = ImmutableMap.<String, String>builder()
+            .put("viewsEnabled", "true")
+            .put("spark.datasource.bigquery.temporaryGcsBucket", "bucket")
+            .build();
+    SparkBigQueryConfig config =
+            SparkBigQueryConfig.from(
+                    options.asMap(),
+                    globalOptions,
+                    hadoopConfiguration,
+                    DEFAULT_PARALLELISM,
+                    new SQLConf(),
+                    SPARK_VERSION,
+                    Optional.empty());
+
+    assertThat(config.isViewsEnabled()).isTrue();
+    assertThat(config.getTemporaryGcsBucket()).isEqualTo(Optional.of("bucket"));
   }
 }


### PR DESCRIPTION
A regression bug preventing the usage of the `--conf` parameter to configure the connector's option has been introduced in version 0.17.2. This PR fixes that