### PR TITLE
Moved zstd-jni library to be provided in order to solve Spark 2.4 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,9 +95,12 @@ lazy val connector = (project in file("connector"))
         exclude("org.checkerframework", "checker-qual"),
       "org.slf4j" % "slf4j-api" % "1.7.16" % "provided",
       "aopalliance" % "aopalliance" % "1.0" % "provided",
+      "javax.inject" % "javax.inject" % "1" % "provided",
       "org.codehaus.jackson" % "jackson-core-asl" % "1.9.13" % "provided",
       "org.codehaus.jackson" % "jackson-mapper-asl" % "1.9.13" % "provided",
-      "com.google.inject" % "guice" % "4.2.3",
+      "com.google.inject" % "guice" % "4.2.3"
+        exclude("aopalliance", "aopalliance")
+        exclude("javax.inject", "javax.inject"),
       "org.apache.arrow" % "arrow-vector" % "4.0.0"
 			  excludeAll(ExclusionRule(organization = "org.slf4j"),
 			   ExclusionRule(organization = "com.fasterxml.jackson.core"),
@@ -221,7 +224,9 @@ val excludedOrgs = Seq(
 lazy val renamed = Seq(
   "avro.shaded",
   "com.fasterxml",
+  "com.github.luben",
   "com.google",
+  "com.google.android",
   "com.thoughtworks.paranamer",
   "com.typesafe",
   "io.grpc",
@@ -229,6 +234,7 @@ lazy val renamed = Seq(
   "io.opencensus",
   "org.apache.arrow",
   "io.perfmark",
+  "org.apache.beam",
   "org.apache.commons",
   "org.apache.http",
   "org.checkerframework",

--- a/build.sbt
+++ b/build.sbt
@@ -226,7 +226,6 @@ val excludedOrgs = Seq(
 lazy val renamed = Seq(
   "avro.shaded",
   "com.fasterxml",
-  // "com.github.luben",
   "com.google",
   "com.google.android",
   "com.thoughtworks.paranamer",

--- a/build.sbt
+++ b/build.sbt
@@ -94,6 +94,7 @@ lazy val connector = (project in file("connector"))
         exclude("org.checkerframework", "checker-qual"),
       "org.slf4j" % "slf4j-api" % "1.7.16" % "provided",
       "aopalliance" % "aopalliance" % "1.0" % "provided",
+      "com.github.luben" % "zstd-jni" % "1.4.9-1" % "provided",
       "javax.inject" % "javax.inject" % "1" % "provided",
       "org.codehaus.jackson" % "jackson-core-asl" % "1.9.13" % "provided",
       "org.codehaus.jackson" % "jackson-mapper-asl" % "1.9.13" % "provided",
@@ -109,9 +110,11 @@ lazy val connector = (project in file("connector"))
 			     ExclusionRule(organization = "io.netty"),
 		       ExclusionRule(organization = "com.fasterxml.jackson.core")),
       "org.apache.arrow" % "arrow-compression" % "4.0.0"
+         exclude("com.github.luben", "zstd-jni")
 			   excludeAll(ExclusionRule(organization = "org.slf4j"),
 			     ExclusionRule(organization = "io.netty"),
 		       ExclusionRule(organization = "com.fasterxml.jackson.core")),
+
 
       // Keep com.google.cloud dependencies in sync
       "com.google.cloud" % "google-cloud-bigquery" % "1.131.1",

--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,6 @@ lazy val commonTestDependencies = Seq(
 )
 
 lazy val connector = (project in file("connector"))
-  .enablePlugins(BuildInfoPlugin)
   .configs(ITest)
   .settings(
     commonSettings,
@@ -83,7 +82,7 @@ lazy val connector = (project in file("connector"))
     buildInfoPackage := "com.google.cloud.spark.bigquery",
     resourceGenerators in Compile += Def.task {
       val file = (resourceManaged in Compile).value / "spark-bigquery-connector.properties"
-      IO.write(file, s"scala.version=${scalaVersion.value}\n")
+      IO.write(file, s"scala.version=${scalaVersion.value}\nconnector.version=${version.value}\n")
       Seq(file)
     }.taskValue,
     libraryDependencies ++= (commonTestDependencies ++ Seq(
@@ -224,7 +223,7 @@ val excludedOrgs = Seq(
 lazy val renamed = Seq(
   "avro.shaded",
   "com.fasterxml",
-  "com.github.luben",
+  // "com.github.luben",
   "com.google",
   "com.google.android",
   "com.thoughtworks.paranamer",

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConnectorUserAgentProvider.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConnectorUserAgentProvider.java
@@ -45,7 +45,6 @@ public class SparkBigQueryConnectorUserAgentProvider implements UserAgentProvide
           .map(image -> " dataproc-image/" + image)
           .orElse("");
 
-  private static String CONNECTOR_VERSION = BuildInfo.version();
   // In order to avoid using SparkContext or SparkSession, we are going directly to the source
   private static String SPARK_VERSION = org.apache.spark.package$.MODULE$.SPARK_VERSION();
   private static String JAVA_VERSION = System.getProperty("java.runtime.version");
@@ -53,7 +52,7 @@ public class SparkBigQueryConnectorUserAgentProvider implements UserAgentProvide
   static final String USER_AGENT =
       format(
           "spark-bigquery-connector/%s spark/%s java/%s scala/%s%s%s",
-          CONNECTOR_VERSION,
+          SparkBigQueryUtil.CONNECTOR_VERSION,
           SPARK_VERSION,
           JAVA_VERSION,
           SCALA_VERSION,

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConnectorVersionProvider.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConnectorVersionProvider.java
@@ -33,7 +33,7 @@ public class SparkBigQueryConnectorVersionProvider implements VersionProvider {
   public String getVersion() {
     return format(
         "spark-bigquery-connector/%s spark/%s java/%s scala/%s",
-        BuildInfo.version(),
+        SparkBigQueryUtil.CONNECTOR_VERSION,
         sparkContext.version(),
         System.getProperty("java.runtime.version"),
         Properties.versionNumberString());

--- a/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryUtil.java
+++ b/connector/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryUtil.java
@@ -17,10 +17,28 @@ package com.google.cloud.spark.bigquery;
 
 import com.google.cloud.bigquery.connector.common.BigQueryUtil;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
+import java.util.Properties;
 
 /** Spark related utilities */
 public class SparkBigQueryUtil {
+
+  static final Properties BUILD_PROPERTIES = loadBuildProperties();
+
+  static final String CONNECTOR_VERSION = BUILD_PROPERTIES.getProperty("connector.version");
+
+  private static Properties loadBuildProperties() {
+    try {
+      Properties buildProperties = new Properties();
+      buildProperties.load(
+          SparkBigQueryUtil.class.getResourceAsStream("/spark-bigquery-connector.properties"));
+      return buildProperties;
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
   /**
    * Optimizing the URI list for BigQuery load, using the Spark specific file prefix and suffix
    * patterns, based on <code>BigQueryUtil.optimizeLoadUriList()</code>


### PR DESCRIPTION
When using Arrow compression in Spark 2.4 the user need to add `--conf spark.executor.userClassPathFirst=true --conf spark.driver.userClassPathFirst=true --packages com.github.luben:zstd-jni:1.4.9-1` to the spark-submit