### PR TITLE
Allow Reading of External Tables in Spark Connector

### DIFF
--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
@@ -105,7 +105,7 @@ public class BigQueryClient {
 
     TableDefinition tableDefinition = table.getDefinition();
     TableDefinition.Type tableType = tableDefinition.getType();
-    if (TableDefinition.Type.TABLE == tableType) {
+    if (TableDefinition.Type.TABLE == tableType || TableDefinition.Type.EXTERNAL == tableType) {
       return table;
     }
     if (TableDefinition.Type.VIEW == tableType

--- a/spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
+++ b/spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
@@ -18,7 +18,7 @@ package com.google.cloud.spark.bigquery
 import java.util.Optional
 
 import com.google.cloud.bigquery.TableDefinition
-import com.google.cloud.bigquery.TableDefinition.Type.{MATERIALIZED_VIEW, TABLE, VIEW}
+import com.google.cloud.bigquery.TableDefinition.Type.{EXTERNAL, MATERIALIZED_VIEW, TABLE, VIEW}
 import com.google.cloud.bigquery.connector.common.{BigQueryClient, BigQueryClientModule, BigQueryUtil}
 import com.google.cloud.spark.bigquery.direct.DirectBigQueryRelation
 import com.google.common.collect.ImmutableMap
@@ -79,7 +79,7 @@ class BigQueryRelationProvider(
     val table = Option(tableInfo)
       .getOrElse(sys.error(s"Table $tableName not found"))
     table.getDefinition[TableDefinition].getType match {
-      case TABLE => new DirectBigQueryRelation(opts, table)(sqlContext)
+      case TABLE | EXTERNAL => new DirectBigQueryRelation(opts, table)(sqlContext)
       case VIEW | MATERIALIZED_VIEW => if (opts.isViewsEnabled) {
         new DirectBigQueryRelation(opts, table)(sqlContext)
       } else {

--- a/spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
+++ b/spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.scala
@@ -112,7 +112,7 @@ private[bigquery] class DirectBigQueryRelation(
       if (requiredColumns.isEmpty) {
         logDebug(s"Not using optimized empty projection")
       }
-      val actualTableDefinition = actualTable.getDefinition[StandardTableDefinition]
+      val actualTableDefinition = actualTable.getDefinition[TableDefinition]
       val actualTablePath = DirectBigQueryRelation.toTablePath(actualTable.getTableId)
       val readOptions = TableReadOptions.newBuilder()
         .addAllSelectedFields(requiredColumns.toList.asJava)
@@ -298,9 +298,10 @@ private[bigquery] class DirectBigQueryRelation(
 
   def getNumBytes(tableDefinition: TableDefinition): Long = {
     val tableType = tableDefinition.getType
-    if (options.isViewsEnabled &&
-      (TableDefinition.Type.VIEW == tableType ||
-        TableDefinition.Type.MATERIALIZED_VIEW == tableType)) {
+    if (TableDefinition.Type.EXTERNAL == tableType ||
+      (options.isViewsEnabled &&
+        (TableDefinition.Type.VIEW == tableType ||
+        TableDefinition.Type.MATERIALIZED_VIEW == tableType))) {
       sqlContext.sparkSession.sessionState.conf.defaultSizeInBytes
     } else {
       tableDefinition.asInstanceOf[StandardTableDefinition].getNumBytes


### PR DESCRIPTION
Testing: existing unit testing pass, end-to-end tests