### PR TITLE
Adding read from query capability

### DIFF
--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
@@ -92,12 +92,11 @@ public class BigQueryClient {
 
   public TableInfo getReadTable(ReadTableOptions options) {
     Optional<String> query = options.query();
-    String tableParam = options.tableId().getTable();
     // first, let check if this is a query
-    if (query.isPresent() || tableParam.toLowerCase().startsWith("select ")) {
+    if (query.isPresent()) {
       // in this case, let's materialize it and use it as the table
       validateViewsEnabled(options);
-      String sql = query.orElse(tableParam);
+      String sql = query.get();
       return materializeQueryToTable(sql, options.viewExpirationTimeInHours());
     }
 
@@ -159,9 +158,8 @@ public class BigQueryClient {
       Optional<String> referenceProject, Optional<String> referenceDataset) {
     String project = materializationProject.orElse(referenceProject.orElse(null));
     String dataset = materializationDataset.orElse(referenceDataset.orElse(null));
-    DatasetId datasetId = DatasetId.of(project, dataset);
     String name = format("_bqc_%s", randomUUID().toString().toLowerCase(ENGLISH).replace("-", ""));
-    return TableId.of(datasetId.getProject(), datasetId.getDataset(), name);
+    return project == null ? TableId.of(dataset, name) : TableId.of(project, dataset, name);
   }
 
   public Table update(TableInfo table) {

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreator.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreator.java
@@ -15,27 +15,22 @@
  */
 package com.google.cloud.bigquery.connector.common;
 
-import com.google.cloud.BaseServiceException;
-import com.google.cloud.bigquery.*;
+import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.TableDefinition;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.storage.v1.BigQueryReadClient;
 import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
 import com.google.cloud.bigquery.storage.v1.ReadSession;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import static com.google.cloud.bigquery.connector.common.BigQueryErrorCode.BIGQUERY_VIEW_DESTINATION_TABLE_CREATION_FAILED;
 import static com.google.cloud.bigquery.connector.common.BigQueryErrorCode.UNSUPPORTED;
-import static com.google.cloud.bigquery.connector.common.BigQueryUtil.convertToBigQueryException;
 import static java.lang.String.format;
 
 // A helper class, also handles view materialization
@@ -48,9 +43,6 @@ public class ReadSessionCreator {
   private static final int DEFAULT_BYTES_PER_PARTITION = 400 * 1000 * 1000;
 
   private static final Logger log = LoggerFactory.getLogger(ReadSessionCreator.class);
-
-  private static Cache<String, TableInfo> destinationTableCache =
-      CacheBuilder.newBuilder().expireAfterWrite(15, TimeUnit.MINUTES).maximumSize(1000).build();
 
   private final ReadSessionCreatorConfig config;
   private final BigQueryClient bigQueryClient;
@@ -136,14 +128,8 @@ public class ReadSessionCreator {
       // get it from the view
       String querySql = bigQueryClient.createSql(table.getTableId(), requiredColumns, filters);
       log.debug("querySql is %s", querySql);
-      try {
-        return destinationTableCache.get(
-            querySql,
-            new DestinationTableBuilder(bigQueryClient, config, querySql, table.getTableId()));
-      } catch (ExecutionException e) {
-        throw new BigQueryConnectorException(
-            BIGQUERY_VIEW_DESTINATION_TABLE_CREATION_FAILED, "Error creating destination table", e);
-      }
+      return bigQueryClient.materializeViewToTable(
+          querySql, table.getTableId(), config.getViewExpirationTimeInHours());
     } else {
       // not regular table or a view
       throw new BigQueryConnectorException(
@@ -151,65 +137,6 @@ public class ReadSessionCreator {
           format(
               "Table type '%s' of table '%s.%s' is not supported",
               tableType, table.getTableId().getDataset(), table.getTableId().getTable()));
-    }
-  }
-
-  static class DestinationTableBuilder implements Callable<TableInfo> {
-    final BigQueryClient bigQueryClient;
-    final ReadSessionCreatorConfig config;
-    final String querySql;
-    final TableId table;
-
-    DestinationTableBuilder(
-        BigQueryClient bigQueryClient,
-        ReadSessionCreatorConfig config,
-        String querySql,
-        TableId table) {
-      this.bigQueryClient = bigQueryClient;
-      this.config = config;
-      this.querySql = querySql;
-      this.table = table;
-    }
-
-    @Override
-    public TableInfo call() {
-      return createTableFromQuery();
-    }
-
-    TableInfo createTableFromQuery() {
-      TableId destinationTable = bigQueryClient.createDestinationTable(table);
-      log.debug("destinationTable is %s", destinationTable);
-      JobInfo jobInfo =
-          JobInfo.of(
-              QueryJobConfiguration.newBuilder(querySql)
-                  .setDestinationTable(destinationTable)
-                  .build());
-      log.debug("running query %s", jobInfo);
-      Job job = waitForJob(bigQueryClient.create(jobInfo));
-      log.debug("job has finished. %s", job);
-      if (job.getStatus().getError() != null) {
-        throw convertToBigQueryException(job.getStatus().getError());
-      }
-      // add expiration time to the table
-      TableInfo createdTable = bigQueryClient.getTable(destinationTable);
-      long expirationTime =
-          createdTable.getCreationTime()
-              + TimeUnit.HOURS.toMillis(config.viewExpirationTimeInHours);
-      Table updatedTable =
-          bigQueryClient.update(createdTable.toBuilder().setExpirationTime(expirationTime).build());
-      return updatedTable;
-    }
-
-    Job waitForJob(Job job) {
-      try {
-        return job.waitFor();
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new BigQueryException(
-            BaseServiceException.UNKNOWN_CODE,
-            format("Job %s has been interrupted", job.getJobId()),
-            e);
-      }
     }
   }
 }

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/DataSourceVersion.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/DataSourceVersion.java
@@ -1,0 +1,24 @@
+package com.google.cloud.spark.bigquery;
+
+import java.util.Map;
+
+/**
+ * A single place to put data source implementations customizations, in order to avoid a general
+ * `if(dataSource==v1) {...} else {...}` throughout the code.
+ */
+public enum DataSourceVersion {
+  V1,
+  V2;
+
+  public void updateOptionsMap(Map<String, String> optionsMap) {
+    // these updates are v2 only
+    if (this == V2) {
+      // no need for the spark-avro module, we have an internal copy of avro
+      optionsMap.put(SparkBigQueryConfig.VALIDATE_SPARK_AVRO_PARAM.toLowerCase(), "false");
+      // DataSource V2 implementation uses Java only
+      optionsMap.put(
+          SparkBigQueryConfig.INTERMEDIATE_FORMAT_OPTION.toLowerCase(),
+          SparkBigQueryConfig.IntermediateFormat.AVRO.toString());
+    }
+  }
+}

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -81,7 +81,7 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
   private static final int DEFAULT_BIGQUERY_CLIENT_CONNECT_TIMEOUT = 60 * 1000;
   private static final int DEFAULT_BIGQUERY_CLIENT_READ_TIMEOUT = 60 * 1000;
   TableId tableId;
-  com.google.common.base.Optional<String> query;
+  com.google.common.base.Optional<String> query = empty();
   String parentProjectId;
   com.google.common.base.Optional<String> credentialsKey;
   com.google.common.base.Optional<String> credentialsFile;
@@ -360,6 +360,7 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
   public Optional<String> getQuery() {
     return query.toJavaUtil();
   }
+
   @Override
   public String getParentProjectId() {
     return parentProjectId;

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryDataSourceReaderModule.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryDataSourceReaderModule.java
@@ -23,9 +23,6 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
-import org.apache.spark.sql.types.StructType;
-
-import java.util.Optional;
 
 public class BigQueryDataSourceReaderModule implements Module {
   @Override
@@ -39,9 +36,7 @@ public class BigQueryDataSourceReaderModule implements Module {
       BigQueryClient bigQueryClient,
       BigQueryReadClientFactory bigQueryReadClientFactory,
       SparkBigQueryConfig config) {
-    TableInfo tableInfo =
-        bigQueryClient.getSupportedTable(
-            config.getTableId(), config.isViewsEnabled(), SparkBigQueryConfig.VIEWS_ENABLED_OPTION);
+    TableInfo tableInfo = bigQueryClient.getReadTable(config.toReadTableOptions());
     return new BigQueryDataSourceReader(
         tableInfo,
         bigQueryClient,

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryDataSourceV2.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryDataSourceV2.java
@@ -20,6 +20,7 @@ import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.connector.common.BigQueryClient;
 import com.google.cloud.bigquery.connector.common.BigQueryClientModule;
 import com.google.cloud.bigquery.connector.common.BigQueryUtil;
+import com.google.cloud.spark.bigquery.DataSourceVersion;
 import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -53,7 +54,8 @@ public class BigQueryDataSourceV2 implements DataSourceV2, ReadSupport, WriteSup
     SparkSession spark = getDefaultSparkSessionOrCreate();
     return Guice.createInjector(
         new BigQueryClientModule(),
-        new SparkBigQueryConnectorModule(spark, options, Optional.ofNullable(schema)),
+        new SparkBigQueryConnectorModule(
+            spark, options, Optional.ofNullable(schema), DataSourceVersion.V2),
         module);
   }
 

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
@@ -17,13 +17,13 @@ package com.google.cloud.spark.bigquery
 
 import java.util.Optional
 
+import com.google.cloud.bigquery.TableDefinition
 import com.google.cloud.bigquery.TableDefinition.Type.{MATERIALIZED_VIEW, TABLE, VIEW}
 import com.google.cloud.bigquery.connector.common.{BigQueryClient, BigQueryClientModule, BigQueryUtil}
-import com.google.cloud.bigquery.{BigQuery, TableDefinition}
 import com.google.cloud.spark.bigquery.direct.DirectBigQueryRelation
 import com.google.cloud.spark.bigquery.v2.SparkBigQueryConnectorModule
 import com.google.common.collect.ImmutableMap
-import com.google.inject.Guice
+import com.google.inject.{Guice, Injector}
 import org.apache.spark.sql.execution.streaming.Sink
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.sources.v2.DataSourceOptions
@@ -34,8 +34,8 @@ import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
 import scala.collection.JavaConverters._
 
 class BigQueryRelationProvider(
-    getBigQuery: () => Option[BigQuery])
-    extends RelationProvider
+                                getGuiceInjectorCreator: () => GuiceInjectorCreator)
+  extends RelationProvider
     with CreatableRelationProvider
     with SchemaRelationProvider
     with DataSourceRegister
@@ -48,7 +48,7 @@ class BigQueryRelationProvider(
     createRelationInternal(sqlContext, parameters)
   }
 
-  def this() = this(() => None)
+  def this() = this(() => new GuiceInjectorCreator {})
 
   override def createRelation(sqlContext: SQLContext,
                               parameters: Map[String, String],
@@ -62,26 +62,23 @@ class BigQueryRelationProvider(
                            parameters: Map[String, String],
                            partitionColumns: Seq[String],
                            outputMode: OutputMode): Sink = {
-    val opts = createSparkBigQueryConfig(sqlContext, parameters, None)
-    val bigquery: BigQuery = getOrCreateBigQuery(opts)
-    BigQueryStreamingSink(sqlContext, parameters, partitionColumns, outputMode, opts, bigquery)
+    val injector = getGuiceInjectorCreator().createGuiceInjector(sqlContext, parameters)
+    val opts = injector.getInstance(classOf[SparkBigQueryConfig])
+    val bigQueryClient = injector.getInstance(classOf[BigQueryClient])
+    BigQueryStreamingSink(
+      sqlContext, parameters, partitionColumns, outputMode, opts, bigQueryClient)
   }
 
   protected def createRelationInternal(
                                         sqlContext: SQLContext,
                                         parameters: Map[String, String],
                                         schema: Option[StructType] = None): BigQueryRelation = {
-    val dataSourceOptions = new DataSourceOptions(parameters.asJava)
-    val spark = sqlContext.sparkSession
-    val injector = Guice.createInjector(
-      new BigQueryClientModule,
-      new SparkBigQueryConnectorModule(
-        spark, dataSourceOptions, Optional.ofNullable(schema.orNull)))
+    val injector = getGuiceInjectorCreator().createGuiceInjector(sqlContext, parameters, schema)
     val opts = injector.getInstance(classOf[SparkBigQueryConfig])
     val bigQueryClient = injector.getInstance(classOf[BigQueryClient])
-    val tableId = opts.getTableId(bigQueryClient)
-    val tableName = BigQueryUtil.friendlyTableName(tableId)
-    val table = Option(bigQueryClient.getTable(tableId))
+    val tableInfo = bigQueryClient.getReadTable(opts.toReadTableOptions)
+    val tableName = BigQueryUtil.friendlyTableName(opts.getTableId)
+    val table = Option(tableInfo)
       .getOrElse(sys.error(s"Table $tableName not found"))
     table.getDefinition[TableDefinition].getType match {
       case TABLE => new DirectBigQueryRelation(opts, table)(sqlContext)
@@ -105,16 +102,12 @@ class BigQueryRelationProvider(
                                mode: SaveMode,
                                parameters: Map[String, String],
                                data: DataFrame): BaseRelation = {
-    val dataSourceOptions = new DataSourceOptions(parameters.asJava)
-    val spark = sqlContext.sparkSession
-    val injector = Guice.createInjector(
-      new BigQueryClientModule,
-      new SparkBigQueryConnectorModule(
-        spark, dataSourceOptions, Optional.ofNullable(schema.orNull)))
+    val injector = getGuiceInjectorCreator().createGuiceInjector(
+      sqlContext, parameters, Some(data.schema))
     val options = injector.getInstance(classOf[SparkBigQueryConfig])
     val bigQueryClient = injector.getInstance(classOf[BigQueryClient])
-    val tableId = opts.getTableId(bigQueryClient)
-    val relation = BigQueryInsertableRelation(bigQuery, sqlContext, options)
+    val tableId = options.getTableId
+    val relation = BigQueryInsertableRelation(bigQueryClient, sqlContext, options)
 
     mode match {
       case SaveMode.Append => relation.insert(data, overwrite = false)
@@ -140,12 +133,9 @@ class BigQueryRelationProvider(
     relation
   }
 
-  private def getOrCreateBigQuery(options: SparkBigQueryConfig) =
-    getBigQuery().getOrElse(BigQueryUtilScala.createBigQuery(options))
-
   def createSparkBigQueryConfig(sqlContext: SQLContext,
-                                 parameters: Map[String, String],
-                                 schema: Option[StructType] = None): SparkBigQueryConfig = {
+                                parameters: Map[String, String],
+                                schema: Option[StructType] = None): SparkBigQueryConfig = {
     SparkBigQueryConfig.from(parameters.asJava,
       ImmutableMap.copyOf(sqlContext.getAllConfs.asJava),
       sqlContext.sparkContext.hadoopConfiguration,
@@ -156,6 +146,21 @@ class BigQueryRelationProvider(
   }
 
   override def shortName: String = "bigquery"
+}
+
+// externalized to be used by tests
+trait GuiceInjectorCreator {
+  def createGuiceInjector(sqlContext: SQLContext,
+                          parameters: Map[String, String],
+                          schema: Option[StructType] = None): Injector = {
+    val dataSourceOptions = new DataSourceOptions(parameters.asJava)
+    val spark = sqlContext.sparkSession
+    val injector = Guice.createInjector(
+      new BigQueryClientModule,
+      new SparkBigQueryConnectorModule(
+        spark, dataSourceOptions, Optional.ofNullable(schema.orNull), DataSourceVersion.V1))
+    injector
+  }
 }
 
 // DefaultSource is required for spark.read.format("com.google.cloud.spark.bigquery")

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryStreamingSink.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryStreamingSink.scala
@@ -18,7 +18,7 @@ package com.google.cloud.spark.bigquery
 
 import java.io.IOException
 
-import com.google.cloud.bigquery.BigQuery
+import com.google.cloud.bigquery.connector.common.BigQueryClient
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.execution.streaming.Sink
 import org.apache.spark.sql.streaming.OutputMode
@@ -38,7 +38,7 @@ case class BigQueryStreamingSink(
                          partitionColumns: Seq[String],
                          outputMode: OutputMode,
                          opts: SparkBigQueryConfig,
-                         client: BigQuery
+                         bigQueryClient: BigQueryClient
                        ) extends Sink with Logging {
 
   @volatile private var latestBatchId: Long = -1L
@@ -49,7 +49,7 @@ case class BigQueryStreamingSink(
       logWarning("Skipping as already committed batch " + batchId)
     } else {
       logDebug(s"addBatch($batchId)")
-      BigQueryStreamWriter.writeBatch(data, sqlContext, outputMode, opts, client)
+      BigQueryStreamWriter.writeBatch(data, sqlContext, outputMode, opts, bigQueryClient)
     }
     latestBatchId = batchId
   }

--- a/connector/src/test/scala/com/google/cloud/spark/bigquery/it/SparkBigQueryEndToEndReadFromQueryITSuite.scala
+++ b/connector/src/test/scala/com/google/cloud/spark/bigquery/it/SparkBigQueryEndToEndReadFromQueryITSuite.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.it
+
+import com.google.cloud.bigquery._
+import com.google.cloud.spark.bigquery.TestUtils
+import org.apache.spark.sql.SparkSession
+import org.scalatest.concurrent.TimeLimits
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FunSuite, Matchers}
+
+
+class SparkBigQueryEndToEndReadFromQueryITSuite extends FunSuite
+  with BeforeAndAfter
+  with BeforeAndAfterAll
+  with Matchers
+  with TimeLimits
+  with TableDrivenPropertyChecks {
+
+  val bq = BigQueryOptions.getDefaultInstance.getService
+  private val ALL_TYPES_TABLE_NAME = "all_types"
+  private var spark: SparkSession = _
+  private var testDataset: String = _
+
+  before {
+    // have a fresh table for each test
+    testTable = s"test_${System.nanoTime()}"
+  }
+
+  private var testTable: String = _
+
+  override def beforeAll: Unit = {
+    spark = TestUtils.getOrCreateSparkSession(getClass.getSimpleName)
+    testDataset = s"spark_bigquery_${getClass.getSimpleName}_${System.currentTimeMillis()}"
+    IntegrationTestUtils.createDataset(testDataset)
+  }
+
+  def testReadFromQuery(format: String) {
+    // the query suffix is to make sure that each format will have
+    // a different table createddue to the destination table cache
+    val sql = "SELECT corpus, corpus_date FROM `bigquery-public-data.samples.shakespeare` " +
+      s"WHERE word='spark' AND '$format'='$format'";
+    val df = spark.read.format(format)
+      .option("viewsEnabled", true)
+      .option("materializationDataset", testDataset)
+      .load(sql)
+
+    val totalRows = df.count
+    totalRows should equal(9)
+
+    val corpuses = df.select("corpus").collect().map(row => row(0).toString).sorted
+    val expectedCorpuses = Array("2kinghenryvi", "3kinghenryvi", "allswellthatendswell", "hamlet",
+      "juliuscaesar", "kinghenryv", "kinglear", "periclesprinceoftyre", "troilusandcressida")
+    corpuses should equal(expectedCorpuses)
+  }
+
+  test("test read from query - v1") {
+    testReadFromQuery("bigquery")
+  }
+
+  test("test read from query - v2") {
+    testReadFromQuery("com.google.cloud.spark.bigquery.v2.BigQueryDataSourceV2")
+  }
+
+
+  override def afterAll: Unit = {
+    IntegrationTestUtils.deleteDatasetAndTables(testDataset)
+  }
+
+}
+


### PR DESCRIPTION
Adding the option to run an ad-hoc query on BigQuery and then read the result directly into a dataframe. The syntax is in the following manner:
```
df = df = spark.read.format("bigquery")
      .option("viewsEnabled", true)
      .option("materializationDataset", <dataset>)
      .load("SELECT ...")
```
or
```
df = df = spark.read.format("bigquery")
      .option("viewsEnabled", true)
      .option("materializationDataset", <dataset>)
      .option("query", "SELECT ...")
      .load()
```
The queries are materialized to a temporary table and are re-used if the same query is used. For example
`df.select("col1").where("condition")` should use the temporary table and not re-run the query.

This also gives the option to efficiently run complex queries using joins on BigQuery specific functions from spark.
