### PR TITLE
Add QueueingInputPartitionReader for parallel processing of Readers.

### DIFF
--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/QueueingInputPartitionReader.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/QueueingInputPartitionReader.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2021 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.v2;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.apache.arrow.util.AutoCloseables;
+import org.apache.arrow.util.Preconditions;
+import org.apache.spark.sql.sources.v2.reader.InputPartitionReader;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+
+/*
+ * An {@link InputPartitionReader} that will do round-robin asynchronous reads from
+ * other readers.
+ *
+ * This is useful in a few contexts:
+ * * For InputPartitionReaders that have expensive synchronous CPU operations
+ *   (e.g. parsing/decompression) this allows for pipelining operations with Spark application level
+ *   code (assuming there are free CPU cycles).
+ * * A way of composing underlying readers for increased throughput (e.g. if readers are each IO
+ *   bound waiting on separate services).
+ *
+ */
+public class QueueingInputPartitionReader implements InputPartitionReader<ColumnarBatch> {
+
+  final static int POLL_TIME = 100;
+  private final BlockingQueue<Future<ColumnarBatch>> queue;
+  private final List<InputPartitionReader<ColumnarBatch>> readers;
+  private final ExecutorService executor;
+
+  // Whether processing of delegates is finished.
+  private boolean done = false;
+  // Background thread for reading from delegates.
+  private Thread readerThread;
+  // Holder for exceptions encountered while working with delegates.
+  private IOException readException;
+  // The more recently loaded batch.
+  private Future<ColumnarBatch> currentBatch;
+
+  /**
+   * @param readers The readers to read from in a round robin order.
+   * @param executor An ExecutorService to process the get method on the delegates. The service will
+   * be shutdown when this object is closed.
+   */
+  QueueingInputPartitionReader(
+      List<InputPartitionReader<ColumnarBatch>> readers, ExecutorService executor) {
+    this.readers = readers;
+    queue = new ArrayBlockingQueue<>(readers.size());
+    this.executor = executor;
+  }
+
+  @Override
+  public boolean next() throws IOException {
+    if (readerThread == null) {
+      start();
+    }
+
+    currentBatch = null;
+    while (hasMoreElements() && currentBatch == null) {
+      try {
+        currentBatch = queue.poll(POLL_TIME, TimeUnit.MILLISECONDS);
+      } catch (InterruptedException e) {
+        break;
+      }
+    }
+    if (readException != null) {
+      throw readException;
+    }
+    if (currentBatch != null) {
+      try {
+        currentBatch.get();
+      } catch (InterruptedException e) {
+        throw new IOException(e);
+      } catch (ExecutionException e) {
+        if (e.getCause() instanceof IOException) {
+          throw (IOException) e.getCause();
+        }
+        throw new IOException(e);
+      }
+    }
+
+    return currentBatch != null;
+  }
+
+  private boolean hasMoreElements() {
+    return !done || queue.size() > 0;
+  }
+
+  private void start() {
+    readerThread = new Thread(this::consumeReaders);
+    readerThread.setDaemon(true);
+    readerThread.start();
+  }
+
+  private void consumeReaders() {
+    // Tracks which readers have exhausted all of there elements
+    boolean[] readersDone = new boolean[readers.size()];
+    int readersReady = readers.size();
+    Arrays.fill(readersDone, false);
+    CountDownLatch[] readerLocks = new CountDownLatch[readers.size()];
+    for (int x = 0; x < readerLocks.length; x++) {
+      readerLocks[x] = new CountDownLatch(0);
+    }
+
+    try {
+
+      while (!done) {
+        for (int readerIdx = 0; readerIdx < readers.size(); readerIdx++) {
+          if (readersDone[readerIdx]) {
+            continue;
+          }
+          InputPartitionReader<ColumnarBatch> reader = readers.get(readerIdx);
+          // Ensure that we don't submit another task for the same reader
+          // until the last one completed. This is necessary when some readers run out of
+          // tasks.
+          readerLocks[readerIdx].await();
+          readerLocks[readerIdx] = new CountDownLatch(1);
+          readersDone[readerIdx] = !reader.next();
+
+          if (!readersDone[readerIdx]) {
+
+            final int idx = readerIdx;
+            queue.put(executor.submit(() -> {
+              ColumnarBatch batch = reader.get();
+              readerLocks[idx].countDown();
+              return batch;
+            }));
+          } else {
+            readersReady--;
+            if (readersReady <= 0) {
+              done = true;
+            }
+          }
+        }
+      }
+    } catch (IOException e) {
+      readException = e;
+    } catch (InterruptedException e) {
+      // This should only happen on shutdown.
+    }
+    done = true;
+  }
+
+  @Override
+  public ColumnarBatch get() {
+    Preconditions.checkState(currentBatch != null);
+    try {
+      return currentBatch.get();
+    } catch (Exception e) {
+      // Note we've already called get once above so this
+      // shouldn't happen in practice.
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void close() {
+    done = true;
+    // Try to force reader thread to stop.
+    if (readerThread != null) {
+      readerThread.interrupt();
+    }
+    // Stop any queued tasks from processing.
+    executor.shutdownNow();
+
+    try {
+      executor.awaitTermination(POLL_TIME, TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      // Nothing to do here.
+    }
+
+    try {
+      AutoCloseables.close(readers);
+    } catch (Exception e) {
+      throw new RuntimeException("Trouble closing delegate readers", e);
+    }
+  }
+}

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/v2/QueueingInputPartitionReaderTest.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/v2/QueueingInputPartitionReaderTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2021 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.v2;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.truth.Correspondence;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.apache.spark.sql.sources.v2.reader.InputPartitionReader;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+
+public class QueueingInputPartitionReaderTest {
+
+  @Test
+  public void testReadsAllBatchesInRoundRobin() throws Exception {
+
+    ColumnarBatch[] batches = new ColumnarBatch[6];
+    for (int x = 0; x < batches.length; x++) {
+      batches[x] = new ColumnarBatch(new ColumnVector[0]);
+    }
+    InputPartitionReader<ColumnarBatch> r1 = mock(InputPartitionReader.class);
+    when(r1.next()).thenReturn(true).thenReturn(false);
+    when(r1.get()).thenReturn(batches[0]);
+    InputPartitionReader<ColumnarBatch> r2 = mock(InputPartitionReader.class);
+    when(r2.next()).thenReturn(true).thenReturn(true).thenReturn(false);
+    when(r2.get()).thenReturn(batches[1]).thenReturn(batches[3]);
+    InputPartitionReader<ColumnarBatch> r3 = mock(InputPartitionReader.class);
+    when(r3.next()).thenReturn(true).thenReturn(true).thenReturn(true).thenReturn(false);
+    when(r3.get()).thenReturn(batches[2]).thenReturn(batches[4]).thenReturn(batches[5]);
+
+    ExecutorService executor = Executors.newFixedThreadPool(3);
+    QueueingInputPartitionReader reader =
+        new QueueingInputPartitionReader(ImmutableList.of(r1, r2, r3), executor);
+    List<ColumnarBatch> read = new ArrayList<>();
+    while (reader.next()) {
+      read.add(reader.get());
+    }
+    reader.close();
+
+    assertThat(read).comparingElementsUsing(Correspondence.from((a, b) -> {
+      return a == b;
+    }, "same")).containsExactlyElementsIn(batches).inOrder();
+    assertThat(executor.isShutdown()).isTrue();
+  }
+
+  @Test
+  public void testExceptionIsPropagatedFromNext() throws Exception {
+
+    IOException exception = new IOException("an exception");
+    InputPartitionReader<ColumnarBatch> r1 = mock(InputPartitionReader.class);
+    when(r1.next()).thenThrow(exception);
+
+    ExecutorService executor = MoreExecutors.newDirectExecutorService();
+    QueueingInputPartitionReader reader =
+        new QueueingInputPartitionReader(ImmutableList.of(r1), executor);
+
+    IOException e = Assert.assertThrows(IOException.class, reader::next);
+
+    assertThat(e).isSameInstanceAs(exception);
+  }
+
+  @Test
+  public void testInterruptsOnClose() throws Exception {
+    InputPartitionReader<ColumnarBatch> r1 = mock(InputPartitionReader.class);
+    when(r1.next()).thenReturn(true);
+    when(r1.get()).thenReturn(new ColumnarBatch(new ColumnVector[0]));
+    CountDownLatch latch = new CountDownLatch(1);
+    InputPartitionReader<ColumnarBatch> r2 = mock(InputPartitionReader.class);
+    when(r2.next())
+        .thenAnswer(
+            (InvocationOnMock invocation) -> {
+              latch.countDown();
+              MILLISECONDS.sleep(QueueingInputPartitionReader.POLL_TIME);
+              return true;
+            });
+    when(r2.get())
+        .thenAnswer(
+            (InvocationOnMock invocation) -> {
+              MILLISECONDS.sleep(QueueingInputPartitionReader.POLL_TIME);
+              return new ColumnarBatch(new ColumnVector[0]);
+            });
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    QueueingInputPartitionReader reader =
+        new QueueingInputPartitionReader(ImmutableList.of(r1, r2), executor);
+
+    ExecutorService oneOff = Executors.newSingleThreadExecutor();
+    Instant start = Instant.now();
+
+    Future<Instant> endTime =
+        oneOff.submit(
+            () -> {
+              try {
+                while (reader.next()) {
+                  reader.get();
+                }
+              } catch (IOException e) {
+                e.printStackTrace();
+                return Instant.ofEpochMilli(0);
+              }
+              return Instant.now();
+            });
+
+    // Wait until next gets called.
+    latch.await();
+    // Should interrupt blocking operations.
+    reader.close();
+    oneOff.shutdown();
+
+    assertThat(endTime.get()).isGreaterThan(start);
+    assertThat(Duration.between(start, endTime.get()))
+        .isLessThan(Duration.ofMillis(QueueingInputPartitionReader.POLL_TIME * 2));
+
+
+  }
+}


### PR DESCRIPTION
I'll send out a PR incorporating this into the reader separately.

Ran thread dependendent/timing tests 1000 times to help verify
no issues.