### PR TITLE
Change to BigQueryRelation so that the query plans are readable in Spark UI

### DIFF
--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelation.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelation.scala
@@ -37,6 +37,16 @@ private[bigquery] case class BigQueryRelation(options: SparkBigQueryConfig, tabl
     options.getSchema.orElse(SchemaConverters.toSpark(tableDefinition.getSchema))
   }
 
+  override def toString(): String = {
+    val formatter = java.text.NumberFormat.getIntegerInstance
+    val tableId =
+      s"${table.getTableId.getProject}.${table.getTableId.getDataset}.${table.getTableId.getTable}"
+
+    s"""BigQueryRelation(${tableId}
+       |numRows=${formatter.format(table.getNumRows)}
+       |numBytes=${formatter.format(table.getNumBytes)}
+       |)""".stripMargin
+  }
 }
 
 


### PR DESCRIPTION
Tested by running a Spark job.