### PR TITLE
Improved filter and pseudo column support

### DIFF
--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/LoggingBigQueryStorageReadRowsTracer.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/LoggingBigQueryStorageReadRowsTracer.java
@@ -94,7 +94,7 @@ public class LoggingBigQueryStorageReadRowsTracer implements BigQueryStorageRead
       return 0;
     }
     Duration time = timer.getAccumulatedTime();
-    double seconds =  (time.toMillis() / 1000.0);
+    double seconds = (time.toMillis() / 1000.0);
     if (seconds != 0) {
       return (long) (metric / seconds);
     }

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SparkFilterUtils.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SparkFilterUtils.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.spark.bigquery;
 
-import com.google.cloud.bigquery.storage.v1.DataFormat;
 import com.google.common.collect.ImmutableList;
 import org.apache.spark.sql.sources.*;
 import org.apache.spark.sql.types.StructField;
@@ -36,87 +35,9 @@ public class SparkFilterUtils {
 
   private SparkFilterUtils() {}
 
-  // Structs are not handled
-  public static boolean isTopLevelFieldHandled(
-      Filter filter, DataFormat readDataFormat, Map<String, StructField> fields) {
-    if (filter instanceof EqualTo) {
-      EqualTo equalTo = (EqualTo) filter;
-      return isFilterWithNamedFieldHandled(filter, readDataFormat, fields, equalTo.attribute());
-    }
-    if (filter instanceof GreaterThan) {
-      GreaterThan greaterThan = (GreaterThan) filter;
-      return isFilterWithNamedFieldHandled(filter, readDataFormat, fields, greaterThan.attribute());
-    }
-    if (filter instanceof GreaterThanOrEqual) {
-      GreaterThanOrEqual greaterThanOrEqual = (GreaterThanOrEqual) filter;
-      return isFilterWithNamedFieldHandled(
-          filter, readDataFormat, fields, greaterThanOrEqual.attribute());
-    }
-    if (filter instanceof LessThan) {
-      LessThan lessThan = (LessThan) filter;
-      return isFilterWithNamedFieldHandled(filter, readDataFormat, fields, lessThan.attribute());
-    }
-    if (filter instanceof LessThanOrEqual) {
-      LessThanOrEqual lessThanOrEqual = (LessThanOrEqual) filter;
-      return isFilterWithNamedFieldHandled(
-          filter, readDataFormat, fields, lessThanOrEqual.attribute());
-    }
-    if (filter instanceof In) {
-      In in = (In) filter;
-      return isFilterWithNamedFieldHandled(filter, readDataFormat, fields, in.attribute());
-    }
-    if (filter instanceof IsNull) {
-      IsNull isNull = (IsNull) filter;
-      return isFilterWithNamedFieldHandled(filter, readDataFormat, fields, isNull.attribute());
-    }
-    if (filter instanceof IsNotNull) {
-      IsNotNull isNotNull = (IsNotNull) filter;
-      return isFilterWithNamedFieldHandled(filter, readDataFormat, fields, isNotNull.attribute());
-    }
-    if (filter instanceof And) {
-      And and = (And) filter;
-      return isTopLevelFieldHandled(and.left(), readDataFormat, fields)
-          && isTopLevelFieldHandled(and.right(), readDataFormat, fields);
-    }
-    if (filter instanceof Or) {
-      Or or = (Or) filter;
-      return readDataFormat == DataFormat.AVRO
-          && isTopLevelFieldHandled(or.left(), readDataFormat, fields)
-          && isTopLevelFieldHandled(or.right(), readDataFormat, fields);
-    }
-    if (filter instanceof Not) {
-      Not not = (Not) filter;
-      return isTopLevelFieldHandled(not.child(), readDataFormat, fields);
-    }
-    if (filter instanceof StringStartsWith) {
-      StringStartsWith stringStartsWith = (StringStartsWith) filter;
-      return isFilterWithNamedFieldHandled(
-          filter, readDataFormat, fields, stringStartsWith.attribute());
-    }
-    if (filter instanceof StringEndsWith) {
-      StringEndsWith stringEndsWith = (StringEndsWith) filter;
-      return isFilterWithNamedFieldHandled(
-          filter, readDataFormat, fields, stringEndsWith.attribute());
-    }
-    if (filter instanceof StringContains) {
-      StringContains stringContains = (StringContains) filter;
-      return isFilterWithNamedFieldHandled(
-          filter, readDataFormat, fields, stringContains.attribute());
-    }
-
-    throw new IllegalArgumentException(format("Invalid filter: %s", filter));
-  }
-
-  static boolean isFilterWithNamedFieldHandled(
-      Filter filter, DataFormat readDataFormat, Map<String, StructField> fields, String fieldName) {
-    return Optional.ofNullable(fields.get(fieldName))
-        .filter(field -> field.dataType() instanceof StructType)
-        .map(field -> false)
-        .orElse(isHandled(filter, readDataFormat));
-  }
-
-  public static boolean isHandled(Filter filter, DataFormat readDataFormat) {
+  public static boolean isHandled(Filter filter) {
     if (filter instanceof EqualTo
+        || filter instanceof EqualNullSafe
         || filter instanceof GreaterThan
         || filter instanceof GreaterThanOrEqual
         || filter instanceof LessThan
@@ -129,52 +50,43 @@ public class SparkFilterUtils {
         || filter instanceof StringContains) {
       return true;
     }
-    // There is no direct equivalent of EqualNullSafe in Google standard SQL.
-    if (filter instanceof EqualNullSafe) {
-      return false;
-    }
     if (filter instanceof And) {
       And and = (And) filter;
-      return isHandled(and.left(), readDataFormat) && isHandled(and.right(), readDataFormat);
+      return isHandled(and.left()) && isHandled(and.right());
     }
     if (filter instanceof Or) {
       Or or = (Or) filter;
-      return readDataFormat == DataFormat.AVRO
-          && isHandled(or.left(), readDataFormat)
-          && isHandled(or.right(), readDataFormat);
+      return isHandled(or.left()) && isHandled(or.right());
     }
     if (filter instanceof Not) {
-      return isHandled(((Not) filter).child(), readDataFormat);
+      return isHandled(((Not) filter).child());
     }
     return false;
   }
 
-  public static Iterable<Filter> handledFilters(DataFormat readDataFormat, Filter... filters) {
-    return handledFilters(readDataFormat, ImmutableList.copyOf(filters));
+  public static Iterable<Filter> handledFilters(Filter... filters) {
+    return handledFilters(ImmutableList.copyOf(filters));
   }
 
-  public static Iterable<Filter> handledFilters(
-      DataFormat readDataFormat, Iterable<Filter> filters) {
+  public static Iterable<Filter> handledFilters(Iterable<Filter> filters) {
     return StreamSupport.stream(filters.spliterator(), false)
-        .filter(f -> isHandled(f, readDataFormat))
+        .filter(f -> isHandled(f))
         .collect(Collectors.toList());
   }
 
-  public static Iterable<Filter> unhandledFilters(DataFormat readDataFormat, Filter... filters) {
-    return unhandledFilters(readDataFormat, ImmutableList.copyOf(filters));
+  public static Iterable<Filter> unhandledFilters(Filter... filters) {
+    return unhandledFilters(ImmutableList.copyOf(filters));
   }
 
-  public static Iterable<Filter> unhandledFilters(
-      DataFormat readDataFormat, Iterable<Filter> filters) {
+  public static Iterable<Filter> unhandledFilters(Iterable<Filter> filters) {
     return StreamSupport.stream(filters.spliterator(), false)
-        .filter(f -> !isHandled(f, readDataFormat))
+        .filter(f -> !isHandled(f))
         .collect(Collectors.toList());
   }
 
-  public static String getCompiledFilter(
-      DataFormat readDataFormat, Optional<String> configFilter, Filter... pushedFilters) {
+  public static String getCompiledFilter(Optional<String> configFilter, Filter... pushedFilters) {
     String compiledPushedFilter =
-        compileFilters(handledFilters(readDataFormat, ImmutableList.copyOf(pushedFilters)));
+        compileFilters(handledFilters(ImmutableList.copyOf(pushedFilters)));
     return Stream.of(
             configFilter,
             compiledPushedFilter.length() == 0
@@ -190,6 +102,14 @@ public class SparkFilterUtils {
     if (filter instanceof EqualTo) {
       EqualTo equalTo = (EqualTo) filter;
       return format("%s = %s", quote(equalTo.attribute()), compileValue(equalTo.value()));
+    }
+    if (filter instanceof EqualNullSafe) {
+      EqualNullSafe equalNullSafe = (EqualNullSafe) filter;
+      String lhs = quote(equalNullSafe.attribute());
+      String rhs = compileValue(equalNullSafe.value());
+      return format(
+          "(%s = %s) OR ((%s = %s) IS NULL AND (%s IS NULL) AND (%s IS NULL))",
+          lhs, rhs, lhs, rhs, lhs, rhs);
     }
     if (filter instanceof GreaterThan) {
       GreaterThan greaterThan = (GreaterThan) filter;

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelation.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelation.scala
@@ -34,7 +34,7 @@ private[bigquery] case class BigQueryRelation(options: SparkBigQueryConfig, tabl
   private val tableDefinition: TableDefinition = table.getDefinition[TableDefinition]
 
   override val schema: StructType = {
-    options.getSchema.orElse(SchemaConverters.toSpark(tableDefinition.getSchema))
+    options.getSchema.orElse(SchemaConverters.toSpark(SchemaConverters.getSchemaWithPseudoColumns(table)))
   }
 
   override def toString(): String = {
@@ -48,6 +48,3 @@ private[bigquery] case class BigQueryRelation(options: SparkBigQueryConfig, tabl
        |)""".stripMargin
   }
 }
-
-
-

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/SparkFilterUtilsTest.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/SparkFilterUtilsTest.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.spark.bigquery;
 
-import com.google.cloud.bigquery.storage.v1.DataFormat;
 import com.google.common.collect.ImmutableList;
 import org.apache.spark.sql.sources.*;
 import org.junit.Test;
@@ -29,14 +28,12 @@ import static com.google.common.truth.Truth.assertThat;
 
 public class SparkFilterUtilsTest {
 
-  private static final DataFormat ARROW = DataFormat.ARROW;
-  private static final DataFormat AVRO = DataFormat.AVRO;
-
   @Test
-  public void testValidFiltersForAvro() {
+  public void testValidFilters() {
     ImmutableList<Filter> validFilters =
         ImmutableList.of(
             EqualTo.apply("foo", "manatee"),
+            EqualNullSafe.apply("foo", "manatee"),
             GreaterThan.apply("foo", "aardvark"),
             GreaterThanOrEqual.apply("bar", 2),
             LessThan.apply("foo", "zebra"),
@@ -50,82 +47,41 @@ public class SparkFilterUtilsTest {
             StringStartsWith.apply("foo", "abc"),
             StringEndsWith.apply("foo", "def"),
             StringContains.apply("foo", "abcdef"));
-    validFilters.forEach(f -> assertThat(SparkFilterUtils.unhandledFilters(AVRO, f)).isEmpty());
-  }
-
-  @Test
-  public void testValidFiltersForArrow() {
-    ImmutableList<Filter> validFilters =
-        ImmutableList.of(
-            EqualTo.apply("foo", "manatee"),
-            GreaterThan.apply("foo", "aardvark"),
-            GreaterThanOrEqual.apply("bar", 2),
-            LessThan.apply("foo", "zebra"),
-            LessThanOrEqual.apply("bar", 1),
-            In.apply("foo", new Object[] {1, 2, 3}),
-            IsNull.apply("foo"),
-            IsNotNull.apply("foo"),
-            And.apply(IsNull.apply("foo"), IsNotNull.apply("bar")),
-            Not.apply(IsNull.apply("foo")),
-            StringStartsWith.apply("foo", "abc"),
-            StringEndsWith.apply("foo", "def"),
-            StringContains.apply("foo", "abcdef"));
-    validFilters.forEach(f -> assertThat(SparkFilterUtils.unhandledFilters(ARROW, f)).isEmpty());
+    validFilters.forEach(f -> assertThat(SparkFilterUtils.unhandledFilters(f)).isEmpty());
   }
 
   @Test
   public void testMultipleValidFiltersAreHandled() {
     Filter valid1 = EqualTo.apply("foo", "bar");
     Filter valid2 = EqualTo.apply("bar", 1);
-    assertThat(SparkFilterUtils.unhandledFilters(AVRO, valid1, valid2)).isEmpty();
-  }
-
-  @Test
-  public void testInvalidFiltersWithAvro() {
-    Filter valid1 = EqualTo.apply("foo", "bar");
-    Filter valid2 = EqualTo.apply("bar", 1);
-    Filter invalid1 = EqualNullSafe.apply("foo", "bar");
-    Filter invalid2 =
-        And.apply(EqualTo.apply("foo", "bar"), Not.apply(EqualNullSafe.apply("bar", 1)));
-    Iterable<Filter> unhandled =
-        SparkFilterUtils.unhandledFilters(AVRO, valid1, valid2, invalid1, invalid2);
-    assertThat(unhandled).containsExactly(invalid1, invalid2);
-  }
-
-  @Test
-  public void testInvalidFiltersWithArrow() {
-    Filter valid1 = EqualTo.apply("foo", "bar");
-    Filter valid2 = EqualTo.apply("bar", 1);
-    Filter invalid1 = EqualNullSafe.apply("foo", "bar");
-    Filter invalid2 =
-        And.apply(EqualTo.apply("foo", "bar"), Not.apply(EqualNullSafe.apply("bar", 1)));
-    Filter invalid3 = Or.apply(IsNull.apply("foo"), IsNotNull.apply("foo"));
-    Iterable<Filter> unhandled =
-        SparkFilterUtils.unhandledFilters(ARROW, valid1, valid2, invalid1, invalid2, invalid3);
-    assertThat(unhandled).containsExactly(invalid1, invalid2, invalid3);
+    assertThat(SparkFilterUtils.unhandledFilters(valid1, valid2)).isEmpty();
   }
 
   @Test
   public void testNewFilterBehaviourWithFilterOption() {
-    checkFilters(
-        AVRO, "(f>1)", "(f>1) AND (`a` > 2)", Optional.of("f>1"), GreaterThan.apply("a", 2));
+    checkFilters("(f>1)", "(f>1) AND (`a` > 2)", Optional.of("f>1"), GreaterThan.apply("a", 2));
   }
 
   @Test
   public void testNewFilterBehaviourNoFilterOption() {
-    checkFilters(AVRO, "", "(`a` > 2)", Optional.empty(), GreaterThan.apply("a", 2));
+    checkFilters("", "(`a` > 2)", Optional.empty(), GreaterThan.apply("a", 2));
   }
 
   private void checkFilters(
-      DataFormat readDateFormat,
       String resultWithoutFilters,
       String resultWithFilters,
       Optional<String> configFilter,
       Filter... filters) {
-    String result1 = SparkFilterUtils.getCompiledFilter(readDateFormat, configFilter);
+    String result1 = SparkFilterUtils.getCompiledFilter(configFilter);
     assertThat(result1).isEqualTo(resultWithoutFilters);
-    String result2 = SparkFilterUtils.getCompiledFilter(readDateFormat, configFilter, filters);
+    String result2 = SparkFilterUtils.getCompiledFilter(configFilter, filters);
     assertThat(result2).isEqualTo(resultWithFilters);
+  }
+
+  @Test
+  public void testEqualNullSafeFilter() {
+    assertThat(SparkFilterUtils.compileFilter(EqualNullSafe.apply("a", "b")))
+        .isEqualTo("(`a` = 'b') OR ((`a` = 'b') IS NULL AND (`a` IS NULL) AND ('b' IS NULL))");
   }
 
   @Test
@@ -190,12 +146,11 @@ public class SparkFilterUtilsTest {
   }
 
   @Test
-  public void testFiltersWithNestedOrAndForAVRO_1() {
+  public void testFiltersWithNestedOrAnd_1() {
     // original query
     // (c1 >= 500 or c1 <= 70 or c1 >= 900 or c3 <= 50) and
     // (c1 >= 100 or c1 <= 700  or c2 <= 900) and
     // (c1 >= 5000 or c1 <= 701)
-
 
     Filter part1 =
         Or.apply(
@@ -210,7 +165,6 @@ public class SparkFilterUtilsTest {
     Filter part3 = Or.apply(GreaterThanOrEqual.apply("c1", 5000), LessThanOrEqual.apply("c1", 701));
 
     checkFilters(
-        AVRO,
         "",
         "(((((`c1` >= 100) OR (`c1` <= 700))) OR (`c2` <= 900)) "
             + "AND ((((`c1` >= 500) OR (`c1` <= 70))) OR (((`c1` >= 900) OR "
@@ -222,7 +176,7 @@ public class SparkFilterUtilsTest {
   }
 
   @Test
-  public void testFiltersWithNestedOrAndForAVRO_2() {
+  public void testFiltersWithNestedOrAnd_2() {
     // original query
     // (c1 >= 500 and c2 <= 300) or (c1 <= 800 and c3 >= 230)
 
@@ -232,7 +186,6 @@ public class SparkFilterUtilsTest {
             And.apply(LessThanOrEqual.apply("c1", 800), GreaterThanOrEqual.apply("c3", 230)));
 
     checkFilters(
-        AVRO,
         "",
         "(((((`c1` >= 500) AND (`c2` <= 300))) OR (((`c1` <= 800) AND (`c3` >= 230)))))",
         Optional.empty(),
@@ -240,7 +193,7 @@ public class SparkFilterUtilsTest {
   }
 
   @Test
-  public void testFiltersWithNestedOrAndForAVRO_3() {
+  public void testFiltersWithNestedOrAndFor_3() {
     // original query
     // (((c1 >= 500 or c1 <= 70) and
     // (c1 >= 900 or (c3 <= 50 and (c2 >= 20 or c3 > 200))))) and
@@ -266,7 +219,6 @@ public class SparkFilterUtilsTest {
                 Or.apply(GreaterThanOrEqual.apply("c2", 15), GreaterThanOrEqual.apply("c3", 10))));
 
     checkFilters(
-        AVRO,
         "",
         "(((((((`c1` >= 5000) OR (`c1` <= 701))) AND "
             + "(((`c2` >= 150) OR (`c3` >= 100))))) OR (((((`c1` >= 50) OR "


### PR DESCRIPTION
This PR introduces some changes to connector's filter and pseudo column handling so that it can take advantage of the BQ Storage API. 

Filter changes: 
- Removed push down filter restrictions based on readDataFormat (i.e. both Avro and Arrow behave the same). 
- Added support for EqualNullSafe filter type (which can't be supported natively by the BQ Storage API, but it can be supported as a compound expression). 
- Removed restriction on struct field filtering (which is supported by BQ Storage API), but spark itself doesn't seem to try push them anyways at the moment.

Pseudo column changes: If queried BQ table is [ingestion time partitioned](https://cloud.google.com/bigquery/docs/creating-partitioned-tables), schema of the table is modified with the additions of top level `_PARTITIONTIME` and `_PARTITIONDATE` fields. This introduces a slight behavior change for `select *` queries (i.e. the two new pseudo columns are returned on top of regular schema). This can't be avoided at the moment because there isn't a way to differentiate queries within connector as far as I can tell.

On top of the unit tests, I also ran some tests on a 2.4 dataproc cluster (specifically on pseudo columns).