### PR TITLE
Fix variable declarations in ParallelArrowReader.

### DIFF
--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ParallelArrowReader.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ParallelArrowReader.java
@@ -55,12 +55,13 @@ public class ParallelArrowReader implements AutoCloseable {
   // Visible for testing.
   static final int POLL_TIME = 100;
   private final BlockingQueue<Future<ArrowRecordBatch>> queue;
-  Future<ArrowRecordBatch> currentFuture;
   private final List<ArrowReader> readers;
   private final ExecutorService executor;
   private final VectorLoader loader;
   private final BigQueryStorageReadRowsTracer rootTracer;
-  BigQueryStorageReadRowsTracer tracers[];
+  private final BigQueryStorageReadRowsTracer tracers[];
+
+  private volatile Future<ArrowRecordBatch> currentFuture;
 
   // Whether processing of delegates is finished.
   private volatile boolean done = false;


### PR DESCRIPTION
The additional of volatile for currentFuture is likely needed for
correctness.  Otherwise when closing the reader there are likely
no guarantees that a non-null value will be seen from the closing thread
and therefore a memory leak can occur.