### PR TITLE
Add options for tuning ReadRowsCalls.

### DIFF
--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfig.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfig.java
@@ -35,6 +35,8 @@ public class ReadSessionCreatorConfig {
   private final Optional<String> endpoint;
   private final int backgroundParsingThreads;
   private final boolean pushAllFilters;
+  private final int prebufferResponses;
+  private final int streamsPerPartition;
 
   ReadSessionCreatorConfig(
       boolean viewsEnabled,
@@ -49,7 +51,9 @@ public class ReadSessionCreatorConfig {
       Optional<String> requestEncodedBase,
       Optional<String> endpoint,
       int backgroundParsingThreads,
-      boolean pushAllFilters) {
+      boolean pushAllFilters,
+      int prebufferResponses,
+      int streamsPerPartition) {
     this.viewsEnabled = viewsEnabled;
     this.materializationProject = materializationProject;
     this.materializationDataset = materializationDataset;
@@ -63,6 +67,8 @@ public class ReadSessionCreatorConfig {
     this.endpoint = endpoint;
     this.backgroundParsingThreads = backgroundParsingThreads;
     this.pushAllFilters = pushAllFilters;
+    this.prebufferResponses = prebufferResponses;
+    this.streamsPerPartition = streamsPerPartition;
   }
 
   public boolean isViewsEnabled() {
@@ -119,6 +125,14 @@ public class ReadSessionCreatorConfig {
 
   public ReadRowsHelper.Options toReadRowsHelperOptions() {
     return new ReadRowsHelper.Options(
-        getMaxReadRowsRetries(), endpoint(), backgroundParsingThreads());
+        getMaxReadRowsRetries(), endpoint(), backgroundParsingThreads(), getPrebufferResponses());
+  }
+
+  public int streamsPerPartition() {
+    return streamsPerPartition;
+  }
+
+  public int getPrebufferResponses() {
+    return prebufferResponses;
   }
 }

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfigBuilder.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfigBuilder.java
@@ -19,6 +19,8 @@ public class ReadSessionCreatorConfigBuilder {
   private Optional<String> endpoint = Optional.empty();
   private int backgroundParsingThreads = 0;
   private boolean pushAllFilters = true;
+  int prebufferResponses = 1;
+  int streamsPerPartition = 1;
 
   public ReadSessionCreatorConfigBuilder setViewsEnabled(boolean viewsEnabled) {
     this.viewsEnabled = viewsEnabled;
@@ -89,6 +91,16 @@ public class ReadSessionCreatorConfigBuilder {
     return this;
   }
 
+  public ReadSessionCreatorConfigBuilder setPrebufferReadRowsResponses(int prebufferResponses) {
+    this.prebufferResponses = prebufferResponses;
+    return this;
+  }
+
+  public ReadSessionCreatorConfigBuilder setStreamsPerPartition(int streamsPerPartition) {
+    this.streamsPerPartition = streamsPerPartition;
+    return this;
+  }
+
   public ReadSessionCreatorConfig build() {
     return new ReadSessionCreatorConfig(
         viewsEnabled,
@@ -103,6 +115,8 @@ public class ReadSessionCreatorConfigBuilder {
         requestEncodedBase,
         endpoint,
         backgroundParsingThreads,
-        pushAllFilters);
+        pushAllFilters,
+        prebufferResponses,
+        streamsPerPartition);
   }
 }

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/StreamCombiningIterator.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/StreamCombiningIterator.java
@@ -65,12 +65,11 @@ public class StreamCombiningIterator implements Iterator<ReadRowsResponse> {
       }
 
       try {
-        completeStream(/*addEos=*/false);
+        completeStream(/*addEos=*/ false);
       } finally {
         Preconditions.checkState(
             responses.add(error), "Responses should always have capacity to add element");
       }
-
     }
   }
 
@@ -144,7 +143,7 @@ public class StreamCombiningIterator implements Iterator<ReadRowsResponse> {
       if (cancelled) {
         return;
       }
-      completeStream(/*addEos=*/true);
+      completeStream(/*addEos=*/ true);
     }
   }
 
@@ -156,7 +155,7 @@ public class StreamCombiningIterator implements Iterator<ReadRowsResponse> {
       if (hasActiveObservers()) {
         return;
       }
-      completeStream(/*addEos=*/true);
+      completeStream(/*addEos=*/ true);
     }
     for (Observer observer : observers) {
       observer.cancel();

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/StreamCombiningIterator.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/StreamCombiningIterator.java
@@ -1,0 +1,292 @@
+package com.google.cloud.bigquery.connector.common;
+
+import com.google.api.gax.rpc.ResponseObserver;
+import com.google.api.gax.rpc.StreamController;
+import com.google.cloud.bigquery.storage.v1.BigQueryReadClient;
+import com.google.cloud.bigquery.storage.v1.ReadRowsRequest;
+import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/**
+ * An iterator that combines one or more ReadRows requests into a single iterator. Ordering of
+ * messages is not guaranteed from the streams.
+ *
+ * <p>This is adapated fro ServerStream in gax. In comparison toServerStream, this implementation
+ * also buffers more a configured number of responses instead of a single one. For connections with
+ * high latency between client and server this can processing costs. It also allows combining one or
+ * more ReadRows calls into single iterator to potentially increase perceived client throughput if
+ * that becomes a bottleneck for processing.
+ */
+public class StreamCombiningIterator implements Iterator<ReadRowsResponse> {
+  private static final Object EOS = new Object();
+  // Contains either a ReadRowsResponse, or a terminal object of throwable OR EOS
+  // This class is engineered keep responses below capacity unless a terminal state has
+  // been reached.
+  private final ArrayBlockingQueue<Object> responses;
+  private final ArrayBlockingQueue<Observer> observersQueue;
+  private final AtomicInteger observersLeft;
+  private final int bufferPerStream;
+  private final int numRetries;
+  private final Object lock = new Object();
+  private final BigQueryReadClient client;
+  Object last;
+  volatile boolean cancelled = false;
+  private final Collection<Observer> observers;
+
+  StreamCombiningIterator(
+      BigQueryReadClient client,
+      Collection<ReadRowsRequest.Builder> requests,
+      int bufferPerStream,
+      int numRetries) {
+    this.client = client;
+    observersLeft = new AtomicInteger(requests.size());
+    this.bufferPerStream = bufferPerStream;
+    // + 1 to leave space for terminal object.
+    if (bufferPerStream < 1) {
+      bufferPerStream = 1;
+    }
+    responses = new ArrayBlockingQueue<>((requests.size() * bufferPerStream) + 1);
+    observersQueue = new ArrayBlockingQueue<>(requests.size() * bufferPerStream);
+    this.numRetries = numRetries;
+    observers = requests.stream().map(Observer::new).collect(Collectors.toList());
+  }
+
+  synchronized void stopWithError(Throwable error) {
+    synchronized (lock) {
+      if (cancelled) {
+        return;
+      }
+      cancelled = true;
+      observersLeft.set(0);
+      Preconditions.checkState(
+          responses.add(error), "Responses should always have capacity to add element");
+    }
+  }
+
+  private boolean hasActiveObservers() {
+    return observersLeft.get() > 0;
+  }
+
+  /**
+   * Consumes the next response and asynchronously request the next response from the observer.
+   *
+   * @return The next response.
+   * @throws NoSuchElementException If the stream has been consumed or cancelled.
+   */
+  @Override
+  public ReadRowsResponse next() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    try {
+      Observer observer = observersQueue.poll();
+      Preconditions.checkState(observer != null);
+      observer.request();
+      @SuppressWarnings("unchecked")
+      ReadRowsResponse tmp = (ReadRowsResponse) last;
+      return tmp;
+    } finally {
+      if (last != EOS) {
+        last = null;
+      }
+    }
+  }
+
+  /**
+   * Checks if the stream has been fully consumed or cancelled. This method will block until the
+   * observer enqueues another event (response or completion event). If the observer encountered an
+   * error, this method will propagate the error and put itself into an error where it will always
+   * return the same error.
+   *
+   * @return true If iterator has more responses.
+   */
+  @Override
+  public boolean hasNext() {
+    if (last == null) {
+      try {
+        last = responses.take();
+      } catch (InterruptedException e) {
+        cancel();
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      }
+    }
+    // Preserve async error while keeping the caller's stacktrace as a suppressed exception
+    if (last instanceof RuntimeException) {
+      RuntimeException runtimeException = (RuntimeException) last;
+      runtimeException.addSuppressed(new RuntimeException("Asynchronous task failed"));
+      throw runtimeException;
+    }
+
+    // This should never really happen because currently gax doesn't throw checked exceptions.
+    // Wrap checked exceptions. This will preserve both the caller's stacktrace and the async error.
+    if (last instanceof Throwable) {
+      Throwable throwable = (Throwable) last;
+      throw new UncheckedExecutionException(throwable);
+    }
+
+    return last != EOS;
+  }
+
+  public void cancel() {
+    synchronized (lock) {
+      if (cancelled) {
+        return;
+      }
+      completeStream();
+    }
+  }
+
+  private void maybeFinished() {
+    synchronized (lock) {
+      if (cancelled) {
+        return;
+      }
+      if (hasActiveObservers()) {
+        return;
+      }
+      completeStream();
+    }
+    for (Observer observer : observers) {
+      observer.cancel();
+    }
+  }
+
+  private void completeStream() {
+    cancelled = true;
+    responses.add(EOS);
+    observersLeft.set(0);
+  }
+
+  private void newConnection(Observer observer, ReadRowsRequest.Builder request) {
+    synchronized (lock) {
+      if (!cancelled) {
+        client.readRowsCallable().call(request.build(), observer);
+      }
+    }
+  }
+
+  class Observer implements ResponseObserver<ReadRowsResponse> {
+    /* Offset into the stream that this is processing. */
+    private long readRowsCount = 0;
+    /* Number of retries so far on this observer */
+    private int retries = 0;
+    /**
+     * All methods accessing controller must be synchronized using controllerLock. The states of
+     * this object are: - Fresh object: null - Stream ready (receiving responses): not null -
+     * Retrying stream: null - Stream Finished: null
+     */
+    StreamController controller;
+    // Number of responses enqueued in the main iterator.
+    AtomicInteger enqueuedCount = new AtomicInteger(0);
+    private final Object controllerLock = new Object();
+
+    // The ReadRows request.  Uses a builder so offset can easily be set for retry.
+    ReadRowsRequest.Builder builder;
+
+    Observer(ReadRowsRequest.Builder builder) {
+      this.builder = builder;
+      newConnection(this, builder);
+    }
+
+    @Override
+    public void onResponse(ReadRowsResponse value) {
+      readRowsCount += value.getRowCount();
+      // Note we don't take a global lock here, so ordering of observers might be different then
+      // responses.  This should be OK because it should balance out in the end (there should
+      // never be more then bufferResponses enquered from any given observer at any time).
+      // Ordering is important to ensure there is always an observer present for the given response.
+      Preconditions.checkState(observersQueue.add(this));
+      Preconditions.checkState(responses.add(value), "Expected capacity in responses");
+      int enqueued = enqueuedCount.incrementAndGet();
+    }
+
+    @Override
+    public void onStart(StreamController controller) {
+      synchronized (StreamCombiningIterator.this.lock) {
+        if (cancelled) {
+          controller.cancel();
+          return;
+        }
+        synchronized (controllerLock) {
+          this.controller = controller;
+
+          controller.disableAutoInboundFlowControl();
+          int requestCount = bufferPerStream - enqueuedCount.get();
+          if (requestCount > 0) {
+            controller.request(requestCount);
+          }
+        }
+      }
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      // if relevant, retry the read, from the last read position
+      if (BigQueryUtil.isRetryable(t) && retries < numRetries) {
+        synchronized (controllerLock) {
+          controller = null;
+        }
+        builder.setOffset(readRowsCount);
+        newConnection(this, builder);
+        retries++;
+      } else {
+        stopWithError(t);
+      }
+    }
+
+    @Override
+    public void onComplete() {
+      synchronized (controllerLock) {
+        controller = null;
+      }
+      int left = observersLeft.decrementAndGet();
+      maybeFinished();
+    }
+
+    public synchronized void request() {
+      if (cancelled) {
+        return;
+      }
+      boolean canExit = false;
+      while (!canExit) {
+        synchronized (controllerLock) {
+          enqueuedCount.decrementAndGet();
+          if (controller == null) {
+            return;
+          }
+
+          // When not null there are a few cases to consider:
+          // 1.  Stream is active, so we want to request here.
+          // 2.  Stream is active but onError has been called and blocked on the lock.
+          //     In this case by decrementing above the new request should be taken care
+          //     after clearing and creating the new stream.
+          // 3.  The stream has no more messages.
+          // 4.  Stream is inactive (still initializing).
+          try {
+            controller.request(1);
+            canExit = true;
+          } catch (RuntimeException e) {
+            // controller might not be started and javadoc isn't clear if it is on its path
+            // to shutdown on what should happen.
+          }
+        }
+      }
+    }
+
+    public void cancel() {
+      synchronized (controllerLock) {
+        if (controller != null) {
+          controller.cancel();
+        }
+      }
+    }
+  }
+}

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/StreamCombiningIterator.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/StreamCombiningIterator.java
@@ -48,8 +48,10 @@ public class StreamCombiningIterator implements Iterator<ReadRowsResponse> {
     this.client = client;
     observersLeft = new AtomicInteger(requests.size());
     this.bufferEntriesPerStream = bufferEntriesPerStream;
-    Preconditions.checkArgument(this.bufferEntriesPerStream > 0,
-        "bufferEntriesPerstream must be positive.  Received: %s", this.bufferEntriesPerStream);
+    Preconditions.checkArgument(
+        this.bufferEntriesPerStream > 0,
+        "bufferEntriesPerstream must be positive.  Received: %s",
+        this.bufferEntriesPerStream);
     // + 1 to leave space for terminal object.
     responses = new ArrayBlockingQueue<>((requests.size() * this.bufferEntriesPerStream) + 1);
     observersQueue = new ArrayBlockingQueue<>(requests.size() * this.bufferEntriesPerStream);

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -119,6 +119,8 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
   private com.google.common.base.Optional<String> encodedCreateReadSessionRequest = empty();
   private com.google.common.base.Optional<String> storageReadEndpoint = empty();
   private int numBackgroundThreadsPerStream = 0;
+  private int numPrebufferReadRowsResponses = 1;
+  private int numStreamsPerPartition = 1;
 
   @VisibleForTesting
   SparkBigQueryConfig() {
@@ -281,6 +283,14 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
             .transform(Integer::parseInt)
             .or(0);
     config.pushAllFilters = getAnyBooleanOption(globalOptions, options, "pushAllFilters", true);
+    config.numPrebufferReadRowsResponses =
+        getAnyOption(globalOptions, options, "bqPrebufferResponsesPerStream")
+            .transform(Integer::parseInt)
+            .or(1);
+    config.numStreamsPerPartition =
+        getAnyOption(globalOptions, options, "bqNumStreamsPerPartition")
+            .transform(Integer::parseInt)
+            .or(1);
 
     return config;
   }
@@ -591,6 +601,8 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
         .setEndpoint(storageReadEndpoint.toJavaUtil())
         .setBackgroundParsingThreads(numBackgroundThreadsPerStream)
         .setPushAllFilters(pushAllFilters)
+        .setPrebufferReadRowsResponses(numPrebufferReadRowsResponses)
+        .setStreamsPerPartition(numStreamsPerPartition)
         .build();
   }
 

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -82,6 +82,10 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
   private static final int DEFAULT_BIGQUERY_CLIENT_CONNECT_TIMEOUT = 60 * 1000;
   private static final int DEFAULT_BIGQUERY_CLIENT_READ_TIMEOUT = 60 * 1000;
   private static final Pattern LOWERCASE_QUERY_PATTERN = Pattern.compile("^(select|with)\\s+.*$");
+  // Both MIN values correspond to the lower possible value that will actually make the code work.
+  // 0 or less would make code hang or other bad side effects.
+  public static final int MIN_BUFFERED_RESPONSES_PER_STREAM = 1;
+  public static final int MIN_STREAMS_PER_PARTITION = 1;
   TableId tableId;
   // as the config needs to be Serializable, internally it uses
   // com.google.common.base.Optional<String> but externally it uses the regular java.util.Optional
@@ -119,8 +123,8 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
   private com.google.common.base.Optional<String> encodedCreateReadSessionRequest = empty();
   private com.google.common.base.Optional<String> storageReadEndpoint = empty();
   private int numBackgroundThreadsPerStream = 0;
-  private int numPrebufferReadRowsResponses = 1;
-  private int numStreamsPerPartition = 1;
+  private int numPrebufferReadRowsResponses = MIN_BUFFERED_RESPONSES_PER_STREAM;
+  private int numStreamsPerPartition = MIN_STREAMS_PER_PARTITION;
 
   @VisibleForTesting
   SparkBigQueryConfig() {
@@ -286,11 +290,11 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
     config.numPrebufferReadRowsResponses =
         getAnyOption(globalOptions, options, "bqPrebufferResponsesPerStream")
             .transform(Integer::parseInt)
-            .or(1);
+            .or(MIN_BUFFERED_RESPONSES_PER_STREAM);
     config.numStreamsPerPartition =
         getAnyOption(globalOptions, options, "bqNumStreamsPerPartition")
             .transform(Integer::parseInt)
-            .or(1);
+            .or(MIN_STREAMS_PER_PARTITION);
 
     return config;
   }

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryDataSourceReader.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryDataSourceReader.java
@@ -217,6 +217,7 @@ public class BigQueryDataSourceReader
                     bigQueryTracerFactory,
                     streams.stream()
                         .map(ReadStream::getName)
+                        // This formulation is used to guarantee a serializable list.
                         .collect(Collectors.toCollection(ArrayList::new)),
                     readSessionCreatorConfig.toReadRowsHelperOptions(),
                     partitionSelectedFields,

--- a/connector/src/test/java/com/google/cloud/bigquery/connector/common/ReadRowsHelperTest.java
+++ b/connector/src/test/java/com/google/cloud/bigquery/connector/common/ReadRowsHelperTest.java
@@ -152,13 +152,16 @@ public class ReadRowsHelperTest {
     batch2.addResponse(ReadRowsResponse.newBuilder().setRowCount(11).build());
     ReadRowsRequest.Builder request2 = ReadRowsRequest.newBuilder().setReadStream("abc");
 
-    fakeService.reset(ImmutableMap.of(request.getReadStream(), batch1,
-                      request2.getReadStream(), batch2));
+    fakeService.reset(
+        ImmutableMap.of(request.getReadStream(), batch1, request2.getReadStream(), batch2));
 
     when(clientFactory.createBigQueryReadClient(any())).thenReturn(fakeServerClient());
 
-    helper = new ReadRowsHelper(clientFactory,
-        ImmutableList.of(request, request2), defaultConfig.toReadRowsHelperOptions());
+    helper =
+        new ReadRowsHelper(
+            clientFactory,
+            ImmutableList.of(request, request2),
+            defaultConfig.toReadRowsHelperOptions());
 
     Iterator<ReadRowsResponse> responses = helper.readRows();
     // Try to make sure both requests are active.

--- a/connector/src/test/java/com/google/cloud/spark/bigquery/v2/BigQueryInputPartitionTest.java
+++ b/connector/src/test/java/com/google/cloud/spark/bigquery/v2/BigQueryInputPartitionTest.java
@@ -4,6 +4,7 @@ import com.google.cloud.bigquery.connector.common.ReadRowsHelper;
 import com.google.cloud.bigquery.connector.common.ReadRowsHelper.Options;
 import com.google.cloud.bigquery.connector.common.ReadSessionResponse;
 import com.google.cloud.bigquery.storage.v1.ReadSession;
+import com.google.common.collect.Lists;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
@@ -18,9 +19,12 @@ public class BigQueryInputPartitionTest {
             new ArrowInputPartition(
                 /*bigQueryClientFactory=*/ null,
                 /*tracerFactory=*/ null,
-                "streamName",
+                Lists.newArrayList("streamName"),
                 new ReadRowsHelper.Options(
-                    /*maxRetries=*/ 5, Optional.of("endpoint"), /*backgroundParsingThreads=*/ 5),
+                    /*maxRetries=*/ 5,
+                    Optional.of("endpoint"),
+                    /*backgroundParsingThreads=*/ 5,
+                    /*prebufferResponses=*/ 1),
                 null,
                 new ReadSessionResponse(ReadSession.getDefaultInstance(), null),
                 null));


### PR DESCRIPTION
- Adds option to prebuffer more then 1 response at a time. This is
  useful for high latency environments.

- Adds option to combine streams into one partition. This is useful if
  there are more streams per core, and the time spent in spark
  processing is significantly less then the time spent receiving data
  from the server.  One case where this can occur is with partially
  restricted push down filters.

This is done by adapting ResponseObserver from gax to support retries,
multiple streams and prebuffering.  Most of the complexity is because
of retries, which should soon be handled by the underlying client.

I'll be experimenting with parameters here to see if there are better
defaults.