### PR TITLE
Update google-cloud-bom to 0.161.0 in order to update google-cloud-bigquerystorage dependency to 2.1.2

### DIFF
--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -33,7 +33,7 @@
     <avro.version>1.8.2</avro.version>
     <arrow.version>4.0.0</arrow.version>
     <gax.version>1.64.0</gax.version>
-    <google-cloud-bom.version>0.155.0</google-cloud-bom.version>
+    <google-cloud-bom.version>0.161.0</google-cloud-bom.version>
     <grpc.version>1.32.2</grpc.version>
     <guava.version>30.1.1-jre</guava.version>
     <netty.version>4.1.65.Final</netty.version>


### PR DESCRIPTION
This version includes necessary changes to handle certain
RESOURCE_EXHAUSTED errors returned from Bigquery sStorage Read
service.