### PR TITLE
Spark 3 compatibility fixes

### DIFF
--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryDataSourceV2.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryDataSourceV2.java
@@ -55,7 +55,7 @@ public class BigQueryDataSourceV2 implements DataSourceV2, ReadSupport, WriteSup
     return Guice.createInjector(
         new BigQueryClientModule(),
         new SparkBigQueryConnectorModule(
-            spark, options, Optional.ofNullable(schema), DataSourceVersion.V2),
+            spark, options.asMap(), Optional.ofNullable(schema), DataSourceVersion.V2),
         module);
   }
 

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/SparkBigQueryConnectorModule.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/SparkBigQueryConnectorModule.java
@@ -26,10 +26,8 @@ import com.google.inject.Module;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.sources.v2.DataSourceOptions;
 import org.apache.spark.sql.types.StructType;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/SparkBigQueryConnectorModule.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/SparkBigQueryConnectorModule.java
@@ -38,13 +38,13 @@ import static scala.collection.JavaConversions.mapAsJavaMap;
 public class SparkBigQueryConnectorModule implements Module {
 
   private final SparkSession spark;
-  private final DataSourceOptions options;
+  private final Map<String, String> options;
   private final Optional<StructType> schema;
   private final DataSourceVersion dataSourceVersion;
 
   public SparkBigQueryConnectorModule(
       SparkSession spark,
-      DataSourceOptions options,
+      Map<String, String> options,
       Optional<StructType> schema,
       DataSourceVersion dataSourceVersion) {
     this.spark = spark;
@@ -67,7 +67,7 @@ public class SparkBigQueryConnectorModule implements Module {
   @Singleton
   @Provides
   public SparkBigQueryConfig provideSparkBigQueryConfig() {
-    Map<String, String> optionsMap = new HashMap<>(options.asMap());
+    Map<String, String> optionsMap = options;
     dataSourceVersion.updateOptionsMap(optionsMap);
     return SparkBigQueryConfig.from(
         ImmutableMap.copyOf(optionsMap),

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableMap
 import com.google.inject.{Guice, Injector}
 import org.apache.spark.sql.execution.streaming.Sink
 import org.apache.spark.sql.sources._
-import org.apache.spark.sql.sources.v2.DataSourceOptions
 import org.apache.spark.sql.streaming.OutputMode
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
@@ -153,12 +152,11 @@ trait GuiceInjectorCreator {
   def createGuiceInjector(sqlContext: SQLContext,
                           parameters: Map[String, String],
                           schema: Option[StructType] = None): Injector = {
-    val dataSourceOptions = new DataSourceOptions(parameters.asJava)
     val spark = sqlContext.sparkSession
     val injector = Guice.createInjector(
       new BigQueryClientModule,
       new SparkBigQueryConnectorModule(
-        spark, dataSourceOptions, Optional.ofNullable(schema.orNull), DataSourceVersion.V1))
+        spark, parameters.asJava, Optional.ofNullable(schema.orNull), DataSourceVersion.V1))
     injector
   }
 }


### PR DESCRIPTION
Following the suggestions from #242 This implementation relies on org.apache.spark.sql.sources.v2.DataSourceOptions which does not exist in Spark 3 due to the massive DataSource API change it had.

This PR addresses that by:

Removing DataSourceOptions from SparkBigQueryConnectorModule.jav and BigQueryRelationProvider.scala