### PR TITLE
Add runtime flag to allow usage of unsafe API in compile/tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,6 @@ lazy val commonTestDependencies = Seq(
   "io.grpc" % "grpc-netty" % grpcVersion,
   "com.google.api" % "gax-grpc" % "1.60.0" exclude("io.grpc", "grpc-netty-shaded"),
   "com.google.guava" % "guava" % "30.0-jre",
-
   "org.scalatest" %% "scalatest" % "3.1.0" % "test",
   "org.mockito" %% "mockito-scala-scalatest" % "1.10.0" % "test",
   "junit" % "junit" % "4.13" % "test",
@@ -66,6 +65,8 @@ lazy val connector = (project in file("connector"))
     testOptions in ITest := Seq(Tests.Filter(itFilter)),
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
     buildInfoPackage := "com.google.cloud.spark.bigquery",
+    fork := true,
+    javaOptions ++= Seq("-Dio.netty.tryReflectionSetAccessible=true"),
     resourceGenerators in Compile += Def.task {
       val file = (resourceManaged in Compile).value / "spark-bigquery-connector.properties"
       IO.write(file, s"scala.version=${scalaVersion.value}\n")

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowInputPartition.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowInputPartition.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.spark.bigquery.v2;
 
-
 import com.google.cloud.bigquery.connector.common.BigQueryReadClientFactory;
 import com.google.cloud.bigquery.connector.common.BigQueryStorageReadRowsTracer;
 import com.google.cloud.bigquery.connector.common.BigQueryTracerFactory;

--- a/connector/src/test/scala/com/google/cloud/spark/bigquery/BigQueryUtilsSuite.scala
+++ b/connector/src/test/scala/com/google/cloud/spark/bigquery/BigQueryUtilsSuite.scala
@@ -16,7 +16,7 @@
 package com.google.cloud.spark.bigquery
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{LocatedFileStatus, Path}
+import org.apache.hadoop.fs.Path
 import org.scalatest.OptionValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.funsuite.AnyFunSuite


### PR DESCRIPTION
This PR addresses the compilation issue related to netty/arrow as documented in #290 

> For Java 11, -Dio.netty.tryReflectionSetAccessible=true is required additionally for Apache Arrow library. This prevents java.lang.UnsupportedOperationException: sun.misc.Unsafe or java.nio.DirectByteBuffer.(long, int) not available when Apache Arrow uses Netty internally.

Adding the compiler flag and `fork`-ing the jvm for testing solves the problem.

That process broke the `BigQueryUtilsSuite.scala` which is made more robust in this PR.