### PR TITLE
Add configuration options.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,6 @@ lazy val commonTestDependencies = Seq(
   "io.grpc" % "grpc-alts" % grpcVersion exclude("io.grpc", "grpc-netty-shaded"),
   "io.grpc" % "grpc-netty" % grpcVersion,
   "com.google.api" % "gax-grpc" % "1.60.0" exclude("io.grpc", "grpc-netty-shaded"),
-  "com.google.guava" % "guava" % "30.0-jre",
 
   "org.scalatest" %% "scalatest" % "3.1.0" % "test",
   "org.mockito" %% "mockito-scala-scalatest" % "1.10.0" % "test",
@@ -91,6 +90,7 @@ lazy val connector = (project in file("connector"))
       "aopalliance" % "aopalliance" % "1.0" % "provided",
       "org.codehaus.jackson" % "jackson-core-asl" % "1.9.13" % "provided",
       "org.codehaus.jackson" % "jackson-mapper-asl" % "1.9.13" % "provided",
+      "com.google.guava" % "guava" % "30.1.1-jre",
       "com.google.inject" % "guice" % "4.2.3",
       "org.apache.arrow" % "arrow-vector" % "4.0.0"
 			  excludeAll(ExclusionRule(organization="org.slf4j"),
@@ -129,11 +129,11 @@ lazy val connector = (project in file("connector"))
         exclude("com.google.cloud.bigdataoss", "util-hadoop"),
       // scalastyle:on
       // test
-
       "org.apache.spark" %% "spark-avro" % sparkVersion % "test"
       ))
       .map(_.excludeAll(excludedOrgs.map(ExclusionRule(_)): _*)),
-    dependencyOverrides += "org.slf4j" % "slf4j-api" % "1.7.16" % "provided"
+    dependencyOverrides ++= Set("org.slf4j" % "slf4j-api" % "1.7.16" % "provided",
+                                "com.google.guava" % "guava" % "30.1.1-jre")
   )
 
 lazy val fatJar = project

--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,7 @@ lazy val root = (project in file("."))
 lazy val commonTestDependencies = Seq(
   "io.grpc" % "grpc-alts" % grpcVersion exclude("io.grpc", "grpc-netty-shaded"),
   "io.grpc" % "grpc-netty" % grpcVersion,
-  "com.google.api" % "gax-grpc" % "1.60.0" exclude("io.grpc", "grpc-netty-shaded"),
+  "com.google.api" % "gax-grpc" % "1.61.0" exclude("io.grpc", "grpc-netty-shaded"),
 
   "org.scalatest" %% "scalatest" % "3.1.0" % "test",
   "org.mockito" %% "mockito-scala-scalatest" % "1.10.0" % "test",

--- a/build.sbt
+++ b/build.sbt
@@ -105,10 +105,9 @@ lazy val connector = (project in file("connector"))
 			     ExclusionRule(organization="io.netty"),
 		       ExclusionRule(organization ="com.fasterxml.jackson.core")),
 
-
       // Keep com.google.cloud dependencies in sync
       "com.google.cloud" % "google-cloud-bigquery" % "1.123.2",
-      "com.google.cloud" % "google-cloud-bigquerystorage" % "1.6.0"
+      "com.google.cloud" % "google-cloud-bigquerystorage" % "1.17.0"
         exclude("io.grpc", "grpc-netty-shaded"),
       // Keep in sync with com.google.cloud
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.11.3",

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@
 lazy val scala211Version = "2.11.12"
 lazy val scala212Version = "2.12.10"
 lazy val sparkVersion = "2.4.0"
-lazy val grpcVersion = "1.35.0"
+lazy val grpcVersion = "1.30.2"
 // should match the dependency from grpc-netty
 lazy val nettyVersion = "4.1.51.Final"
 // should match the dependency in grpc-netty
