### PR TITLE
Fix next() to be interrupt safe.

### DIFF
--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/NonInterruptibleBlockingBytesChannel.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/NonInterruptibleBlockingBytesChannel.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.bigquery.connector.common;
 
 import java.io.IOException;

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/NonInterruptibleBlockingBytesChannel.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/NonInterruptibleBlockingBytesChannel.java
@@ -33,7 +33,7 @@ public class NonInterruptibleBlockingBytesChannel implements ReadableByteChannel
   private static final int TRANSFER_SIZE = 4096;
   private final InputStream is;
   private boolean closed = false;
-  private byte[] transferBuffer = new byte[512];
+  private byte[] transferBuffer = new byte[TRANSFER_SIZE];
 
   public NonInterruptibleBlockingBytesChannel(InputStream is) {
     this.is = is;
@@ -47,10 +47,6 @@ public class NonInterruptibleBlockingBytesChannel implements ReadableByteChannel
 
     while (totalRead < len) {
       int bytesToRead = Math.min((len - totalRead), TRANSFER_SIZE);
-      if (transferBuffer.length < bytesToRead) {
-        transferBuffer = new byte[bytesToRead];
-      }
-
       bytesRead = is.read(transferBuffer, 0, bytesToRead);
       if (bytesRead < 0) {
         break;
@@ -59,7 +55,9 @@ public class NonInterruptibleBlockingBytesChannel implements ReadableByteChannel
       }
       dst.put(transferBuffer, 0, bytesRead);
     }
-    if ((bytesRead < 0) && (totalRead == 0)) return -1;
+    if ((bytesRead < 0) && (totalRead == 0)) {
+      return -1;
+    }
 
     return totalRead;
   }

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/NonInterruptibleBlockingBytesChannel.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/NonInterruptibleBlockingBytesChannel.java
@@ -30,10 +30,10 @@ import java.nio.channels.ReadableByteChannel;
  * full message boundaries, which should be sufficient for our use-cases.
  */
 public class NonInterruptibleBlockingBytesChannel implements ReadableByteChannel {
+  private static final int TRANSFER_SIZE = 4096;
   private final InputStream is;
   private boolean closed = false;
-  private static final int TRANSFER_SIZE = 4096;
-  byte[] transfer_buffer = new byte[512];
+  private byte[] transferBuffer = new byte[512];
 
   public NonInterruptibleBlockingBytesChannel(InputStream is) {
     this.is = is;
@@ -47,12 +47,17 @@ public class NonInterruptibleBlockingBytesChannel implements ReadableByteChannel
 
     while (totalRead < len) {
       int bytesToRead = Math.min((len - totalRead), TRANSFER_SIZE);
-      if (transfer_buffer.length < bytesToRead) transfer_buffer = new byte[bytesToRead];
+      if (transferBuffer.length < bytesToRead) {
+        transferBuffer = new byte[bytesToRead];
+      }
 
-      bytesRead = is.read(transfer_buffer, 0, bytesToRead);
-      if (bytesRead < 0) break;
-      else totalRead += bytesRead;
-      dst.put(transfer_buffer, 0, bytesRead);
+      bytesRead = is.read(transferBuffer, 0, bytesToRead);
+      if (bytesRead < 0) {
+        break;
+      } else {
+        totalRead += bytesRead;
+      }
+      dst.put(transferBuffer, 0, bytesRead);
     }
     if ((bytesRead < 0) && (totalRead == 0)) return -1;
 

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ParallelArrowReader.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ParallelArrowReader.java
@@ -216,10 +216,11 @@ public class ParallelArrowReader implements AutoCloseable {
                           /*bytesReceived=*/ incrementalBytesRead);
                       lastBytesRead[idx] = reader.bytesRead();
                     } catch (IOException e) {
+                      log.info("IOException while consuming reader.", e);
                       readException = e;
                       hasData[idx].set(false);
                     } catch (Exception e) {
-                      readException = new IOException("failed to consume readers", e);
+                      readException = new IOException("Failed to consume readers", e);
                       hasData[idx].set(false);
                     }
                     ArrowRecordBatch batch = null;
@@ -243,9 +244,10 @@ public class ParallelArrowReader implements AutoCloseable {
         }
       }
     } catch (IOException e) {
+      log.info("Error while reading in streams", e);
       readException = e;
     } catch (InterruptedException e) {
-      log.debug("Reader thread interrupted.");
+      log.info("Reader thread interrupted.");
     }
     done = true;
   }
