### PR TITLE
Parametrised JavaShakespeare.java example

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,6 +75,9 @@ lazy val connector = (project in file("connector"))
       "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
       "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
       "org.apache.spark" %% "spark-mllib" % sparkVersion % "provided",
+      "org.apache.beam" % "beam-sdks-java-io-hadoop-common" % "2.28.0"
+        exclude("org.apache.beam", "beam-sdks-java-core")
+        exclude("org.checkerframework", "checker-qual"),
       "org.slf4j" % "slf4j-api" % "1.7.16" % "provided",
       "aopalliance" % "aopalliance" % "1.0" % "provided",
       "org.codehaus.jackson" % "jackson-core-asl" % "1.9.13" % "provided",

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/examples/JavaShakespeare.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/examples/JavaShakespeare.java
@@ -60,10 +60,10 @@ public class JavaShakespeare {
             .option("table", inputBigqueryTable)
             .load()
             .cache();
-    wordsDF.createOrReplaceTempView("words");
 
     wordsDF.show();
     wordsDF.printSchema();
+    wordsDF.createOrReplaceTempView("words");
 
     // Perform word count.
     Dataset<Row> wordCountDF =

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/examples/JavaShakespeare.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/examples/JavaShakespeare.java
@@ -40,7 +40,12 @@ public class JavaShakespeare {
 
     // Load data in from BigQuery.
     Dataset<Row> wordsDF =
-        spark.read().format("bigquery").option("table", "bigquery-public-data.samples.shakespeare").load().cache();
+        spark
+            .read()
+            .format("bigquery")
+            .option("table", "bigquery-public-data.samples.shakespeare")
+            .load()
+            .cache();
 
     wordsDF.show();
     wordsDF.printSchema();
@@ -54,7 +59,11 @@ public class JavaShakespeare {
     wordCountDF.printSchema();
 
     // Saving the data to BigQuery
-    wordCountDF.write().format("bigquery").option("table", outputBigqueryTable).save();
+    wordCountDF
+        .write()
+        .format("bigquery")
+        .option("table", outputBigqueryTable)
+        .save();
   }
 
   private static void usage() {

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryDataSourceReader.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryDataSourceReader.java
@@ -45,6 +45,8 @@ import org.apache.spark.sql.sources.v2.reader.SupportsScanColumnarBatch;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import scala.collection.JavaConversions;
 
 import java.util.ArrayList;
@@ -63,6 +65,8 @@ public class BigQueryDataSourceReader
         SupportsPushDownFilters,
         SupportsReportStatistics,
         SupportsScanColumnarBatch {
+
+  private static final Logger logger = LoggerFactory.getLogger(BigQueryDataSourceReader.class);
 
   private static Statistics UNKNOWN_STATISTICS =
       new Statistics() {
@@ -228,6 +232,7 @@ public class BigQueryDataSourceReader
 
   List<InputPartition<InternalRow>> createEmptyProjectionPartitions() {
     long rowCount = bigQueryClient.calculateTableSize(tableId, globalFilter);
+    logger.info("Used optimized BQ count(*) path. Count: " + rowCount);
     int partitionsCount = readSessionCreatorConfig.getDefaultParallelism();
     int partitionSize = (int) (rowCount / partitionsCount);
     InputPartition<InternalRow>[] partitions =

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryIndirectDataSourceWriter.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryIndirectDataSourceWriter.java
@@ -32,6 +32,7 @@ import com.google.cloud.spark.bigquery.AvroSchemaConverter;
 import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
 import com.google.cloud.spark.bigquery.SparkBigQueryUtil;
 import com.google.cloud.spark.bigquery.SupportedCustomDataType;
+import org.apache.beam.sdk.io.hadoop.SerializableConfiguration;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
@@ -41,7 +42,6 @@ import org.apache.spark.sql.sources.v2.writer.DataSourceWriter;
 import org.apache.spark.sql.sources.v2.writer.DataWriterFactory;
 import org.apache.spark.sql.sources.v2.writer.WriterCommitMessage;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.util.SerializableConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryIndirectDataWriterFactory.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryIndirectDataWriterFactory.java
@@ -16,13 +16,13 @@
 package com.google.cloud.spark.bigquery.v2;
 
 import org.apache.avro.Schema;
+import org.apache.beam.sdk.io.hadoop.SerializableConfiguration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.sources.v2.writer.DataWriter;
 import org.apache.spark.sql.sources.v2.writer.DataWriterFactory;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.util.SerializableConfiguration;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -53,7 +53,7 @@ class BigQueryIndirectDataWriterFactory implements DataWriterFactory<InternalRow
       UUID uuid = new UUID(taskId, epochId);
       String uri = String.format("%s/part-%06d-%s.avro", gcsDirPath, partitionId, uuid);
       Path path = new Path(uri);
-      FileSystem fs = path.getFileSystem(conf.value());
+      FileSystem fs = path.getFileSystem(conf.get());
       IntermediateRecordWriter intermediateRecordWriter =
           new AvroIntermediateRecordWriter(avroSchema, fs.create(path));
       return new BigQueryIndirectDataWriter(

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
@@ -189,7 +189,7 @@ private[bigquery] class DirectBigQueryRelation(
       val result = bigQuery.query(QueryJobConfiguration.of(sql))
       result.iterateAll.iterator.next.get(0).getLongValue
     }
-    logDebug(s"Creating a DataFrame of empty rows with size $numberOfRows")
+    logInfo(s"Used optimized BQ count(*) path. Count: $numberOfRows")
     sqlContext.sparkContext.range(0, numberOfRows)
       .map(_ => InternalRow.empty)
       .asInstanceOf[RDD[Row]]


### PR DESCRIPTION
Modified JavaShakespeare.java to incorporate parameters for input/output/temporary GCS buckets