### PR TITLE
Push all filters to BigQuery Storage API

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,16 @@ The API Supports a number of options to configure the read
    <td>Read</td>
   </tr>
   <tr valign="top">
+   <td><code>pushAllFilters</code>
+   </td>
+   <td>If set to <code>true</code>, the connector pushes all the filters Spark can delegate
+       to BigQuery Storage API. This reduces amount of data that needs to be sent from
+       BigQuery Storage API servers to Spark clients.
+       <br/>(Optional, defaults to <code>true</code>)
+   </td>
+   <td>Read</td>
+  </tr>
+  <tr valign="top">
      <td><code>createDisposition</code>
       </td>
       <td>Specifies whether the job is allowed to create new tables. The permitted
@@ -802,4 +812,3 @@ or
 ```
 spark.conf.set("gcpAccessToken", "<access-token>")
 ```
-

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfig.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfig.java
@@ -34,6 +34,7 @@ public class ReadSessionCreatorConfig {
   private final Optional<String> requestEncodedBase;
   private final Optional<String> endpoint;
   private final int backgroundParsingThreads;
+  private final boolean pushAllFilters;
 
   ReadSessionCreatorConfig(
       boolean viewsEnabled,
@@ -47,7 +48,8 @@ public class ReadSessionCreatorConfig {
       int defaultParallelism,
       Optional<String> requestEncodedBase,
       Optional<String> endpoint,
-      int backgroundParsingThreads) {
+      int backgroundParsingThreads,
+      boolean pushAllFilters) {
     this.viewsEnabled = viewsEnabled;
     this.materializationProject = materializationProject;
     this.materializationDataset = materializationDataset;
@@ -60,6 +62,7 @@ public class ReadSessionCreatorConfig {
     this.requestEncodedBase = requestEncodedBase;
     this.endpoint = endpoint;
     this.backgroundParsingThreads = backgroundParsingThreads;
+    this.pushAllFilters = pushAllFilters;
   }
 
   public boolean isViewsEnabled() {
@@ -108,6 +111,10 @@ public class ReadSessionCreatorConfig {
 
   public int backgroundParsingThreads() {
     return this.backgroundParsingThreads;
+  }
+
+  public boolean getPushAllFilters() {
+    return this.pushAllFilters;
   }
 
   public ReadRowsHelper.Options toReadRowsHelperOptions() {

--- a/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfigBuilder.java
+++ b/connector/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfigBuilder.java
@@ -18,6 +18,7 @@ public class ReadSessionCreatorConfigBuilder {
   private Optional<String> requestEncodedBase = Optional.empty();
   private Optional<String> endpoint = Optional.empty();
   private int backgroundParsingThreads = 0;
+  private boolean pushAllFilters = true;
 
   public ReadSessionCreatorConfigBuilder setViewsEnabled(boolean viewsEnabled) {
     this.viewsEnabled = viewsEnabled;
@@ -83,6 +84,11 @@ public class ReadSessionCreatorConfigBuilder {
     return this;
   }
 
+  public ReadSessionCreatorConfigBuilder setPushAllFilters(boolean pushAllFilters) {
+    this.pushAllFilters = pushAllFilters;
+    return this;
+  }
+
   public ReadSessionCreatorConfig build() {
     return new ReadSessionCreatorConfig(
         viewsEnabled,
@@ -96,6 +102,7 @@ public class ReadSessionCreatorConfigBuilder {
         defaultParallelism,
         requestEncodedBase,
         endpoint,
-        backgroundParsingThreads);
+        backgroundParsingThreads,
+        pushAllFilters);
   }
 }

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -115,10 +115,10 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
   ImmutableList<JobInfo.SchemaUpdateOption> loadSchemaUpdateOptions = ImmutableList.of();
   int materializationExpirationTimeInMinutes = DEFAULT_MATERIALIZATION_EXPRIRATION_TIME_IN_MINUTES;
   int maxReadRowsRetries = 3;
+  boolean pushAllFilters = true;
   private com.google.common.base.Optional<String> encodedCreateReadSessionRequest = empty();
   private com.google.common.base.Optional<String> storageReadEndpoint = empty();
   private int numBackgroundThreadsPerStream = 0;
-  private boolean pushAllFilters = true;
 
   @VisibleForTesting
   SparkBigQueryConfig() {
@@ -548,10 +548,6 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
 
   public boolean getPushAllFilters() {
     return pushAllFilters;
-  }
-
-  public void setPushAllFilters(boolean pushAllFilters) {
-    this.pushAllFilters = pushAllFilters;
   }
 
   // in order to simplify the configuration, the BigQuery client settings are fixed. If needed

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -118,6 +118,7 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
   private com.google.common.base.Optional<String> encodedCreateReadSessionRequest = empty();
   private com.google.common.base.Optional<String> storageReadEndpoint = empty();
   private int numBackgroundThreadsPerStream = 0;
+  private boolean pushAllFilters = true;
 
   @VisibleForTesting
   SparkBigQueryConfig() {
@@ -279,6 +280,7 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
         getAnyOption(globalOptions, options, "bqBackgroundThreadsPerStream")
             .transform(Integer::parseInt)
             .or(0);
+    config.pushAllFilters = getAnyBooleanOption(globalOptions, options, "pushAllFilters", true);
 
     return config;
   }
@@ -544,6 +546,14 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
     return maxReadRowsRetries;
   }
 
+  public boolean getPushAllFilters() {
+    return pushAllFilters;
+  }
+
+  public void setPushAllFilters(boolean pushAllFilters) {
+    this.pushAllFilters = pushAllFilters;
+  }
+
   // in order to simplify the configuration, the BigQuery client settings are fixed. If needed
   // we will add configuration properties for them.
 
@@ -584,6 +594,7 @@ public class SparkBigQueryConfig implements BigQueryConfig, Serializable {
         .setRequestEncodedBase(encodedCreateReadSessionRequest.toJavaUtil())
         .setEndpoint(storageReadEndpoint.toJavaUtil())
         .setBackgroundParsingThreads(numBackgroundThreadsPerStream)
+        .setPushAllFilters(pushAllFilters)
         .build();
   }
 

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryDataSourceReader.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryDataSourceReader.java
@@ -155,7 +155,10 @@ public class BigQueryDataSourceReader
     Optional<String> filter =
         emptyIfNeeded(
             SparkFilterUtils.getCompiledFilter(
-                readSessionCreatorConfig.getReadDataFormat(), globalFilter, pushedFilters));
+                readSessionCreatorConfig.getPushAllFilters(),
+                readSessionCreatorConfig.getReadDataFormat(),
+                globalFilter,
+                pushedFilters));
     ReadSessionResponse readSessionResponse =
         readSessionCreator.create(tableId, selectedFields, filter);
     ReadSession readSession = readSessionResponse.getReadSession();
@@ -182,7 +185,10 @@ public class BigQueryDataSourceReader
     Optional<String> filter =
         emptyIfNeeded(
             SparkFilterUtils.getCompiledFilter(
-                readSessionCreatorConfig.getReadDataFormat(), globalFilter, pushedFilters));
+                readSessionCreatorConfig.getPushAllFilters(),
+                readSessionCreatorConfig.getReadDataFormat(),
+                globalFilter,
+                pushedFilters));
     ReadSessionResponse readSessionResponse =
         readSessionCreator.create(tableId, selectedFields, filter);
     ReadSession readSession = readSessionResponse.getReadSession();
@@ -269,7 +275,10 @@ public class BigQueryDataSourceReader
     List<Filter> unhandledFilters = new ArrayList<>();
     for (Filter filter : filters) {
       if (SparkFilterUtils.isTopLevelFieldHandled(
-          filter, readSessionCreatorConfig.getReadDataFormat(), fields)) {
+          readSessionCreatorConfig.getPushAllFilters(),
+          filter,
+          readSessionCreatorConfig.getReadDataFormat(),
+          fields)) {
         handledFilters.add(filter);
       } else {
         unhandledFilters.add(filter);

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
@@ -333,7 +333,7 @@ private[bigquery] class DirectBigQueryRelation(
   }
 
   private def handledFilters(filters: Array[Filter]): Array[Filter] = {
-    filters.filter(filter => DirectBigQueryRelation.isTopLevelFieldFilterHandled(
+    filters.filter(filter => DirectBigQueryRelation.isTopLevelFieldFilterHandled(options.getPushAllFilters,
       filter, options.getReadDataFormat, topLevelFields))
   }
 
@@ -378,40 +378,46 @@ object DirectBigQueryRelation {
       new SparkBigQueryConnectorUserAgentProvider("v1").getUserAgent)
 
   def isTopLevelFieldFilterHandled(
+      pushAllFilters: Boolean,
       filter: Filter,
       readDataFormat: DataFormat,
-      fields: Map[String, StructField]): Boolean = filter match {
-    case EqualTo(attr, _) =>
-      isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
-    case GreaterThan(attr, _) =>
-      isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
-    case GreaterThanOrEqual(attr, _) =>
-      isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
-    case LessThan(attr, _) =>
-      isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
-    case LessThanOrEqual(attr, _) =>
-      isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
-    case In(attr, _) =>
-      isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
-    case IsNull(attr) =>
-      isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
-    case IsNotNull(attr) =>
-      isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
-    case And(lhs, rhs) =>
-      isTopLevelFieldFilterHandled(lhs, readDataFormat, fields) &&
-      isTopLevelFieldFilterHandled(rhs, readDataFormat, fields)
-    case Or(lhs, rhs) =>
-      readDataFormat == DataFormat.AVRO &&
-      isTopLevelFieldFilterHandled(lhs, readDataFormat, fields) &&
-      isTopLevelFieldFilterHandled(rhs, readDataFormat, fields)
-    case Not(child) => isTopLevelFieldFilterHandled(child, readDataFormat, fields)
-    case StringStartsWith(attr, _) =>
-      isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
-    case StringEndsWith(attr, _) =>
-      isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
-    case StringContains(attr, _) =>
-      isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
-    case _ => false
+      fields: Map[String, StructField]): Boolean = {
+    if (pushAllFilters) {
+      return true
+    }
+    filter match {
+      case EqualTo(attr, _) =>
+        isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
+      case GreaterThan(attr, _) =>
+        isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
+      case GreaterThanOrEqual(attr, _) =>
+        isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
+      case LessThan(attr, _) =>
+        isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
+      case LessThanOrEqual(attr, _) =>
+        isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
+      case In(attr, _) =>
+        isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
+      case IsNull(attr) =>
+        isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
+      case IsNotNull(attr) =>
+        isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
+      case And(lhs, rhs) =>
+        isTopLevelFieldFilterHandled(pushAllFilters, lhs, readDataFormat, fields) &&
+        isTopLevelFieldFilterHandled(pushAllFilters, rhs, readDataFormat, fields)
+      case Or(lhs, rhs) =>
+        readDataFormat == DataFormat.AVRO &&
+        isTopLevelFieldFilterHandled(pushAllFilters, lhs, readDataFormat, fields) &&
+        isTopLevelFieldFilterHandled(pushAllFilters, rhs, readDataFormat, fields)
+      case Not(child) => isTopLevelFieldFilterHandled(pushAllFilters, child, readDataFormat, fields)
+      case StringStartsWith(attr, _) =>
+        isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
+      case StringEndsWith(attr, _) =>
+        isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
+      case StringContains(attr, _) =>
+        isFilterWithNamedFieldHandled(filter, readDataFormat, fields, attr)
+      case _ => false
+    }
   }
 
   // BigQuery Storage API does not handle RECORD/STRUCT fields at the moment

--- a/connector/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
+++ b/connector/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
@@ -333,8 +333,8 @@ private[bigquery] class DirectBigQueryRelation(
   }
 
   private def handledFilters(filters: Array[Filter]): Array[Filter] = {
-    filters.filter(filter => DirectBigQueryRelation.isTopLevelFieldFilterHandled(options.getPushAllFilters,
-      filter, options.getReadDataFormat, topLevelFields))
+    filters.filter(filter => DirectBigQueryRelation.isTopLevelFieldFilterHandled(
+      options.getPushAllFilters, filter, options.getReadDataFormat, topLevelFields))
   }
 
   override def unhandledFilters(filters: Array[Filter]): Array[Filter] = {

--- a/connector/src/test/scala/com/google/cloud/spark/bigquery/DirectBigQueryRelationSuite.scala
+++ b/connector/src/test/scala/com/google/cloud/spark/bigquery/DirectBigQueryRelationSuite.scala
@@ -141,7 +141,7 @@ class DirectBigQueryRelationSuite
   test("invalid filters with Avro when pushAllFilters is false") {
     val options = defaultOptions
     options.readDataFormat = DataFormat.AVRO
-    options.setPushAllFilters(false)
+    options.pushAllFilters = false
     val bigQueryRelation = new DirectBigQueryRelation(options, TABLE)(sqlCtx)
 
     val valid1 = EqualTo("foo", "bar")
@@ -155,7 +155,7 @@ class DirectBigQueryRelationSuite
   test("no invalid filters with Avro when pushAllFilters is true") {
     val options = defaultOptions
     options.readDataFormat = DataFormat.AVRO
-    options.setPushAllFilters(true)
+    options.pushAllFilters = true
     val bigQueryRelation = new DirectBigQueryRelation(options, TABLE)(sqlCtx)
 
     val valid1 = EqualTo("foo", "bar")
@@ -169,7 +169,7 @@ class DirectBigQueryRelationSuite
   test("invalid filters with Arrow when pushAllFilters is false") {
     val options = defaultOptions
     options.readDataFormat = DataFormat.ARROW
-    options.setPushAllFilters(false)
+    options.pushAllFilters = false
     val bigQueryRelation = new DirectBigQueryRelation(options, TABLE)(sqlCtx)
 
     val valid1 = EqualTo("foo", "bar")
@@ -185,7 +185,7 @@ class DirectBigQueryRelationSuite
   test("invalid filters with Arrow when pushAllFilters is true") {
     val options = defaultOptions
     options.readDataFormat = DataFormat.ARROW
-    options.setPushAllFilters(true)
+    options.pushAllFilters = true
     val bigQueryRelation = new DirectBigQueryRelation(options, TABLE)(sqlCtx)
 
     val valid1 = EqualTo("foo", "bar")

--- a/connector/src/test/scala/com/google/cloud/spark/bigquery/DirectBigQueryRelationSuite.scala
+++ b/connector/src/test/scala/com/google/cloud/spark/bigquery/DirectBigQueryRelationSuite.scala
@@ -138,7 +138,12 @@ class DirectBigQueryRelationSuite
     assert(bigQueryRelation.unhandledFilters(Array(valid1, valid2)).isEmpty)
   }
 
-  test("invalid filters with Avro") {
+  test("invalid filters with Avro when pushAllFilters is false") {
+    val options = defaultOptions
+    options.readDataFormat = DataFormat.AVRO
+    options.setPushAllFilters(false)
+    val bigQueryRelation = new DirectBigQueryRelation(options, TABLE)(sqlCtx)
+
     val valid1 = EqualTo("foo", "bar")
     val valid2 = EqualTo("bar", 1)
     val invalid1 = EqualNullSafe("foo", "bar")
@@ -147,9 +152,24 @@ class DirectBigQueryRelationSuite
     unhandled should contain allElementsOf Array(invalid1, invalid2)
   }
 
-  test("invalid filters with Arrow") {
+  test("no invalid filters with Avro when pushAllFilters is true") {
+    val options = defaultOptions
+    options.readDataFormat = DataFormat.AVRO
+    options.setPushAllFilters(true)
+    val bigQueryRelation = new DirectBigQueryRelation(options, TABLE)(sqlCtx)
+
+    val valid1 = EqualTo("foo", "bar")
+    val valid2 = EqualTo("bar", 1)
+    val invalid1 = EqualNullSafe("foo", "bar")
+    val invalid2 = And(EqualTo("foo", "bar"), Not(EqualNullSafe("bar", 1)))
+    val unhandled = bigQueryRelation.unhandledFilters(Array(valid1, valid2, invalid1, invalid2))
+    assert(unhandled.isEmpty)
+  }
+
+  test("invalid filters with Arrow when pushAllFilters is false") {
     val options = defaultOptions
     options.readDataFormat = DataFormat.ARROW
+    options.setPushAllFilters(false)
     val bigQueryRelation = new DirectBigQueryRelation(options, TABLE)(sqlCtx)
 
     val valid1 = EqualTo("foo", "bar")
@@ -160,6 +180,22 @@ class DirectBigQueryRelationSuite
     val unhandled = bigQueryRelation.unhandledFilters(Array(valid1, valid2,
       invalid1, invalid2, invalid3))
     unhandled should contain allElementsOf Array(invalid1, invalid2, invalid3)
+  }
+
+  test("invalid filters with Arrow when pushAllFilters is true") {
+    val options = defaultOptions
+    options.readDataFormat = DataFormat.ARROW
+    options.setPushAllFilters(true)
+    val bigQueryRelation = new DirectBigQueryRelation(options, TABLE)(sqlCtx)
+
+    val valid1 = EqualTo("foo", "bar")
+    val valid2 = EqualTo("bar", 1)
+    val invalid1 = EqualNullSafe("foo", "bar")
+    val invalid2 = And(EqualTo("foo", "bar"), Not(EqualNullSafe("bar", 1)))
+    val invalid3 = Or(IsNull("foo"), IsNotNull("foo"))
+    val unhandled = bigQueryRelation.unhandledFilters(Array(valid1, valid2,
+      invalid1, invalid2, invalid3))
+    assert(unhandled.isEmpty)
   }
 
   test("old filter behaviour, with filter option") {
@@ -299,4 +335,3 @@ class DirectBigQueryRelationSuite
   }
 
 }
-


### PR DESCRIPTION
This PR modifies the filter handling code so that connector pushes all the filters it is handed by spark to the BigQuery Storage API for the read case. There is still an option to disable this (set `pushAllFilters` to `False`) so if spark tries to pushes something Storage API can't handle, users can turn this feature off.