### PR TITLE
Reverting dependency updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,9 +16,9 @@
 lazy val scala211Version = "2.11.12"
 lazy val scala212Version = "2.12.10"
 lazy val sparkVersion = "2.4.0"
-lazy val grpcVersion = "1.35.0"
+lazy val grpcVersion = "1.30.2"
 // should match the dependency from grpc-netty
-lazy val nettyVersion = "4.1.52.Final"
+lazy val nettyVersion = "4.1.51.Final"
 // should match the dependency in grpc-netty
 lazy val nettyTcnativeVersion = "2.0.34.Final"
 
@@ -42,8 +42,8 @@ lazy val root = (project in file("."))
 lazy val commonTestDependencies = Seq(
   "io.grpc" % "grpc-alts" % grpcVersion exclude("io.grpc", "grpc-netty-shaded"),
   "io.grpc" % "grpc-netty" % grpcVersion,
-  "com.google.api" % "gax-grpc" % "1.61.0" exclude("io.grpc", "grpc-netty-shaded"),
-  "com.google.guava" % "guava" % "30.1-jre",
+  "com.google.api" % "gax-grpc" % "1.60.0" exclude("io.grpc", "grpc-netty-shaded"),
+  "com.google.guava" % "guava" % "30.0-jre",
 
   "org.scalatest" %% "scalatest" % "3.1.0" % "test",
   "org.mockito" %% "mockito-scala-scalatest" % "1.10.0" % "test",
@@ -88,13 +88,13 @@ lazy val connector = (project in file("connector"))
         exclude("com.hadoop.gplcompression", "hadoop-lzo"),
 
       // Keep com.google.cloud dependencies in sync
-      "com.google.cloud" % "google-cloud-bigquery" % "1.127.4",
-      "com.google.cloud" % "google-cloud-bigquerystorage" % "1.10.0"
+      "com.google.cloud" % "google-cloud-bigquery" % "1.123.2",
+      "com.google.cloud" % "google-cloud-bigquerystorage" % "1.6.0"
         exclude("io.grpc", "grpc-netty-shaded"),
       // Keep in sync with com.google.cloud
-      "com.fasterxml.jackson.core" % "jackson-databind" % "2.12.1",
-      "com.fasterxml.jackson.module" % "jackson-module-paranamer" % "2.12.1",
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.12.1",
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.11.3",
+      "com.fasterxml.jackson.module" % "jackson-module-paranamer" % "2.11.3",
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.11.3",
 
       // Netty, with a version supporting Java 11
       "io.netty" % "netty-all" % nettyVersion % "provided",

--- a/build.sbt
+++ b/build.sbt
@@ -85,6 +85,7 @@ lazy val connector = (project in file("connector"))
       "com.google.inject" % "guice" % "4.2.3",
       "org.apache.arrow" % "arrow-vector" % "0.16.0" exclude("org.slf4j", "slf4j-api"),
       "org.apache.parquet" % "parquet-protobuf" % "1.10.0"
+        exclude("org.apache.thrift", "libthrift")
         exclude("com.hadoop.gplcompression", "hadoop-lzo"),
 
       // Keep com.google.cloud dependencies in sync


### PR DESCRIPTION
Some of the newer dependencies caused networking issues. The rollback has been tested and shown that it resolves these issues.