### PR TITLE
Solving Scala 2.12 private API dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,6 +75,9 @@ lazy val connector = (project in file("connector"))
       "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
       "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
       "org.apache.spark" %% "spark-mllib" % sparkVersion % "provided",
+      "org.apache.beam" % "beam-sdks-java-io-hadoop-common" % "2.28.0"
+        exclude("org.apache.beam", "beam-sdks-java-core")
+        exclude("org.checkerframework", "checker-qual"),
       "org.slf4j" % "slf4j-api" % "1.7.16" % "provided",
       "aopalliance" % "aopalliance" % "1.0" % "provided",
       "org.codehaus.jackson" % "jackson-core-asl" % "1.9.13" % "provided",

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryIndirectDataSourceWriter.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryIndirectDataSourceWriter.java
@@ -32,6 +32,7 @@ import com.google.cloud.spark.bigquery.AvroSchemaConverter;
 import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
 import com.google.cloud.spark.bigquery.SparkBigQueryUtil;
 import com.google.cloud.spark.bigquery.SupportedCustomDataType;
+import org.apache.beam.sdk.io.hadoop.SerializableConfiguration;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
@@ -41,7 +42,6 @@ import org.apache.spark.sql.sources.v2.writer.DataSourceWriter;
 import org.apache.spark.sql.sources.v2.writer.DataWriterFactory;
 import org.apache.spark.sql.sources.v2.writer.WriterCommitMessage;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.util.SerializableConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryIndirectDataWriterFactory.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryIndirectDataWriterFactory.java
@@ -16,13 +16,13 @@
 package com.google.cloud.spark.bigquery.v2;
 
 import org.apache.avro.Schema;
+import org.apache.beam.sdk.io.hadoop.SerializableConfiguration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.sources.v2.writer.DataWriter;
 import org.apache.spark.sql.sources.v2.writer.DataWriterFactory;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.util.SerializableConfiguration;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -53,7 +53,7 @@ class BigQueryIndirectDataWriterFactory implements DataWriterFactory<InternalRow
       UUID uuid = new UUID(taskId, epochId);
       String uri = String.format("%s/part-%06d-%s.avro", gcsDirPath, partitionId, uuid);
       Path path = new Path(uri);
-      FileSystem fs = path.getFileSystem(conf.value());
+      FileSystem fs = path.getFileSystem(conf.get());
       IntermediateRecordWriter intermediateRecordWriter =
           new AvroIntermediateRecordWriter(avroSchema, fs.create(path));
       return new BigQueryIndirectDataWriter(


### PR DESCRIPTION
Taking `SerializableConfiguration `from Apache-Beam rather than from a spark private API. This had worked with Scala 2.11 but fails with Scala 2.12.