### PR TITLE
Issue #326: Fixing netty_tcnative_windows.dll shading

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -134,6 +134,10 @@ lazy val fatJar = project
       case PathList(ps@_*) if ps.last.endsWith(".proto") => MergeStrategy.discard
       // Relocate netty-tcnative.so. This is necessary even though gRPC shades it, because we shade
       // gRPC.
+      case PathList("META-INF", "native", f) if f.contains("netty_tcnative_windows") =>
+        RelocationMergeStrategy(path =>
+          path.replace("netty_tcnative_windows",
+            s"${relocationPrefix.replace('.', '_')}_netty_tcnative_windows"))
       case PathList("META-INF", "native", f) if f.contains("netty_tcnative") =>
         RelocationMergeStrategy(path =>
           path.replace("native/lib", s"native/lib${relocationPrefix.replace('.', '_')}_"))


### PR DESCRIPTION
Tested:
```
$ unzip -l ~/.m2/repository/com/google/cloud/spark/spark-bigquery-with-dependencies_2.11/0.19.2-SNAPSHOT/spark-bigquery-with-dependencies_2.11-0.19.2-SNAPSHOT.jar | grep netty_tcnative
  1933284  02-24-2021 15:34   META-INF/native/libcom_google_cloud_spark_bigquery_repackaged_netty_tcnative_linux_aarch64.so
  2628280  02-24-2021 15:34   META-INF/native/libcom_google_cloud_spark_bigquery_repackaged_netty_tcnative_linux_x86_64.so
  2714596  02-24-2021 15:34   META-INF/native/libcom_google_cloud_spark_bigquery_repackaged_netty_tcnative_osx_x86_64.jnilib
  2425856  02-24-2021 15:34   META-INF/native/com_google_cloud_spark_bigquery_repackaged_netty_tcnative_windows_x86_64.dll
```