### PR TITLE
Add option to enable useAvroLogicalTypes option in LoadJobConfiguration

### DIFF
--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -49,6 +49,7 @@ import static java.lang.String.format;
 public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
 
   public static final String VIEWS_ENABLED_OPTION = "viewsEnabled";
+  public static final String USE_AVRO_LOGICAL_TYPES_OPTION = "useAvroLogicalTypes";
   public static final String DATE_PARTITION_PARAM = "datePartition";
   @VisibleForTesting static final DataFormat DEFAULT_READ_DATA_FORMAT = DataFormat.ARROW;
 
@@ -93,6 +94,7 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
   com.google.common.base.Optional<String[]> clusteredFields = empty();
   com.google.common.base.Optional<JobInfo.CreateDisposition> createDisposition = empty();
   boolean optimizedEmptyProjection = true;
+  boolean useAvroLogicalTypes = false;
   ImmutableList<JobInfo.SchemaUpdateOption> loadSchemaUpdateOptions = ImmutableList.of();
   int viewExpirationTimeInHours = 24;
   int maxReadRowsRetries = 3;
@@ -172,6 +174,7 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
               "Data read format '%s' is not supported. Supported formats are '%s'",
               readDataFormatParam, String.join(",", PERMITTED_READ_DATA_FORMATS)));
     }
+    config.useAvroLogicalTypes = getAnyBooleanOption(globalOptions, options, USE_AVRO_LOGICAL_TYPES_OPTION, false);
     config.readDataFormat = DataFormat.valueOf(readDataFormatParam);
     config.combinePushedDownFilters =
         getAnyBooleanOption(globalOptions, options, "combinePushedDownFilters", true);
@@ -391,6 +394,10 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
 
   public boolean isCombinePushedDownFilters() {
     return combinePushedDownFilters;
+  }
+
+  public boolean isUseAvroLogicalTypes() {
+    return useAvroLogicalTypes;
   }
 
   public boolean isViewsEnabled() {

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryWriteHelper.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryWriteHelper.scala
@@ -139,6 +139,10 @@ case class BigQueryWriteHelper(bigQuery: BigQuery,
       }
     }
 
+    if (options.isUseAvroLogicalTypes) {
+      jobConfigurationBuilder.setUseAvroLogicalTypes(true)
+    }
+
     if (!options.getLoadSchemaUpdateOptions.isEmpty) {
       jobConfigurationBuilder.setSchemaUpdateOptions(options.getLoadSchemaUpdateOptions)
     }

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -71,6 +71,7 @@ public class SparkBigQueryConfigTest {
     assertThat(config.getLoadSchemaUpdateOptions()).isEqualTo(ImmutableList.of());
     assertThat(config.getViewExpirationTimeInHours()).isEqualTo(24);
     assertThat(config.getMaxReadRowsRetries()).isEqualTo(3);
+    assertThat(!config.isUseAvroLogicalTypes());
   }
 
   @Test
@@ -93,6 +94,7 @@ public class SparkBigQueryConfigTest {
                 .put("createDisposition", "CREATE_NEVER")
                 .put("temporaryGcsBucket", "some_bucket")
                 .put("intermediateFormat", "ORC")
+                .put("useAvroLogicalTypes", "true")
                 .put("partitionRequireFilter", "true")
                 .put("partitionType", "HOUR")
                 .put("partitionField", "some_field")
@@ -134,6 +136,7 @@ public class SparkBigQueryConfigTest {
                 JobInfo.SchemaUpdateOption.ALLOW_FIELD_RELAXATION));
     assertThat(config.getViewExpirationTimeInHours()).isEqualTo(24);
     assertThat(config.getMaxReadRowsRetries()).isEqualTo(3);
+    assertThat(config.isUseAvroLogicalTypes());
   }
 
   @Test

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -71,7 +71,7 @@ public class SparkBigQueryConfigTest {
     assertThat(config.getLoadSchemaUpdateOptions()).isEqualTo(ImmutableList.of());
     assertThat(config.getViewExpirationTimeInHours()).isEqualTo(24);
     assertThat(config.getMaxReadRowsRetries()).isEqualTo(3);
-    assertThat(!config.isUseAvroLogicalTypes());
+    assertThat(config.isUseAvroLogicalTypes()).isFalse();
   }
 
   @Test
@@ -136,7 +136,7 @@ public class SparkBigQueryConfigTest {
                 JobInfo.SchemaUpdateOption.ALLOW_FIELD_RELAXATION));
     assertThat(config.getViewExpirationTimeInHours()).isEqualTo(24);
     assertThat(config.getMaxReadRowsRetries()).isEqualTo(3);
-    assertThat(config.isUseAvroLogicalTypes());
+    assertThat(config.isUseAvroLogicalTypes()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
In order to be able to load a BigQuery table partitioned on a DATE column using Avro, the option `useAvroLogicalTypes` has to be activated in `LoadJobConfiguration`. Otherwise, BigQuery reads DATE columns as INTEGER as documented here: https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro#logical_types 