### PR TITLE
Add option for background threaded reads for Arrow DSv2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,13 +31,6 @@ lazy val commonSettings = Seq(
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint")
 
-initialize := {
-  val _ = initialize.value
-  val javaVersion = sys.props("java.specification.version")
-  if (javaVersion != "1.8")
-    sys.error("Java 1.8 is required for this project. Found " + javaVersion + " instead")
-}
-
 // scalastyle:off
 // For https://github.com/GoogleCloudPlatform/spark-bigquery-connector/issues/72
 // Based on

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,13 @@ lazy val commonSettings = Seq(
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint")
 
+initialize := {
+  val _ = initialize.value
+  val javaVersion = sys.props("java.specification.version")
+  if (javaVersion != "1.8")
+    sys.error("Java 1.8 is required for this project. Found " + javaVersion + " instead")
+}
+
 // scalastyle:off
 // For https://github.com/GoogleCloudPlatform/spark-bigquery-connector/issues/72
 // Based on

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryStorageReadRowsTracer.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryStorageReadRowsTracer.java
@@ -34,10 +34,11 @@ public interface BigQueryStorageReadRowsTracer extends Serializable {
   void nextBatchNeeded();
 
   /**
-   * Creates a new read-rows tracer that is distinguished between IDs.
    *
    * <p>Must only be called before any calls are made to the tracer. This is intended for cases when
    * multiple threads might be used for processing one stream.
+   * tracer that is distinguished between IDs.
+   *
    *
    * @param id A distinguisher to use.
    * @return A new tracer with the ID>

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryStorageReadRowsTracer.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryStorageReadRowsTracer.java
@@ -34,11 +34,9 @@ public interface BigQueryStorageReadRowsTracer extends Serializable {
   void nextBatchNeeded();
 
   /**
-   *
-   * <p>Must only be called before any calls are made to the tracer. This is intended for cases when
-   * multiple threads might be used for processing one stream.
-   * tracer that is distinguished between IDs.
-   *
+   * Must only be called before any calls are made to the tracer. This is intended for cases when
+   * multiple threads might be used for processing one stream. tracer that is distinguished between
+   * IDs.
    *
    * @param id A distinguisher to use.
    * @return A new tracer with the ID>

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/IteratorMultiplexer.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/IteratorMultiplexer.java
@@ -52,7 +52,7 @@ public class IteratorMultiplexer<T> implements AutoCloseable {
       }
       worker = null;
       if (rethrow != null) {
-        throw new RuntimeException("Error while closing.", rethrow);
+        log.info("Error occurred while closing.", rethrow);
       }
     } else {
       for (int x = 0; x < splits; x++) {
@@ -132,6 +132,9 @@ public class IteratorMultiplexer<T> implements AutoCloseable {
     @Override
     public T next() {
       Preconditions.checkState(t != null, "next element cannot be null");
+      if (rethrow != null) {
+        throw rethrow;
+      }
       return t;
     }
   }

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/IteratorMultiplexer.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/IteratorMultiplexer.java
@@ -30,9 +30,10 @@ public class IteratorMultiplexer<T> implements AutoCloseable {
    * @param iterator The Iterator to read from.
    * @param splits The number of output iterators that will read from iterator.
    */
-  IteratorMultiplexer(Iterator<T> iterator, int splits) {
+  public IteratorMultiplexer(Iterator<T> iterator, int splits) {
     this.iterator = iterator;
     this.splits = splits;
+
     // Filled in when initializing iterators.
     iterators = new QueueIterator[splits];
     for (int x = 0; x < splits; x++) {

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ParallelArrowReader.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ParallelArrowReader.java
@@ -253,7 +253,7 @@ public class ParallelArrowReader implements AutoCloseable {
     try {
       AutoCloseables.close(readers);
     } catch (Exception e) {
-      throw new RuntimeException("Trouble closing delegate readers", e);
+      log.info("Trouble closing delegate readers", e);
     }
   }
 }

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ParallelArrowReader.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ParallelArrowReader.java
@@ -183,7 +183,7 @@ public class ParallelArrowReader implements AutoCloseable {
           readerLocks[readerIdx] = new CountDownLatch(1);
 
           final int idx = readerIdx;
-          Future<ArrowRecordBatch> future =
+          currentFuture =
               executor.submit(
                   () -> {
                     try {

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadRowsHelper.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadRowsHelper.java
@@ -30,7 +30,7 @@ import java.util.NoSuchElementException;
 
 import static java.util.Objects.requireNonNull;
 
-public class ReadRowsHelper {
+public class ReadRowsHelper implements AutoCloseable {
   private static final Logger logger = LoggerFactory.getLogger(ReadRowsHelper.class);
   private final Options options;
 
@@ -55,7 +55,7 @@ public class ReadRowsHelper {
     }
 
     public int numBackgroundThreads() {
-      return numBackgroundThreads();
+      return backgroundParsingThreads;
     }
   }
 
@@ -139,6 +139,7 @@ public class ReadRowsHelper {
     }
   }
 
+  @Override
   public void close() {
     if (incomingStream != null) {
       try {

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadRowsHelper.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadRowsHelper.java
@@ -38,9 +38,11 @@ public class ReadRowsHelper {
     private final int maxReadRowsRetries;
     private final String nullableEndpoint;
 
-    public Options(int maxReadRowsRetries, Optional<String> endpoint) {
+    public Options(int maxReadRowsRetries, Optional<String> endpoint,
+        int backgroundParsingThreads) {
       this.maxReadRowsRetries = maxReadRowsRetries;
       this.nullableEndpoint = endpoint.orElse(null);
+      this.backgroundParsingThreads = backgroundParsingThreads;
     }
 
     public int getMaxReadRowsRetries() {

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadRowsHelper.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadRowsHelper.java
@@ -37,9 +37,10 @@ public class ReadRowsHelper {
   public static final class Options implements Serializable {
     private final int maxReadRowsRetries;
     private final String nullableEndpoint;
+    private final int backgroundParsingThreads;
 
-    public Options(int maxReadRowsRetries, Optional<String> endpoint,
-        int backgroundParsingThreads) {
+    public Options(
+        int maxReadRowsRetries, Optional<String> endpoint, int backgroundParsingThreads) {
       this.maxReadRowsRetries = maxReadRowsRetries;
       this.nullableEndpoint = endpoint.orElse(null);
       this.backgroundParsingThreads = backgroundParsingThreads;
@@ -51,6 +52,10 @@ public class ReadRowsHelper {
 
     public Optional<String> getEndpoint() {
       return Optional.ofNullable(nullableEndpoint);
+    }
+
+    public int numBackgroundThreads() {
+      return numBackgroundThreads();
     }
   }
 

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadRowsResponseInputStreamEnumeration.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadRowsResponseInputStreamEnumeration.java
@@ -1,0 +1,52 @@
+package com.google.cloud.bigquery.connector.common;
+
+import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * Instrumented {@link java.util.Enumeration} for translating bytes received from the BQ Storage API
+ * to continuous input streams.
+ */
+public class ReadRowsResponseInputStreamEnumeration implements java.util.Enumeration<InputStream> {
+
+  private final Iterator<ReadRowsResponse> responses;
+  private ReadRowsResponse currentResponse;
+  private final BigQueryStorageReadRowsTracer tracer;
+
+  public ReadRowsResponseInputStreamEnumeration(
+      Iterator<ReadRowsResponse> responses, BigQueryStorageReadRowsTracer tracer) {
+    this.responses = responses;
+    this.tracer = tracer;
+    loadNextResponse();
+  }
+
+  public boolean hasMoreElements() {
+    return currentResponse != null;
+  }
+
+  public InputStream nextElement() {
+    if (!hasMoreElements()) {
+      throw new NoSuchElementException("No more responses");
+    }
+    ReadRowsResponse ret = currentResponse;
+    loadNextResponse();
+    return ret.getArrowRecordBatch().getSerializedRecordBatch().newInput();
+  }
+
+  void loadNextResponse() {
+    // hasNext is actually the blocking call, so call  readRowsResponseRequested
+    // here.
+    tracer.readRowsResponseRequested();
+    if (responses.hasNext()) {
+      currentResponse = responses.next();
+    } else {
+      currentResponse = null;
+    }
+    tracer.readRowsResponseObtained(
+        currentResponse == null
+            ? 0
+            : currentResponse.getArrowRecordBatch().getSerializedRecordBatch().size());
+  }
+}

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfig.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfig.java
@@ -33,6 +33,7 @@ public class ReadSessionCreatorConfig {
   private final int defaultParallelism;
   private final Optional<String> requestEncodedBase;
   private final Optional<String> endpoint;
+  private final int backgroundParsingThreads;
 
   ReadSessionCreatorConfig(
       boolean viewsEnabled,
@@ -45,7 +46,8 @@ public class ReadSessionCreatorConfig {
       OptionalInt maxParallelism,
       int defaultParallelism,
       Optional<String> requestEncodedBase,
-      Optional<String> endpoint) {
+      Optional<String> endpoint,
+      int backgroundParsingThreads) {
     this.viewsEnabled = viewsEnabled;
     this.materializationProject = materializationProject;
     this.materializationDataset = materializationDataset;
@@ -57,6 +59,7 @@ public class ReadSessionCreatorConfig {
     this.defaultParallelism = defaultParallelism;
     this.requestEncodedBase = requestEncodedBase;
     this.endpoint = endpoint;
+    this.backgroundParsingThreads = backgroundParsingThreads;
   }
 
   public boolean isViewsEnabled() {

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfig.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfig.java
@@ -103,7 +103,12 @@ public class ReadSessionCreatorConfig {
     return this.endpoint;
   }
 
+  public int backgroundParsingThreads() {
+    return this.backgroundParsingThreads;
+  }
+
   public ReadRowsHelper.Options toReadRowsHelperOptions() {
-    return new ReadRowsHelper.Options(getMaxReadRowsRetries(), endpoint());
+    return new ReadRowsHelper.Options(
+        getMaxReadRowsRetries(), endpoint(), backgroundParsingThreads());
   }
 }

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfigBuilder.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfigBuilder.java
@@ -17,6 +17,7 @@ public class ReadSessionCreatorConfigBuilder {
   private int defaultParallelism = 1000;
   private Optional<String> requestEncodedBase = Optional.empty();
   private Optional<String> endpoint = Optional.empty();
+  private int backgroundParsingThreads = 0;
 
   public ReadSessionCreatorConfigBuilder setViewsEnabled(boolean viewsEnabled) {
     this.viewsEnabled = viewsEnabled;
@@ -77,6 +78,11 @@ public class ReadSessionCreatorConfigBuilder {
     return this;
   }
 
+  public ReadSessionCreatorConfigBuilder setBackgroundParsingThreads(int backgroundParsingThreads) {
+    this.backgroundParsingThreads = backgroundParsingThreads;
+    return this;
+  }
+
   public ReadSessionCreatorConfig build() {
     return new ReadSessionCreatorConfig(
         viewsEnabled,
@@ -89,6 +95,7 @@ public class ReadSessionCreatorConfigBuilder {
         maxParallelism,
         defaultParallelism,
         requestEncodedBase,
-        endpoint);
+        endpoint,
+        backgroundParsingThreads);
   }
 }

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -115,6 +115,7 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
   int maxReadRowsRetries = 3;
   private com.google.common.base.Optional<String> encodedCreateReadSessionRequest = empty();
   private com.google.common.base.Optional<String> storageReadEndpoint = empty();
+  private int numBackgroundThreadsPerStream = 0;
 
   @VisibleForTesting
   SparkBigQueryConfig() {
@@ -272,6 +273,8 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
     config.storageReadEndpoint = getAnyOption(globalOptions, options, "bqStorageReadEndpoint");
     config.encodedCreateReadSessionRequest =
         getAnyOption(globalOptions, options, "bqEncodedCreateReadSessionRequest");
+    config.numBackgroundThreadsPerStream =
+        getAnyOption(globalOptions, options, "bqBackgroundThreadsPerStream").transform(Integer::parseInt).or(0);
 
     return config;
   }
@@ -570,6 +573,7 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
         .setMaxParallelism(getMaxParallelism())
         .setRequestEncodedBase(encodedCreateReadSessionRequest.toJavaUtil())
         .setEndpoint(storageReadEndpoint.toJavaUtil())
+        .setBackgroundParsingThreads(numBackgroundThreadsPerStream)
         .build();
   }
 

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -274,7 +274,9 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
     config.encodedCreateReadSessionRequest =
         getAnyOption(globalOptions, options, "bqEncodedCreateReadSessionRequest");
     config.numBackgroundThreadsPerStream =
-        getAnyOption(globalOptions, options, "bqBackgroundThreadsPerStream").transform(Integer::parseInt).or(0);
+        getAnyOption(globalOptions, options, "bqBackgroundThreadsPerStream")
+            .transform(Integer::parseInt)
+            .or(0);
 
     return config;
   }

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowColumnBatchPartitionReader.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowColumnBatchPartitionReader.java
@@ -55,6 +55,8 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.sql.sources.v2.reader.InputPartitionReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class ArrowColumnBatchPartitionColumnBatchReader implements InputPartitionReader<ColumnarBatch> {
   private static final long maxAllocation = 500 * 1024 * 1024;

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowColumnBatchPartitionReader.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowColumnBatchPartitionReader.java
@@ -103,21 +103,24 @@ class ArrowColumnBatchPartitionColumnBatchReader implements InputPartitionReader
         ExecutorService executor,
         BigQueryStorageReadRowsTracer tracer,
         AutoCloseable closeable) {
-      if (closeable != null) {
-        closeables.add(closeable);
-      }
       Schema schema = null;
       try {
         schema = readers.get(0).getVectorSchemaRoot().getSchema();
       } catch (IOException e) {
         initialException = e;
         closeables.addAll(readers);
+        closeables.add(closeable);
+        this.reader = null;
+        this.loader = null;
+        this.root = null;
+        return;
       }
       root = VectorSchemaRoot.create(schema, allocator);
       closeables.add(root);
       loader = new VectorLoader(root);
       this.reader = new ParallelArrowReader(readers, executor, loader, tracer);
       closeables.add(reader);
+      closeables.add(closeable);
     }
 
     @Override

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowColumnBatchPartitionReader.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowColumnBatchPartitionReader.java
@@ -55,7 +55,6 @@ import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.sql.sources.v2.reader.InputPartitionReader;
-import spire.macros.Auto;
 
 class ArrowColumnBatchPartitionColumnBatchReader implements InputPartitionReader<ColumnarBatch> {
   private static final long maxAllocation = 500 * 1024 * 1024;
@@ -202,7 +201,7 @@ class ArrowColumnBatchPartitionColumnBatchReader implements InputPartitionReader
             new SequenceInputStream(
                 new ReadRowsResponseInputStreamEnumeration(
                     multiplexer.getSplit(x), tracer.forkWithPrefix("multiplexed-" + x)));
-        InputStream schemaAndBatches = new SequenceInputStream(schema.newInput(), batchStream);
+        InputStream schemaAndBatches = new SequenceInputStream(schema.newInput(), responseStream);
         readers.add(newArrowStreamReader(schemaAndBatches));
       }
       reader =

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowColumnBatchPartitionReader.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowColumnBatchPartitionReader.java
@@ -176,14 +176,13 @@ class ArrowColumnBatchPartitionColumnBatchReader implements InputPartitionReader
     this.userProvidedFieldMap =
         userProvidedFieldList.stream().collect(Collectors.toMap(StructField::name, field -> field));
 
-    // There is a background thread created by ParallelArrowReader that serves
-    // as a thread to do parsing on.
-
     InputStream batchStream =
         new SequenceInputStream(
             new ReadRowsResponseInputStreamEnumeration(readRowsResponses, tracer));
     InputStream fullStream = new SequenceInputStream(schema.newInput(), batchStream);
     if (numBackgroundThreads == 1) {
+      // There is a background thread created by ParallelArrowReader that serves
+      // as a thread to do parsing on.
       reader =
           new ParallelReaderAdapter(
               allocator,
@@ -193,7 +192,7 @@ class ArrowColumnBatchPartitionColumnBatchReader implements InputPartitionReader
               /*closeable=*/ null);
     } else if (numBackgroundThreads > 1) {
       // Subtract one because current excess tasks will be executed
-      // on round robin thread.
+      // on round robin thread in ParallelArrowReader.
       int threads = numBackgroundThreads - 1;
       ExecutorService backgroundParsingService =
           new ThreadPoolExecutor(

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowInputPartition.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowInputPartition.java
@@ -76,6 +76,7 @@ public class ArrowInputPartition implements InputPartition<ColumnarBatch> {
         readRowsHelper,
         selectedFields,
         tracer,
-        userProvidedSchema.toJavaUtil());
+        userProvidedSchema.toJavaUtil(),
+        options.numBackgroundThreads());
   }
 }

--- a/connector/src/test/java/com/google/cloud/bigquery/connector/common/IteratorMultiplexerTest.java
+++ b/connector/src/test/java/com/google/cloud/bigquery/connector/common/IteratorMultiplexerTest.java
@@ -79,7 +79,7 @@ public class IteratorMultiplexerTest {
       executorService.shutdownNow();
       assertThat(executorService.awaitTermination(100, TimeUnit.MILLISECONDS)).isTrue();
       assertThat(executorService.isTerminated());
-      assertThrows(RuntimeException.class, multiplexer::close);
+      multiplexer.close();
     }
   }
 
@@ -120,7 +120,7 @@ public class IteratorMultiplexerTest {
               exited.countDown();
             });
       }
-      Exception thrown = assertThrows(Exception.class, multiplexer::close);
+      multiplexer.close();
 
       assertThat(exited.await(3, TimeUnit.SECONDS)).isTrue();
       executorService.shutdown();

--- a/connector/src/test/java/com/google/cloud/bigquery/connector/common/ParallelArrowReaderTest.java
+++ b/connector/src/test/java/com/google/cloud/bigquery/connector/common/ParallelArrowReaderTest.java
@@ -95,7 +95,11 @@ public class ParallelArrowReaderTest {
         VectorSchemaRoot.create(r1.getVectorSchemaRoot().getSchema(), allocator)) {
       VectorLoader loader = new VectorLoader(root);
       ParallelArrowReader reader =
-          new ParallelArrowReader(ImmutableList.of(r1, r2, r3), executor, loader);
+          new ParallelArrowReader(
+              ImmutableList.of(r1, r2, r3),
+              executor,
+              loader,
+              new LoggingBigQueryStorageReadRowsTracer("stream_name", 2));
 
       while (reader.next()) {
         read.add(((IntVector) root.getVector(0)).get(0));
@@ -118,7 +122,11 @@ public class ParallelArrowReaderTest {
     ExecutorService executor = MoreExecutors.newDirectExecutorService();
     try (VectorSchemaRoot root = new VectorSchemaRoot(ImmutableList.of())) {
       ParallelArrowReader reader =
-          new ParallelArrowReader(ImmutableList.of(r1), executor, new VectorLoader(root));
+          new ParallelArrowReader(
+              ImmutableList.of(r1),
+              executor,
+              new VectorLoader(root),
+              new LoggingBigQueryStorageReadRowsTracer("stream_name", 2));
       IOException e = Assert.assertThrows(IOException.class, reader::next);
       assertThat(e).isSameInstanceAs(exception);
     }
@@ -144,7 +152,11 @@ public class ParallelArrowReaderTest {
 
       ExecutorService executor = Executors.newSingleThreadExecutor();
       ParallelArrowReader reader =
-          new ParallelArrowReader(ImmutableList.of(r1, r2), executor, loader);
+          new ParallelArrowReader(
+              ImmutableList.of(r1, r2),
+              executor,
+              loader,
+              new LoggingBigQueryStorageReadRowsTracer("stream_name", 2));
 
       ExecutorService oneOff = Executors.newSingleThreadExecutor();
       Instant start = Instant.now();

--- a/connector/src/test/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorTest.java
+++ b/connector/src/test/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorTest.java
@@ -49,7 +49,9 @@ public class ReadSessionCreatorTest {
 
   @Test
   public void testSerializedInstanceIsPropagated() throws Exception {
-    ReadSession readSession = ReadSession.newBuilder().setName("abc").build();
+    TableReadOptions tableReadOptions = TableReadOptions.newBuilder().build();
+    ReadSession readSession =
+        ReadSession.newBuilder().setName("abc").setReadOptions(tableReadOptions).build();
     CreateReadSessionRequest request =
         CreateReadSessionRequest.newBuilder().setReadSession(readSession).build();
     Optional<String> encodedBase =

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/v2/BigQueryInputPartitionTest.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/v2/BigQueryInputPartitionTest.java
@@ -19,7 +19,8 @@ public class BigQueryInputPartitionTest {
                 /*bigQueryClientFactory=*/ null,
                 /*tracerFactory=*/ null,
                 "streamName",
-                new ReadRowsHelper.Options(/*maxRetries=*/ 5, Optional.of("endpoint")),
+                new ReadRowsHelper.Options(
+                    /*maxRetries=*/ 5, Optional.of("endpoint"), /*backgroundParsingThreads=*/ 5),
                 null,
                 new ReadSessionResponse(ReadSession.getDefaultInstance(), null),
                 null));

--- a/connector/src/test/scala/com/google/cloud/spark/bigquery/it/SparkBigQueryEndToEndReadITSuite.scala
+++ b/connector/src/test/scala/com/google/cloud/spark/bigquery/it/SparkBigQueryEndToEndReadITSuite.scala
@@ -130,6 +130,40 @@ class SparkBigQueryEndToEndReadITSuite extends FunSuite
       .option("table", SHAKESPEARE_TABLE).load()
   }
 
+  testShakespeare("DataSource v2 - compressed") {
+    val df = spark.read.format("com.google.cloud.spark.bigquery.v2.BigQueryDataSourceV2")
+      .option("table", SHAKESPEARE_TABLE)
+      .option("bqEncodedCreateReadSessionRequest", "EgZCBBoCEAI=")
+      .load()
+    // Test early termination succeeds
+    df.head
+    df
+  }
+
+
+  testShakespeare("DataSource v2 - compressed 1 background threads") {
+    val df = spark.read.format("com.google.cloud.spark.bigquery.v2.BigQueryDataSourceV2")
+      .option("table", SHAKESPEARE_TABLE)
+      .option("bqEncodedCreateReadSessionRequest", "EgZCBBoCEAI=")
+      .option("bqBackgroundThreadsPerStream", "1")
+      .load()
+    // Test early termination succeeds
+    df.head
+    df
+  }
+
+  testShakespeare("DataSource v2 - compressed 2 background threads") {
+    val df = spark.read.format("com.google.cloud.spark.bigquery.v2.BigQueryDataSourceV2")
+      .option("table", SHAKESPEARE_TABLE)
+      .option("bqEncodedCreateReadSessionRequest", "EgZCBBoCEAI=")
+      .option("bqBackgroundThreadsPerStream", "2")
+      .load()
+    // Test early termination succeeds
+    df.head
+    df
+
+  }
+
   for (
     dataFormat <- Seq("avro", "arrow");
     dataSourceFormat <- Seq("bigquery", "com.google.cloud.spark.bigquery.v2.BigQueryDataSourceV2")

--- a/connector/src/test/scala/com/google/cloud/spark/bigquery/it/SparkBigQueryEndToEndReadITSuite.scala
+++ b/connector/src/test/scala/com/google/cloud/spark/bigquery/it/SparkBigQueryEndToEndReadITSuite.scala
@@ -152,11 +152,11 @@ class SparkBigQueryEndToEndReadITSuite extends FunSuite
     df
   }
 
-  testShakespeare("DataSource v2 - compressed 2 background threads") {
+  testShakespeare("DataSource v2 - compressed 4 background threads") {
     val df = spark.read.format("com.google.cloud.spark.bigquery.v2.BigQueryDataSourceV2")
       .option("table", SHAKESPEARE_TABLE)
       .option("bqEncodedCreateReadSessionRequest", "EgZCBBoCEAI=")
-      .option("bqBackgroundThreadsPerStream", "2")
+      .option("bqBackgroundThreadsPerStream", "4")
       .load()
     // Test early termination succeeds
     df.head


### PR DESCRIPTION
- This can potentially help mitigate any overhead decompression adds.  
- Fixed some bugs with existing classes along with some additional refactoring:
   *  Move enumeration to its own class under common.
   *  Don't rethrow for multiplexer or parrallel arrow reader on close (this breaks the ".show" use-case
   * Make sure not to lose track of a future when background thread in parallel reader can be interrupted on placing into 
      the queue.
   *  Adds some more logging.
- Makes better use of child allocators to appropriately track memory for each thread (and remove a previously unncessary child allocator).


One more interesting extension that might help improve throghput is adding more then 1 stream per partition (might improve throughput).