@@ -51,7 +51,7 @@ lazy val root = (project in file("."))
 lazy val commonTestDependencies = Seq(
   "io.grpc" % "grpc-alts" % grpcVersion exclude("io.grpc", "grpc-netty-shaded"),
   "io.grpc" % "grpc-netty" % grpcVersion,
-  "com.google.api" % "gax-grpc" % "1.61.0" exclude("io.grpc", "grpc-netty-shaded"),
+  "com.google.api" % "gax-grpc" % "1.60.0" exclude("io.grpc", "grpc-netty-shaded"),
 
   "org.scalatest" %% "scalatest" % "3.1.0" % "test",
   "org.mockito" %% "mockito-scala-scalatest" % "1.10.6" % "test",
@@ -107,7 +107,7 @@ lazy val connector = (project in file("connector"))
 
       // Keep com.google.cloud dependencies in sync
       "com.google.cloud" % "google-cloud-bigquery" % "1.123.2",
-      "com.google.cloud" % "google-cloud-bigquerystorage" % "1.17.0"
+      "com.google.cloud" % "google-cloud-bigquerystorage" % "1.6.0"
         exclude("io.grpc", "grpc-netty-shaded"),
       // Keep in sync with com.google.cloud
       "com.fasterxml.jackson.core" % "jackson-databind" % "2.11.3",

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@
 lazy val scala211Version = "2.11.12"
 lazy val scala212Version = "2.12.10"
 lazy val sparkVersion = "2.4.0"
-lazy val grpcVersion = "1.30.2"
+lazy val grpcVersion = "1.35.0"
 // should match the dependency from grpc-netty
 lazy val nettyVersion = "4.1.51.Final"
 // should match the dependency in grpc-netty
@@ -54,7 +54,7 @@ lazy val commonTestDependencies = Seq(
   "com.google.api" % "gax-grpc" % "1.61.0" exclude("io.grpc", "grpc-netty-shaded"),
 
   "org.scalatest" %% "scalatest" % "3.1.0" % "test",
-  "org.mockito" %% "mockito-scala-scalatest" % "1.10.0" % "test",
+  "org.mockito" %% "mockito-scala-scalatest" % "1.10.6" % "test",
   "junit" % "junit" % "4.13" % "test",
   "com.novocode" % "junit-interface" % "0.11" % "test",
   "com.google.truth" % "truth" % "1.0.1" % "test"

--- a/build.sbt
+++ b/build.sbt
@@ -52,9 +52,11 @@ lazy val commonTestDependencies = Seq(
   "io.grpc" % "grpc-alts" % grpcVersion exclude("io.grpc", "grpc-netty-shaded"),
   "io.grpc" % "grpc-netty" % grpcVersion,
   "com.google.api" % "gax-grpc" % "1.60.0" exclude("io.grpc", "grpc-netty-shaded"),
+  "com.google.guava" % "guava" % "30.1.1-jre",
 
   "org.scalatest" %% "scalatest" % "3.1.0" % "test",
   "org.mockito" %% "mockito-scala-scalatest" % "1.10.6" % "test",
+
   "junit" % "junit" % "4.13" % "test",
   "com.novocode" % "junit-interface" % "0.11" % "test",
   "com.google.truth" % "truth" % "1.0.1" % "test"
@@ -90,7 +92,6 @@ lazy val connector = (project in file("connector"))
       "aopalliance" % "aopalliance" % "1.0" % "provided",
       "org.codehaus.jackson" % "jackson-core-asl" % "1.9.13" % "provided",
       "org.codehaus.jackson" % "jackson-mapper-asl" % "1.9.13" % "provided",
-      "com.google.guava" % "guava" % "30.1.1-jre",
       "com.google.inject" % "guice" % "4.2.3",
       "org.apache.arrow" % "arrow-vector" % "4.0.0"
 			  excludeAll(ExclusionRule(organization="org.slf4j"),

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
@@ -148,8 +148,8 @@ public class BigQueryClient {
     Set<TableDefinition.Type> allowedTypes = ImmutableSet.copyOf(types);
     Iterable<Table> allTables = bigQuery.listTables(datasetId).iterateAll();
     return StreamSupport.stream(allTables.spliterator(), false)
-            .filter(table -> allowedTypes.contains(table.getDefinition().getType()))
-            .collect(toImmutableList());
+        .filter(table -> allowedTypes.contains(table.getDefinition().getType()))
+        .collect(toImmutableList());
   }
 
   TableId createDestinationTable(

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
@@ -48,6 +48,7 @@ import java.util.stream.StreamSupport;
 import static com.google.cloud.bigquery.connector.common.BigQueryErrorCode.BIGQUERY_VIEW_DESTINATION_TABLE_CREATION_FAILED;
 import static com.google.cloud.bigquery.connector.common.BigQueryErrorCode.UNSUPPORTED;
 import static com.google.cloud.bigquery.connector.common.BigQueryUtil.convertToBigQueryException;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.UUID.randomUUID;
@@ -146,10 +147,9 @@ public class BigQueryClient {
   Iterable<Table> listTables(DatasetId datasetId, TableDefinition.Type... types) {
     Set<TableDefinition.Type> allowedTypes = ImmutableSet.copyOf(types);
     Iterable<Table> allTables = bigQuery.listTables(datasetId).iterateAll();
-    return ImmutableList.copyOf(
-        StreamSupport.stream(allTables.spliterator(), false)
+    return StreamSupport.stream(allTables.spliterator(), false)
             .filter(table -> allowedTypes.contains(table.getDefinition().getType()))
-            .collect(Collectors.toList()));
+            .collect(toImmutableList());
   }
 
   TableId createDestinationTable(

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
@@ -136,7 +136,7 @@ public class BigQueryClient {
     return DatasetId.of(tableId.getProject(), tableId.getDataset());
   }
 
-  String getProjectId() {
+  public String getProjectId() {
     return bigQuery.getOptions().getProjectId();
   }
 

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryReadClientFactory.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryReadClientFactory.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.bigquery.connector.common;
 
-import com.esotericsoftware.minlog.Log;
 import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.auth.Credentials;

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryReadClientFactory.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryReadClientFactory.java
@@ -51,7 +51,7 @@ public class BigQueryReadClientFactory implements Serializable {
     this.userAgentHeaderProvider = userAgentHeaderProvider;
   }
 
-  BigQueryReadClient createBigQueryReadClient(Optional<String> endpoint) {
+  public BigQueryReadClient createBigQueryReadClient(Optional<String> endpoint) {
     try {
       InstantiatingGrpcChannelProvider.Builder transportBuilder =
           BigQueryReadSettings.defaultGrpcTransportProviderBuilder()

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadRowsHelper.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadRowsHelper.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigquery.connector.common;
 
 import java.io.Serializable;
 import java.util.Optional;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,11 +37,12 @@ public class ReadRowsHelper {
 
   public static final class Options implements Serializable {
     private final int maxReadRowsRetries;
-    private final Optional<String> endpoint;
+    @Nullable
+    private final String endpoint;
 
-    Options(int maxReadRowsRetries, Optional<String> endpoint) {
+    public Options(int maxReadRowsRetries, Optional<String> endpoint) {
       this.maxReadRowsRetries = maxReadRowsRetries;
-      this.endpoint = endpoint;
+      this.endpoint = endpoint.orElse(null);
     }
 
     public int getMaxReadRowsRetries() {
@@ -48,7 +50,7 @@ public class ReadRowsHelper {
     }
 
     public Optional<String> getEndpoint() {
-      return endpoint;
+      return Optional.ofNullable(endpoint);
     }
   }
 
@@ -71,7 +73,7 @@ public class ReadRowsHelper {
     if (client != null) {
       client.close();
     }
-    client = bigQueryReadClientFactory.createBigQueryReadClient(options.endpoint);
+    client = bigQueryReadClientFactory.createBigQueryReadClient(options.getEndpoint());
     Iterator<ReadRowsResponse> serverResponses = fetchResponses(request);
     return new ReadRowsIterator(this, serverResponses);
   }

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadRowsHelper.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadRowsHelper.java
@@ -17,7 +17,6 @@ package com.google.cloud.bigquery.connector.common;
 
 import java.io.Serializable;
 import java.util.Optional;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,12 +36,11 @@ public class ReadRowsHelper {
 
   public static final class Options implements Serializable {
     private final int maxReadRowsRetries;
-    @Nullable
-    private final String endpoint;
+    private final String nullableEndpoint;
 
     public Options(int maxReadRowsRetries, Optional<String> endpoint) {
       this.maxReadRowsRetries = maxReadRowsRetries;
-      this.endpoint = endpoint.orElse(null);
+      this.nullableEndpoint = endpoint.orElse(null);
     }
 
     public int getMaxReadRowsRetries() {
@@ -50,7 +48,7 @@ public class ReadRowsHelper {
     }
 
     public Optional<String> getEndpoint() {
-      return Optional.ofNullable(endpoint);
+      return Optional.ofNullable(nullableEndpoint);
     }
   }
 

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreator.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreator.java
@@ -19,8 +19,6 @@ import com.google.cloud.bigquery.StandardTableDefinition;
 import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
-import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions;
-import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions.CompressionCodec;
 import com.google.cloud.bigquery.storage.v1.BigQueryReadClient;
 import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
 import com.google.cloud.bigquery.storage.v1.ReadSession;
@@ -112,11 +110,6 @@ public class ReadSessionCreator {
 
       ReadSession.Builder requestedSession = request.getReadSession().toBuilder();
       TableReadOptions.Builder readOptions = requestedSession.getReadOptionsBuilder();
-      if (config.getCompression() != CompressionCodec.COMPRESSION_UNSPECIFIED) {
-        ArrowSerializationOptions.Builder arrowOptions =
-            readOptions.getArrowSerializationOptionsBuilder();
-        arrowOptions.setBufferCompression(config.getCompression()).build();
-      }
       filter.ifPresent(readOptions::setRowRestriction);
       ReadSession readSession =
           bigQueryReadClient.createReadSession(

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfig.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfig.java
@@ -16,12 +16,10 @@
 package com.google.cloud.bigquery.connector.common;
 
 import com.google.cloud.bigquery.connector.common.ReadRowsHelper.Options;
-import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions.CompressionCodec;
 import com.google.cloud.bigquery.storage.v1.DataFormat;
 
 import java.util.Optional;
 import java.util.OptionalInt;
-import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions;
 
 public class ReadSessionCreatorConfig {
   private final boolean viewsEnabled;
@@ -34,7 +32,6 @@ public class ReadSessionCreatorConfig {
   private final OptionalInt maxParallelism;
   private final int defaultParallelism;
   private final Optional<String> requestEncodedBase;
-  private final ArrowSerializationOptions.CompressionCodec compression;
   private final Optional<String> endpoint;
 
   ReadSessionCreatorConfig(
@@ -48,7 +45,6 @@ public class ReadSessionCreatorConfig {
       OptionalInt maxParallelism,
       int defaultParallelism,
       Optional<String> requestEncodedBase,
-      CompressionCodec compression,
       Optional<String> endpoint) {
     this.viewsEnabled = viewsEnabled;
     this.materializationProject = materializationProject;
@@ -60,7 +56,6 @@ public class ReadSessionCreatorConfig {
     this.maxParallelism = maxParallelism;
     this.defaultParallelism = defaultParallelism;
     this.requestEncodedBase = requestEncodedBase;
-    this.compression = compression;
     this.endpoint = endpoint;
   }
 
@@ -102,10 +97,6 @@ public class ReadSessionCreatorConfig {
 
   public Optional<String> getRequestEncodedBase() {
     return this.requestEncodedBase;
-  }
-
-  public ArrowSerializationOptions.CompressionCodec getCompression() {
-    return this.compression;
   }
 
   public Optional<String> endpoint() {

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfig.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfig.java
@@ -15,23 +15,29 @@
  */
 package com.google.cloud.bigquery.connector.common;
 
+import com.google.cloud.bigquery.connector.common.ReadRowsHelper.Options;
+import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions.CompressionCodec;
 import com.google.cloud.bigquery.storage.v1.DataFormat;
 
 import java.util.Optional;
 import java.util.OptionalInt;
+import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions;
 
 public class ReadSessionCreatorConfig {
-  final boolean viewsEnabled;
-  final Optional<String> materializationProject;
-  final Optional<String> materializationDataset;
-  final String viewEnabledParamName;
-  final int materializationExpirationTimeInMinutes;
-  final DataFormat readDataFormat;
-  final int maxReadRowsRetries;
-  final OptionalInt maxParallelism;
-  final int defaultParallelism;
+  private final boolean viewsEnabled;
+  private final Optional<String> materializationProject;
+  private final Optional<String> materializationDataset;
+  private final String viewEnabledParamName;
+  private final int materializationExpirationTimeInMinutes;
+  private final DataFormat readDataFormat;
+  private final int maxReadRowsRetries;
+  private final OptionalInt maxParallelism;
+  private final int defaultParallelism;
+  private final Optional<String> requestEncodedBase;
+  private final ArrowSerializationOptions.CompressionCodec compression;
+  private final Optional<String> endpoint;
 
-  public ReadSessionCreatorConfig(
+  ReadSessionCreatorConfig(
       boolean viewsEnabled,
       Optional<String> materializationProject,
       Optional<String> materializationDataset,
@@ -40,7 +46,10 @@ public class ReadSessionCreatorConfig {
       int maxReadRowsRetries,
       String viewEnabledParamName,
       OptionalInt maxParallelism,
-      int defaultParallelism) {
+      int defaultParallelism,
+      Optional<String> requestEncodedBase,
+      CompressionCodec compression,
+      Optional<String> endpoint) {
     this.viewsEnabled = viewsEnabled;
     this.materializationProject = materializationProject;
     this.materializationDataset = materializationDataset;
@@ -50,6 +59,9 @@ public class ReadSessionCreatorConfig {
     this.maxReadRowsRetries = maxReadRowsRetries;
     this.maxParallelism = maxParallelism;
     this.defaultParallelism = defaultParallelism;
+    this.requestEncodedBase = requestEncodedBase;
+    this.compression = compression;
+    this.endpoint = endpoint;
   }
 
   public boolean isViewsEnabled() {
@@ -86,5 +98,21 @@ public class ReadSessionCreatorConfig {
 
   public int getDefaultParallelism() {
     return defaultParallelism;
+  }
+
+  public Optional<String> getRequestEncodedBase() {
+    return this.requestEncodedBase;
+  }
+
+  public ArrowSerializationOptions.CompressionCodec getCompression() {
+    return this.compression;
+  }
+
+  public Optional<String> endpoint() {
+    return this.endpoint;
+  }
+
+  public ReadRowsHelper.Options toReadRowsHelperOptions() {
+    return new ReadRowsHelper.Options(getMaxReadRowsRetries(), endpoint());
   }
 }

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfigBuilder.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfigBuilder.java
@@ -1,6 +1,5 @@
 package com.google.cloud.bigquery.connector.common;
 
-import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions.CompressionCodec;
 import com.google.cloud.bigquery.storage.v1.DataFormat;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -17,7 +16,6 @@ public class ReadSessionCreatorConfigBuilder {
   private OptionalInt maxParallelism = OptionalInt.empty();
   private int defaultParallelism = 1000;
   private Optional<String> requestEncodedBase = Optional.empty();
-  private CompressionCodec compression = CompressionCodec.COMPRESSION_UNSPECIFIED;
   private Optional<String> endpoint = Optional.empty();
 
   public ReadSessionCreatorConfigBuilder setViewsEnabled(boolean viewsEnabled) {
@@ -74,11 +72,6 @@ public class ReadSessionCreatorConfigBuilder {
     return this;
   }
 
-  public ReadSessionCreatorConfigBuilder setCompression(CompressionCodec compression) {
-    this.compression = compression;
-    return this;
-  }
-
   public ReadSessionCreatorConfigBuilder setEndpoint(Optional<String> endpoint) {
     this.endpoint = endpoint;
     return this;
@@ -96,7 +89,6 @@ public class ReadSessionCreatorConfigBuilder {
         maxParallelism,
         defaultParallelism,
         requestEncodedBase,
-        compression,
         endpoint);
   }
 }

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfigBuilder.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfigBuilder.java
@@ -1,0 +1,102 @@
+package com.google.cloud.bigquery.connector.common;
+
+import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions.CompressionCodec;
+import com.google.cloud.bigquery.storage.v1.DataFormat;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+public class ReadSessionCreatorConfigBuilder {
+
+  private boolean viewsEnabled;
+  private Optional<String> materializationProject = Optional.empty();
+  private Optional<String> materializationDataset = Optional.empty();
+  private int materializationExpirationTimeInMinutes = 120;
+  private DataFormat readDataFormat = DataFormat.ARROW;
+  private int maxReadRowsRetries = 10;
+  private String viewEnabledParamName = "";
+  private OptionalInt maxParallelism = OptionalInt.empty();
+  private int defaultParallelism = 1000;
+  private Optional<String> requestEncodedBase = Optional.empty();
+  private CompressionCodec compression = CompressionCodec.COMPRESSION_UNSPECIFIED;
+  private Optional<String> endpoint = Optional.empty();
+
+  public ReadSessionCreatorConfigBuilder setViewsEnabled(boolean viewsEnabled) {
+    this.viewsEnabled = viewsEnabled;
+    return this;
+  }
+
+  public ReadSessionCreatorConfigBuilder setMaterializationProject(
+      Optional<String> materializationProject) {
+    this.materializationProject = materializationProject;
+    return this;
+  }
+
+  public ReadSessionCreatorConfigBuilder setMaterializationDataset(
+      Optional<String> materializationDataset) {
+    this.materializationDataset = materializationDataset;
+    return this;
+  }
+
+  public ReadSessionCreatorConfigBuilder setMaterializationExpirationTimeInMinutes(
+      int materializationExpirationTimeInMinutes) {
+    this.materializationExpirationTimeInMinutes = materializationExpirationTimeInMinutes;
+    return this;
+  }
+
+  public ReadSessionCreatorConfigBuilder setReadDataFormat(DataFormat readDataFormat) {
+    this.readDataFormat = readDataFormat;
+    return this;
+  }
+
+  public ReadSessionCreatorConfigBuilder setMaxReadRowsRetries(int maxReadRowsRetries) {
+    this.maxReadRowsRetries = maxReadRowsRetries;
+    return this;
+  }
+
+  public ReadSessionCreatorConfigBuilder setViewEnabledParamName(String viewEnabledParamName) {
+    this.viewEnabledParamName = viewEnabledParamName;
+    return this;
+  }
+
+  public ReadSessionCreatorConfigBuilder setMaxParallelism(OptionalInt maxParallelism) {
+    this.maxParallelism = maxParallelism;
+    return this;
+  }
+
+  public ReadSessionCreatorConfigBuilder setDefaultParallelism(int defaultParallelism) {
+    this.defaultParallelism = defaultParallelism;
+    return this;
+  }
+
+  public ReadSessionCreatorConfigBuilder setRequestEncodedBase(
+      Optional<String> requestEncodedBase) {
+    this.requestEncodedBase = requestEncodedBase;
+    return this;
+  }
+
+  public ReadSessionCreatorConfigBuilder setCompression(CompressionCodec compression) {
+    this.compression = compression;
+    return this;
+  }
+
+  public ReadSessionCreatorConfigBuilder setEndpoint(Optional<String> endpoint) {
+    this.endpoint = endpoint;
+    return this;
+  }
+
+  public ReadSessionCreatorConfig build() {
+    return new ReadSessionCreatorConfig(
+        viewsEnabled,
+        materializationProject,
+        materializationDataset,
+        materializationExpirationTimeInMinutes,
+        readDataFormat,
+        maxReadRowsRetries,
+        viewEnabledParamName,
+        maxParallelism,
+        defaultParallelism,
+        requestEncodedBase,
+        compression,
+        endpoint);
+  }
+}

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/ArrowBinaryIterator.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/ArrowBinaryIterator.java
@@ -72,13 +72,11 @@ public class ArrowBinaryIterator implements Iterator<InternalRow> {
     this.columnsInOrder = columnsInOrder;
 
     List<StructField> userProvidedFieldList =
-        Arrays
-            .stream(userProvidedSchema.orElse(new StructType()).fields())
+        Arrays.stream(userProvidedSchema.orElse(new StructType()).fields())
             .collect(Collectors.toList());
 
     this.userProvidedFieldMap =
-        userProvidedFieldList
-            .stream()
+        userProvidedFieldList.stream()
             .collect(Collectors.toMap(StructField::name, Function.identity()));
   }
 

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SchemaConverters.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SchemaConverters.java
@@ -97,8 +97,7 @@ public class SchemaConverters {
       GenericRecord record,
       Optional<StructType> userProvidedSchema) {
     List<StructField> userProvidedFieldList =
-        Arrays
-            .stream(userProvidedSchema.orElse(new StructType()).fields())
+        Arrays.stream(userProvidedSchema.orElse(new StructType()).fields())
             .collect(Collectors.toList());
 
     return convertAll(schema.getFields(), record, namesInOrder, userProvidedFieldList);
@@ -123,8 +122,7 @@ public class SchemaConverters {
 
       List<Object> valueList = (List<Object>) value;
       return new GenericArrayData(
-          valueList
-              .stream()
+          valueList.stream()
               .map(v -> convert(nestedField, v, getStructFieldForRepeatedMode(userProvidedField)))
               .collect(Collectors.toList()));
     }
@@ -184,8 +182,7 @@ public class SchemaConverters {
 
       if (userProvidedField != null) {
         structList =
-            Arrays
-                .stream(((StructType)userProvidedField.dataType()).fields())
+            Arrays.stream(((StructType) userProvidedField.dataType()).fields())
                 .collect(Collectors.toList());
 
         namesInOrder = structList.stream().map(StructField::name).collect(Collectors.toList());
@@ -218,8 +215,7 @@ public class SchemaConverters {
     Map<String, StructField> userProvidedFieldMap =
         userProvidedFieldList == null
             ? new HashMap<>()
-            : userProvidedFieldList
-                .stream()
+            : userProvidedFieldList.stream()
                 .collect(Collectors.toMap(StructField::name, Function.identity()));
 
     fieldList.stream()

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -27,7 +27,6 @@ import com.google.cloud.bigquery.connector.common.BigQueryConfig;
 import com.google.cloud.bigquery.connector.common.BigQueryCredentialsSupplier;
 import com.google.cloud.bigquery.connector.common.ReadSessionCreatorConfig;
 import com.google.cloud.bigquery.connector.common.ReadSessionCreatorConfigBuilder;
-import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions.CompressionCodec;
 import com.google.cloud.bigquery.storage.v1.DataFormat;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -114,7 +113,6 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
   ImmutableList<JobInfo.SchemaUpdateOption> loadSchemaUpdateOptions = ImmutableList.of();
   int materializationExpirationTimeInMinutes = DEFAULT_MATERIALIZATION_EXPRIRATION_TIME_IN_MINUTES;
   int maxReadRowsRetries = 3;
-  private CompressionCodec compression = CompressionCodec.COMPRESSION_UNSPECIFIED;
   private com.google.common.base.Optional<String> encodedCreateReadSessionRequest = empty();
   private com.google.common.base.Optional<String> storageReadEndpoint = empty();
 
@@ -274,9 +272,6 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
     config.storageReadEndpoint = getAnyOption(globalOptions, options, "bqStorageReadEndpoint");
     config.encodedCreateReadSessionRequest =
         getAnyOption(globalOptions, options, "bqEncodedCreateReadSessionRequest");
-    getAnyOption(globalOptions, options, "bqStorageReadArrowCompression")
-        .toJavaUtil()
-        .ifPresent(c -> config.compression = CompressionCodec.valueOf(c));
 
     return config;
   }
@@ -573,7 +568,6 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
         .setViewEnabledParamName(VIEWS_ENABLED_OPTION)
         .setDefaultParallelism(defaultParallelism)
         .setMaxParallelism(getMaxParallelism())
-        .setCompression(compression)
         .setRequestEncodedBase(encodedCreateReadSessionRequest.toJavaUtil())
         .setEndpoint(storageReadEndpoint.toJavaUtil())
         .build();

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -57,8 +57,7 @@ import static com.google.cloud.bigquery.connector.common.BigQueryUtil.firstPrese
 import static com.google.cloud.bigquery.connector.common.BigQueryUtil.parseTableId;
 import static java.lang.String.format;
 
-// as the config needs to be Serializable, internally it uses
-// com.google.common.base.Optional<String> but externally it uses the regular java.util.Optional
+
 public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
 
   public static final String VIEWS_ENABLED_OPTION = "viewsEnabled";
@@ -84,6 +83,8 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
   private static final int DEFAULT_BIGQUERY_CLIENT_CONNECT_TIMEOUT = 60 * 1000;
   private static final int DEFAULT_BIGQUERY_CLIENT_READ_TIMEOUT = 60 * 1000;
   TableId tableId;
+  // as the config needs to be Serializable, internally it uses
+  // com.google.common.base.Optional<String> but externally it uses the regular java.util.Optional
   com.google.common.base.Optional<String> query = empty();
   String parentProjectId;
   com.google.common.base.Optional<String> credentialsKey;

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -57,7 +57,6 @@ import static com.google.cloud.bigquery.connector.common.BigQueryUtil.firstPrese
 import static com.google.cloud.bigquery.connector.common.BigQueryUtil.parseTableId;
 import static java.lang.String.format;
 
-
 public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
 
   public static final String VIEWS_ENABLED_OPTION = "viewsEnabled";
@@ -116,8 +115,8 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
   int materializationExpirationTimeInMinutes = DEFAULT_MATERIALIZATION_EXPRIRATION_TIME_IN_MINUTES;
   int maxReadRowsRetries = 3;
   private CompressionCodec compression;
-  private Optional<String> encodedCreateReadSessionRequest = Optional.empty();
-  private Optional<String> storageReadEndpoint = Optional.empty();
+  private com.google.common.base.Optional<String> encodedCreateReadSessionRequest = empty();
+  private com.google.common.base.Optional<String> storageReadEndpoint = empty();
 
   @VisibleForTesting
   SparkBigQueryConfig() {
@@ -276,6 +275,7 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
     config.encodedCreateReadSessionRequest =
         getAnyOption(globalOptions, options, "bqEncodedCreateReadSessionRequest");
     getAnyOption(globalOptions, options, "bqStorageReadArrowCompression")
+        .toJavaUtil()
         .ifPresent(c -> config.compression = CompressionCodec.valueOf(c));
 
     return config;
@@ -565,17 +565,17 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
   public ReadSessionCreatorConfig toReadSessionCreatorConfig() {
     return new ReadSessionCreatorConfigBuilder()
         .setViewsEnabled(viewsEnabled)
-        .setMaterializationProject(materializationProject)
-        .setMaterializationDataset(materializationDataset)
+        .setMaterializationProject(materializationProject.toJavaUtil())
+        .setMaterializationDataset(materializationDataset.toJavaUtil())
         .setMaterializationExpirationTimeInMinutes(materializationExpirationTimeInMinutes)
         .setReadDataFormat(readDataFormat)
         .setMaxReadRowsRetries(maxReadRowsRetries)
         .setViewEnabledParamName(VIEWS_ENABLED_OPTION)
         .setDefaultParallelism(defaultParallelism)
-        .setMaxParallelism(maxParallelism)
+        .setMaxParallelism(getMaxParallelism())
         .setCompression(compression)
-        .setRequestEncodedBase(encodedCreateReadSessionRequest)
-        .setEndpoint(storageReadEndpoint)
+        .setRequestEncodedBase(encodedCreateReadSessionRequest.toJavaUtil())
+        .setEndpoint(storageReadEndpoint.toJavaUtil())
         .build();
   }
 

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -114,7 +114,7 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
   ImmutableList<JobInfo.SchemaUpdateOption> loadSchemaUpdateOptions = ImmutableList.of();
   int materializationExpirationTimeInMinutes = DEFAULT_MATERIALIZATION_EXPRIRATION_TIME_IN_MINUTES;
   int maxReadRowsRetries = 3;
-  private CompressionCodec compression;
+  private CompressionCodec compression = CompressionCodec.COMPRESSION_UNSPECIFIED;
   private com.google.common.base.Optional<String> encodedCreateReadSessionRequest = empty();
   private com.google.common.base.Optional<String> storageReadEndpoint = empty();
 

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowColumnBatchPartitionReader.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowColumnBatchPartitionReader.java
@@ -111,8 +111,7 @@ class ArrowColumnBatchPartitionColumnBatchReader implements InputPartitionReader
     this.tracer = tracer;
 
     List<StructField> userProvidedFieldList =
-        Arrays
-            .stream(userProvidedSchema.orElse(new StructType()).fields())
+        Arrays.stream(userProvidedSchema.orElse(new StructType()).fields())
             .collect(Collectors.toList());
 
     this.userProvidedFieldMap =

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowInputPartition.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowInputPartition.java
@@ -38,7 +38,7 @@ public class ArrowInputPartition implements InputPartition<ColumnarBatch> {
   private final BigQueryReadClientFactory bigQueryReadClientFactory;
   private final BigQueryTracerFactory tracerFactory;
   private final String streamName;
-  private final int maxReadRowsRetries;
+  private final ReadRowsHelper.Options options;
   private final ImmutableList<String> selectedFields;
   private final ByteString serializedArrowSchema;
   private final com.google.common.base.Optional<StructType> userProvidedSchema;
@@ -47,13 +47,13 @@ public class ArrowInputPartition implements InputPartition<ColumnarBatch> {
       BigQueryReadClientFactory bigQueryReadClientFactory,
       BigQueryTracerFactory tracerFactory,
       String name,
-      int maxReadRowsRetries,
+      ReadRowsHelper.Options options,
       ImmutableList<String> selectedFields,
       ReadSessionResponse readSessionResponse,
       Optional<StructType> userProvidedSchema) {
     this.bigQueryReadClientFactory = bigQueryReadClientFactory;
     this.streamName = name;
-    this.maxReadRowsRetries = maxReadRowsRetries;
+    this.options = options;
     this.selectedFields = selectedFields;
     this.serializedArrowSchema =
         readSessionResponse.getReadSession().getArrowSchema().getSerializedSchema();
@@ -67,7 +67,7 @@ public class ArrowInputPartition implements InputPartition<ColumnarBatch> {
     ReadRowsRequest.Builder readRowsRequest =
         ReadRowsRequest.newBuilder().setReadStream(streamName);
     ReadRowsHelper readRowsHelper =
-        new ReadRowsHelper(bigQueryReadClientFactory, readRowsRequest, maxReadRowsRetries);
+        new ReadRowsHelper(bigQueryReadClientFactory, readRowsRequest, options);
     tracer.startStream();
     Iterator<ReadRowsResponse> readRowsResponses = readRowsHelper.readRows();
     return new ArrowColumnBatchPartitionColumnBatchReader(

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryDataSourceReader.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryDataSourceReader.java
@@ -192,8 +192,9 @@ public class BigQueryDataSourceReader
       Schema tableSchema =
           SchemaConverters.getSchemaWithPseudoColumns(readSessionResponse.getReadTableInfo());
       selectedFields =
-          ImmutableList.copyOf(
-              tableSchema.getFields().stream().map(Field::getName).collect(Collectors.toList()));
+          tableSchema.getFields().stream()
+              .map(Field::getName)
+              .collect(ImmutableList.toImmutableList());
     }
 
     ImmutableList<String> partitionSelectedFields = selectedFields;
@@ -227,8 +228,9 @@ public class BigQueryDataSourceReader
       if (selectedFields.isEmpty()) {
         // means select *
         selectedFields =
-            ImmutableList.copyOf(
-                schema.getFields().stream().map(Field::getName).collect(Collectors.toList()));
+            schema.getFields().stream()
+                .map(Field::getName)
+                .collect(ImmutableList.toImmutableList());
       } else {
         Set<String> requiredColumnSet = ImmutableSet.copyOf(selectedFields);
         schema =

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryInputPartition.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryInputPartition.java
@@ -30,17 +30,17 @@ public class BigQueryInputPartition implements InputPartition<InternalRow> {
 
   private final BigQueryReadClientFactory bigQueryReadClientFactory;
   private final String streamName;
-  private final int maxReadRowsRetries;
+  private final ReadRowsHelper.Options options;
   private final ReadRowsResponseToInternalRowIteratorConverter converter;
 
   public BigQueryInputPartition(
       BigQueryReadClientFactory bigQueryReadClientFactory,
       String streamName,
-      int maxReadRowsRetries,
+      ReadRowsHelper.Options options,
       ReadRowsResponseToInternalRowIteratorConverter converter) {
     this.bigQueryReadClientFactory = bigQueryReadClientFactory;
     this.streamName = streamName;
-    this.maxReadRowsRetries = maxReadRowsRetries;
+    this.options = options;
     this.converter = converter;
   }
 
@@ -49,7 +49,7 @@ public class BigQueryInputPartition implements InputPartition<InternalRow> {
     ReadRowsRequest.Builder readRowsRequest =
         ReadRowsRequest.newBuilder().setReadStream(streamName);
     ReadRowsHelper readRowsHelper =
-        new ReadRowsHelper(bigQueryReadClientFactory, readRowsRequest, maxReadRowsRetries);
+        new ReadRowsHelper(bigQueryReadClientFactory, readRowsRequest, options);
     Iterator<ReadRowsResponse> readRowsResponses = readRowsHelper.readRows();
     return new BigQueryInputPartitionReader(readRowsResponses, converter, readRowsHelper);
   }

--- a/connector/src/test/java/com/google/cloud/bigquery/connector/common/ReadRowsHelperTest.java
+++ b/connector/src/test/java/com/google/cloud/bigquery/connector/common/ReadRowsHelperTest.java
@@ -20,6 +20,10 @@ import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
 import com.google.common.collect.ImmutableList;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutput;
+import java.io.ObjectOutputStream;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -39,6 +43,11 @@ public class ReadRowsHelperTest {
   private ReadRowsRequest.Builder request = ReadRowsRequest.newBuilder().setReadStream("test");
   private ReadSessionCreatorConfig defaultConfig =
       new ReadSessionCreatorConfigBuilder().setMaxReadRowsRetries(3).build();
+
+  @Test
+  public void testConfigSerializable() throws IOException {
+    new ObjectOutputStream(new ByteArrayOutputStream()).writeObject(defaultConfig);
+  }
 
   @Test
   public void testNoFailures() {

--- a/connector/src/test/java/com/google/cloud/bigquery/connector/common/ReadRowsHelperTest.java
+++ b/connector/src/test/java/com/google/cloud/bigquery/connector/common/ReadRowsHelperTest.java
@@ -46,7 +46,8 @@ public class ReadRowsHelperTest {
 
   @Test
   public void testConfigSerializable() throws IOException {
-    new ObjectOutputStream(new ByteArrayOutputStream()).writeObject(defaultConfig);
+    new ObjectOutputStream(new ByteArrayOutputStream())
+        .writeObject(defaultConfig.toReadRowsHelperOptions());
   }
 
   @Test
@@ -66,7 +67,7 @@ public class ReadRowsHelperTest {
   }
 
   @Test
-  public void endpontIsPropagated() {
+  public void endpointIsPropagated() {
     ArgumentCaptor<Optional<String>> endpointCaptor = ArgumentCaptor.forClass(Optional.class);
     ReadSessionCreatorConfig config =
         new ReadSessionCreatorConfigBuilder()

--- a/connector/src/test/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorTest.java
+++ b/connector/src/test/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorTest.java
@@ -30,7 +30,6 @@ import com.google.cloud.bigquery.storage.v1.stub.EnhancedBigQueryReadStub;
 import com.google.common.collect.ImmutableList;
 import java.util.Optional;
 import java.util.OptionalInt;
-import org.apache.zookeeper.Op.Create;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 

--- a/connector/src/test/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorTest.java
+++ b/connector/src/test/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorTest.java
@@ -1,0 +1,112 @@
+package com.google.cloud.bigquery.connector.common;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.TableDefinition;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
+import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions;
+import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions.CompressionCodec;
+import com.google.cloud.bigquery.storage.v1.BigQueryReadClient;
+import com.google.cloud.bigquery.storage.v1.CreateReadSessionRequest;
+import com.google.cloud.bigquery.storage.v1.ReadSession;
+import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions;
+import com.google.cloud.bigquery.storage.v1.stub.EnhancedBigQueryReadStub;
+import com.google.common.collect.ImmutableList;
+import java.util.Optional;
+import java.util.OptionalInt;
+import org.apache.zookeeper.Op.Create;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class ReadSessionCreatorTest {
+  EnhancedBigQueryReadStub stub = mock(EnhancedBigQueryReadStub.class);
+  BigQueryClient bigQueryClient = mock(BigQueryClient.class);
+  UnaryCallable<CreateReadSessionRequest, ReadSession> createReadSessionCall =
+      mock(UnaryCallable.class);
+  BigQueryReadClient readClient = BigQueryReadClient.create(stub);
+  BigQueryReadClientFactory bigQueryReadClientFactory = mock(BigQueryReadClientFactory.class);
+  TableInfo table =
+      TableInfo.newBuilder(
+              TableId.of("a", "b"),
+              StandardTableDefinition.newBuilder()
+                  .setSchema(Schema.of(Field.of("name", StandardSQLTypeName.BOOL)))
+                  .setNumBytes(1L)
+                  .build())
+          .build();
+
+  @Test
+  public void testCompressionIsPropagated() {
+    ReadSessionCreatorConfig config =
+        new ReadSessionCreatorConfigBuilder()
+            .setCompression(CompressionCodec.LZ4_FRAME)
+            .setMaxParallelism(OptionalInt.of(1))
+            .build();
+    ReadSessionCreator creator =
+        new ReadSessionCreator(config, bigQueryClient, bigQueryReadClientFactory);
+    when(bigQueryReadClientFactory.createBigQueryReadClient(any())).thenReturn(readClient);
+    when(bigQueryClient.getTable(any())).thenReturn(table);
+    when(stub.createReadSessionCallable()).thenReturn(createReadSessionCall);
+
+    creator
+        .create(TableId.of("dataset", "table"), ImmutableList.of(), Optional.empty())
+        .getReadSession();
+
+    ArgumentCaptor<CreateReadSessionRequest> requestCaptor =
+        ArgumentCaptor.forClass(CreateReadSessionRequest.class);
+    verify(createReadSessionCall, times(1)).call(requestCaptor.capture());
+    ReadSession session = requestCaptor.getValue().getReadSession();
+    assertThat(session.getReadOptions().getArrowSerializationOptions().getBufferCompression())
+        .isEqualTo(CompressionCodec.LZ4_FRAME);
+  }
+
+  @Test
+  public void testSerializedInstanceIsPropagated() throws Exception {
+    TableReadOptions tableReadOptions =
+        TableReadOptions.newBuilder()
+            .setArrowSerializationOptions(
+                ArrowSerializationOptions.newBuilder()
+                    .setBufferCompression(CompressionCodec.LZ4_FRAME))
+            .build();
+    ReadSession readSession =
+        ReadSession.newBuilder().setName("abc").setReadOptions(tableReadOptions).build();
+    CreateReadSessionRequest request =
+        CreateReadSessionRequest.newBuilder().setReadSession(readSession).build();
+    Optional<String> encodedBase =
+        Optional.of(java.util.Base64.getEncoder().encodeToString(request.toByteArray()));
+    ReadSessionCreatorConfig config =
+        new ReadSessionCreatorConfigBuilder().setRequestEncodedBase(encodedBase).build();
+    ReadSessionCreator creator =
+        new ReadSessionCreator(config, bigQueryClient, bigQueryReadClientFactory);
+    when(bigQueryReadClientFactory.createBigQueryReadClient(any())).thenReturn(readClient);
+    when(bigQueryClient.getTable(any())).thenReturn(table);
+    when(stub.createReadSessionCallable()).thenReturn(createReadSessionCall);
+
+    creator
+        .create(TableId.of("dataset", "table"), ImmutableList.of(), Optional.empty())
+        .getReadSession();
+
+    ArgumentCaptor<CreateReadSessionRequest> requestCaptor =
+        ArgumentCaptor.forClass(CreateReadSessionRequest.class);
+    verify(createReadSessionCall, times(1)).call(requestCaptor.capture());
+
+    ReadSession actual = requestCaptor.getValue().getReadSession();
+    assertThat(actual.getName()).isEqualTo("abc");
+    assertThat(actual.getReadOptions().getArrowSerializationOptions().getBufferCompression())
+        .isEqualTo(CompressionCodec.LZ4_FRAME);
+  }
+}

--- a/connector/src/test/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorTest.java
+++ b/connector/src/test/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorTest.java
@@ -2,6 +2,7 @@ package com.google.cloud.bigquery.connector.common;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -92,7 +93,8 @@ public class ReadSessionCreatorTest {
         new ReadSessionCreatorConfigBuilder().setRequestEncodedBase(encodedBase).build();
     ReadSessionCreator creator =
         new ReadSessionCreator(config, bigQueryClient, bigQueryReadClientFactory);
-    when(bigQueryReadClientFactory.createBigQueryReadClient(any())).thenReturn(readClient);
+    when(bigQueryReadClientFactory.createBigQueryReadClient(eq(Optional.empty())))
+        .thenReturn(readClient);
     when(bigQueryClient.getTable(any())).thenReturn(table);
     when(stub.createReadSessionCallable()).thenReturn(createReadSessionCall);
 

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.spark.bigquery;
 import com.google.cloud.bigquery.JobInfo;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TimePartitioning;
+import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions.CompressionCodec;
 import com.google.cloud.bigquery.storage.v1.DataFormat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -150,6 +151,9 @@ public class SparkBigQueryConfigTest {
         ImmutableMap.<String, String>builder()
             .put("viewsEnabled", "true")
             .put("spark.datasource.bigquery.temporaryGcsBucket", "bucket")
+            .put("bqStorageReadEndpoint", "ep")
+            .put("bqEncodedCreateReadSessionRequest", "ec")
+            .put("bqStorageReadArrowCompression", "LZ4_FRAME")
             .build();
     SparkBigQueryConfig config =
         SparkBigQueryConfig.from(
@@ -163,6 +167,10 @@ public class SparkBigQueryConfigTest {
 
     assertThat(config.isViewsEnabled()).isTrue();
     assertThat(config.getTemporaryGcsBucket()).isEqualTo(Optional.of("bucket"));
+    assertThat(config.toReadSessionCreatorConfig().endpoint().get()).isEqualTo("ep");
+    assertThat(config.toReadSessionCreatorConfig().getRequestEncodedBase().get()).isEqualTo("ec");
+    assertThat(config.toReadSessionCreatorConfig().getCompression())
+        .isEqualTo(CompressionCodec.LZ4_FRAME);
   }
 
   @Test

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -22,6 +22,9 @@ import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions.Compressio
 import com.google.cloud.bigquery.storage.v1.DataFormat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.sources.v2.DataSourceOptions;
@@ -39,6 +42,23 @@ public class SparkBigQueryConfigTest {
   public static final String SPARK_VERSION = "2.4.0";
   ImmutableMap<String, String> defaultOptions = ImmutableMap.of("table", "dataset.table");
   // "project", "test_project"); // to remove the need for default project
+
+  @Test
+  public void testSerializability() throws IOException {
+    Configuration hadoopConfiguration = new Configuration();
+    DataSourceOptions options = new DataSourceOptions(defaultOptions);
+    // test to make sure all members can be serialized.
+    new ObjectOutputStream(new ByteArrayOutputStream())
+        .writeObject(
+            SparkBigQueryConfig.from(
+                options.asMap(),
+                ImmutableMap.of(),
+                hadoopConfiguration,
+                DEFAULT_PARALLELISM,
+                new SQLConf(),
+                SPARK_VERSION,
+                Optional.empty()));
+  }
 
   @Test
   public void testDefaults() {

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -18,7 +18,6 @@ package com.google.cloud.spark.bigquery;
 import com.google.cloud.bigquery.JobInfo;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TimePartitioning;
-import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions.CompressionCodec;
 import com.google.cloud.bigquery.storage.v1.DataFormat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -173,7 +172,6 @@ public class SparkBigQueryConfigTest {
             .put("spark.datasource.bigquery.temporaryGcsBucket", "bucket")
             .put("bqStorageReadEndpoint", "ep")
             .put("bqEncodedCreateReadSessionRequest", "ec")
-            .put("bqStorageReadArrowCompression", "LZ4_FRAME")
             .build();
     SparkBigQueryConfig config =
         SparkBigQueryConfig.from(
@@ -189,8 +187,6 @@ public class SparkBigQueryConfigTest {
     assertThat(config.getTemporaryGcsBucket()).isEqualTo(Optional.of("bucket"));
     assertThat(config.toReadSessionCreatorConfig().endpoint().get()).isEqualTo("ep");
     assertThat(config.toReadSessionCreatorConfig().getRequestEncodedBase().get()).isEqualTo("ec");
-    assertThat(config.toReadSessionCreatorConfig().getCompression())
-        .isEqualTo(CompressionCodec.LZ4_FRAME);
   }
 
   @Test

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/v2/BigQueryInputPartitionTest.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/v2/BigQueryInputPartitionTest.java
@@ -1,0 +1,23 @@
+package com.google.cloud.spark.bigquery.v2;
+
+import com.google.cloud.bigquery.connector.common.ReadRowsHelper;
+import com.google.cloud.bigquery.connector.common.ReadRowsHelper.Options;
+import com.google.cloud.bigquery.connector.common.ReadSessionResponse;
+import com.google.cloud.bigquery.storage.v1.ReadSession;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.Optional;
+import org.junit.Test;
+
+public class BigQueryInputPartitionTest {
+  @Test
+  public void testSerializability() throws IOException {
+    new ObjectOutputStream(new ByteArrayOutputStream()).writeObject(new ArrowInputPartition(
+        /*bigQueryClientFactory=*/null, /*tracerFactory=*/null, "streamName", new ReadRowsHelper.Options(/*maxRetries=*/5,
+        Optional.of("endpoint")), null,
+        new ReadSessionResponse(ReadSession.getDefaultInstance(), null)
+    ));
+  }
+
+}

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/v2/BigQueryInputPartitionTest.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/v2/BigQueryInputPartitionTest.java
@@ -21,6 +21,7 @@ public class BigQueryInputPartitionTest {
                 "streamName",
                 new ReadRowsHelper.Options(/*maxRetries=*/ 5, Optional.of("endpoint")),
                 null,
-                new ReadSessionResponse(ReadSession.getDefaultInstance(), null)));
+                new ReadSessionResponse(ReadSession.getDefaultInstance(), null),
+                null));
   }
 }

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/v2/BigQueryInputPartitionTest.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/v2/BigQueryInputPartitionTest.java
@@ -13,11 +13,14 @@ import org.junit.Test;
 public class BigQueryInputPartitionTest {
   @Test
   public void testSerializability() throws IOException {
-    new ObjectOutputStream(new ByteArrayOutputStream()).writeObject(new ArrowInputPartition(
-        /*bigQueryClientFactory=*/null, /*tracerFactory=*/null, "streamName", new ReadRowsHelper.Options(/*maxRetries=*/5,
-        Optional.of("endpoint")), null,
-        new ReadSessionResponse(ReadSession.getDefaultInstance(), null)
-    ));
+    new ObjectOutputStream(new ByteArrayOutputStream())
+        .writeObject(
+            new ArrowInputPartition(
+                /*bigQueryClientFactory=*/ null,
+                /*tracerFactory=*/ null,
+                "streamName",
+                new ReadRowsHelper.Options(/*maxRetries=*/ 5, Optional.of("endpoint")),
+                null,
+                new ReadSessionResponse(ReadSession.getDefaultInstance(), null)));
   }
-
 }

--- a/connector/src/test/scala/com/google/cloud/spark/bigquery/DirectBigQueryRelationSuite.scala
+++ b/connector/src/test/scala/com/google/cloud/spark/bigquery/DirectBigQueryRelationSuite.scala
@@ -16,7 +16,6 @@
 package com.google.cloud.spark.bigquery
 
 import java.sql.{Date, Timestamp}
-import java.util.Optional
 
 import com.google.cloud.bigquery._
 import com.google.cloud.bigquery.storage.v1.DataFormat

--- a/connector/src/test/scala/com/google/cloud/spark/bigquery/DirectBigQueryRelationSuite.scala
+++ b/connector/src/test/scala/com/google/cloud/spark/bigquery/DirectBigQueryRelationSuite.scala
@@ -16,6 +16,7 @@
 package com.google.cloud.spark.bigquery
 
 import java.sql.{Date, Timestamp}
+import java.util.Optional
 
 import com.google.cloud.bigquery._
 import com.google.cloud.bigquery.storage.v1.DataFormat
@@ -79,7 +80,7 @@ class DirectBigQueryRelationSuite
   test("user defined schema") {
     val expectedSchema = StructType(Seq(StructField("baz", ShortType)))
     val options = defaultOptions
-    options.schema = com.google.common.base.Optional.of(expectedSchema)
+    options.schema = Optional.of(expectedSchema)
     bigQueryRelation = new DirectBigQueryRelation(options, TABLE)(sqlCtx)
     val schema = bigQueryRelation.schema
     assert(expectedSchema == schema)
@@ -165,7 +166,7 @@ class DirectBigQueryRelationSuite
   test("old filter behaviour, with filter option") {
     val options = defaultOptions
     options.combinePushedDownFilters = false
-    options.filter = com.google.common.base.Optional.of("f>1")
+    options.filter = Optional.of("f>1")
     val r = new DirectBigQueryRelation(options, TABLE)(sqlCtx)
     checkFilters(r, "f>1", Array(GreaterThan("a", 2)), "f>1")
   }
@@ -179,7 +180,7 @@ class DirectBigQueryRelationSuite
 
   test("new filter behaviour, with filter option") {
     val options = defaultOptions
-    options.filter = com.google.common.base.Optional.of("f>1")
+    options.filter = Optional.of("f>1")
     val r = new DirectBigQueryRelation(options, TABLE)(sqlCtx)
     checkFilters(r, "(f>1)", Array(GreaterThan("a", 2)), "(f>1) AND (a > 2)")
   }

--- a/connector/src/test/scala/com/google/cloud/spark/bigquery/DirectBigQueryRelationSuite.scala
+++ b/connector/src/test/scala/com/google/cloud/spark/bigquery/DirectBigQueryRelationSuite.scala
@@ -80,7 +80,7 @@ class DirectBigQueryRelationSuite
   test("user defined schema") {
     val expectedSchema = StructType(Seq(StructField("baz", ShortType)))
     val options = defaultOptions
-    options.schema = Optional.of(expectedSchema)
+    options.schema = com.google.common.base.Optional.of(expectedSchema)
     bigQueryRelation = new DirectBigQueryRelation(options, TABLE)(sqlCtx)
     val schema = bigQueryRelation.schema
     assert(expectedSchema == schema)
@@ -166,7 +166,7 @@ class DirectBigQueryRelationSuite
   test("old filter behaviour, with filter option") {
     val options = defaultOptions
     options.combinePushedDownFilters = false
-    options.filter = Optional.of("f>1")
+    options.filter = com.google.common.base.Optional.of("f>1")
     val r = new DirectBigQueryRelation(options, TABLE)(sqlCtx)
     checkFilters(r, "f>1", Array(GreaterThan("a", 2)), "f>1")
   }
@@ -180,7 +180,7 @@ class DirectBigQueryRelationSuite
 
   test("new filter behaviour, with filter option") {
     val options = defaultOptions
-    options.filter = Optional.of("f>1")
+    options.filter = com.google.common.base.Optional.of("f>1")
     val r = new DirectBigQueryRelation(options, TABLE)(sqlCtx)
     checkFilters(r, "(f>1)", Array(GreaterThan("a", 2)), "(f>1) AND (a > 2)")
   }


### PR DESCRIPTION
Adds options for:
- Endpoint of the Read API - Useful for testing and if we migrate to regional endpoints
- Encoded base CreateReadSessionRequest which allows for setting hidden fields if necessary
- Arrow compression codec - This isn't hooked up yet in Arrow code (we need to wait until Arrow 4.0)

Additionally
- Fix some formatting from prior commits.
- Force version of guava to not be android (otherwise compilation/intellij are flaky)
- Introduce new configuration object for ReadRows calls