@@ -280,7 +282,6 @@ public class ParallelArrowReader implements AutoCloseable {
       }
     } catch (InterruptedException e) {
       log.info("Interrupted when awaiting executor termination");
-      // Nothing to do here.
     }
 
     int inProgress = 0;

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ParallelArrowReader.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ParallelArrowReader.java
@@ -104,7 +104,9 @@ public class ParallelArrowReader implements AutoCloseable {
         log.warn("Exception caught when waiting for batch on second try.  Giving up.");
         throw new IOException(se);
       }
-      resolvedBatch.close();
+      if (resolvedBatch != null) {
+        resolvedBatch.close();
+      }
       throw e;
     } catch (ExecutionException e) {
       if (e.getCause() instanceof IOException) {

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ParallelArrowReader.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ParallelArrowReader.java
@@ -205,25 +205,20 @@ public class ParallelArrowReader implements AutoCloseable {
           readerLocks[readerIdx] = new CountDownLatch(1);
 
           final int idx = readerIdx;
-          log.info("Before submit");
           currentFuture =
               executor.submit(
                   () -> {
                     try {
                       tracers[idx].readRowsResponseRequested();
-                      log.info("loading batch");
                       hasData[idx].set(reader.loadNextBatch());
-                      log.info("batch loaded");
                       long incrementalBytesRead = reader.bytesRead() - lastBytesRead[idx];
                       tracers[idx].readRowsResponseObtained(
                           /*bytesReceived=*/ incrementalBytesRead);
                       lastBytesRead[idx] = reader.bytesRead();
                     } catch (IOException e) {
-                      log.info("io exception");
                       readException = e;
                       hasData[idx].set(false);
                     } catch (Exception e) {
-                      log.info("general exception");
                       readException = new IOException("failed to consume readers", e);
                       hasData[idx].set(false);
                     }
@@ -232,9 +227,7 @@ public class ParallelArrowReader implements AutoCloseable {
                       int rows = reader.getVectorSchemaRoot().getRowCount();
                       // Not quite parsing but re-use it here.
                       tracers[idx].rowsParseStarted();
-                      log.info("batch unloading");
                       batch = unloader[idx].getRecordBatch();
-                      log.info("batch unloaded");
                       tracers[idx].rowsParseFinished(rows);
                     } else {
                       int result = readersReady.addAndGet(-1);
@@ -245,18 +238,14 @@ public class ParallelArrowReader implements AutoCloseable {
                     readerLocks[idx].countDown();
                     return batch;
                   });
-          log.info("After submit");
           queue.put(currentFuture);
-          log.info("Enqueued");
           currentFuture = null;
-          log.info("cleared");
         }
       }
     } catch (IOException e) {
-      log.info("io exception caught.");
       readException = e;
     } catch (InterruptedException e) {
-      log.info("Reader thread interrupted.");
+      log.debug("Reader thread interrupted.");
     }
     done = true;
   }
@@ -300,7 +289,6 @@ public class ParallelArrowReader implements AutoCloseable {
       leftOverWork.add(currentFuture);
     }
     leftOverWork.addAll(queue);
-    log.info("Left over work: {}", leftOverWork.size());
     for (Future<ArrowRecordBatch> batch : leftOverWork) {
       if (batch != null) {
         if (batch.isDone()) {

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ParallelArrowReader.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ParallelArrowReader.java
@@ -272,7 +272,7 @@ public class ParallelArrowReader implements AutoCloseable {
       }
     }
     // Stop any queued tasks from processing.
-    executor.shutdown();
+    executor.shutdownNow();
 
     try {
       if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowColumnBatchPartitionReader.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowColumnBatchPartitionReader.java
@@ -125,7 +125,7 @@ class ArrowColumnBatchPartitionColumnBatchReader implements InputPartitionReader
       closeables.add(root);
       loader = new VectorLoader(root);
       this.reader = new ParallelArrowReader(readers, executor, loader, tracer);
-      closeables.add(reader);
+      closeables.add(0, reader);
       closeables.add(readerAllocator);
     }
 

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowColumnBatchPartitionReader.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowColumnBatchPartitionReader.java
@@ -292,6 +292,9 @@ class ArrowColumnBatchPartitionColumnBatchReader implements InputPartitionReader
     BufferAllocator childAllocator =
         allocator.newChildAllocator("readerAllocator" + (closeables.size() - 1), 0, maxAllocation);
     closeables.add(childAllocator);
-    return new ArrowStreamReader(new NonInterruptibleBlockingBytesChannel(fullStream), childAllocator, CommonsCompressionFactory.INSTANCE);
+    return new ArrowStreamReader(
+        new NonInterruptibleBlockingBytesChannel(fullStream),
+        childAllocator,
+        CommonsCompressionFactory.INSTANCE);
   }
 }

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowColumnBatchPartitionReader.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/ArrowColumnBatchPartitionReader.java
@@ -17,6 +17,7 @@ package com.google.cloud.spark.bigquery.v2;
 
 import com.google.cloud.bigquery.connector.common.ArrowUtil;
 import com.google.cloud.bigquery.connector.common.IteratorMultiplexer;
+import com.google.cloud.bigquery.connector.common.NonInterruptibleBlockingBytesChannel;
 import com.google.cloud.bigquery.connector.common.ParallelArrowReader;
 import com.google.cloud.bigquery.connector.common.ReadRowsHelper;
 import com.google.cloud.bigquery.connector.common.BigQueryStorageReadRowsTracer;
@@ -291,6 +292,6 @@ class ArrowColumnBatchPartitionColumnBatchReader implements InputPartitionReader
     BufferAllocator childAllocator =
         allocator.newChildAllocator("readerAllocator" + (closeables.size() - 1), 0, maxAllocation);
     closeables.add(childAllocator);
-    return new ArrowStreamReader(fullStream, childAllocator, CommonsCompressionFactory.INSTANCE);
+    return new ArrowStreamReader(new NonInterruptibleBlockingBytesChannel(fullStream), childAllocator, CommonsCompressionFactory.INSTANCE);
   }
 }

--- a/connector/src/test/java/com/google/cloud/bigquery/connector/common/ParallelArrowReaderTest.java
+++ b/connector/src/test/java/com/google/cloud/bigquery/connector/common/ParallelArrowReaderTest.java
@@ -177,8 +177,8 @@ public class ParallelArrowReaderTest {
       // Wait until next gets called.
       latch.await();
       // Should interrupt blocking operations.
+      oneOff.shutdownNow();
       reader.close();
-      oneOff.shutdown();
 
       assertThat(endTime.get()).isGreaterThan(start);
       assertThat(Duration.between(start, endTime.get()))


### PR DESCRIPTION
for some reason I did not think Spark would interrupted the thread calling
the next() method, I had trouble tracking this down but thinking more thorougly
about it I think spark could and probably does do this.  In this case
if the thread was interrupted while trying to get the next batch it is
possible for a memory leak to occur.

This also rearranges the close order for DSv2, so that everything shutdown more cleanly, this also could avoid whatever edge case we are seeing with memory leaks.

Unfortunately, the unit test change didn't replicate the flakiness, but
I still think these changes make the code safer.