### PR TITLE
Switched versions to use the ${revision} property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .cache/
 .history/
 .lib/
+.flattened-pom.xml
 dist/*
 target/
 lib_managed/

--- a/bigquery-connector-common/pom.xml
+++ b/bigquery-connector-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../spark-bigquery-parent</relativePath>
   </parent>
 

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../spark-bigquery-parent</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>spark-bigquery-parent</relativePath>
   </parent>
 

--- a/spark-bigquery-connector-common/pom.xml
+++ b/spark-bigquery-connector-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.google.cloud.spark</groupId>
         <artifactId>spark-bigquery-parent</artifactId>
-        <version>0.24.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../spark-bigquery-parent</relativePath>
     </parent>
 

--- a/spark-bigquery-dsv1/pom.xml
+++ b/spark-bigquery-dsv1/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../spark-bigquery-parent</relativePath>
   </parent>
 

--- a/spark-bigquery-dsv1/spark-bigquery-dsv1-parent/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery-dsv1-parent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../../spark-bigquery-parent</relativePath>
   </parent>
 

--- a/spark-bigquery-dsv1/spark-bigquery-dsv1-spark3-support/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery-dsv1-spark3-support/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../../spark-bigquery-parent</relativePath>
   </parent>
 

--- a/spark-bigquery-dsv1/spark-bigquery-with-dependencies-parent/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery-with-dependencies-parent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../../spark-bigquery-parent</relativePath>
   </parent>
   <artifactId>spark-bigquery-with-dependencies-parent</artifactId>

--- a/spark-bigquery-dsv1/spark-bigquery-with-dependencies_2.11/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery-with-dependencies_2.11/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-with-dependencies-parent</artifactId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../spark-bigquery-with-dependencies-parent</relativePath>
   </parent>
 

--- a/spark-bigquery-dsv1/spark-bigquery-with-dependencies_2.12/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery-with-dependencies_2.12/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-with-dependencies-parent</artifactId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../spark-bigquery-with-dependencies-parent</relativePath>
   </parent>
 

--- a/spark-bigquery-dsv1/spark-bigquery_2.11/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery_2.11/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-dsv1-parent</artifactId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../spark-bigquery-dsv1-parent</relativePath>
   </parent>
 

--- a/spark-bigquery-dsv1/spark-bigquery_2.12/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery_2.12/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-dsv1-parent</artifactId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../spark-bigquery-dsv1-parent</relativePath>
   </parent>
 

--- a/spark-bigquery-dsv2/pom.xml
+++ b/spark-bigquery-dsv2/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../spark-bigquery-parent</relativePath>
   </parent>
 

--- a/spark-bigquery-dsv2/spark-2.4-bigquery/pom.xml
+++ b/spark-bigquery-dsv2/spark-2.4-bigquery/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>com.google.cloud.spark</groupId>
         <artifactId>spark-bigquery-dsv2-parent</artifactId>
-        <version>0.24.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../spark-bigquery-dsv2-parent</relativePath>
     </parent>
 
     <artifactId>spark-2.4-bigquery</artifactId>
-    <version>0.24.0-SNAPSHOT-preview</version>
+    <version>${revision}-preview</version>
     <name>BigQuery DataSource v2 for Spark 2.4</name>
     <properties>
         <spark.version>2.4.0</spark.version>

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/pom.xml
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-dsv2-parent</artifactId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../spark-bigquery-dsv2-parent</relativePath>
   </parent>
 
   <artifactId>spark-3.1-bigquery</artifactId>
-  <version>0.24.0-SNAPSHOT-preview</version>
+  <version>${revision}-preview</version>
   <name>BigQuery DataSource v2 for Spark 3.1</name>
   <properties>
     <spark.version>3.1.0</spark.version>

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/pom.xml
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.google.cloud.spark</groupId>
         <artifactId>spark-bigquery-parent</artifactId>
-        <version>0.24.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../../spark-bigquery-parent</relativePath>
     </parent>
 

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-parent/pom.xml
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-parent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../../spark-bigquery-parent</relativePath>
   </parent>
 

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -545,6 +545,31 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>flatten-maven-plugin</artifactId>
+                        <version>1.2.7</version>
+                        <configuration>
+                            <updatePomFile>true</updatePomFile>
+                            <flattenMode>resolveCiFriendliesOnly</flattenMode>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>flatten</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>flatten</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>flatten.clean</id>
+                                <phase>clean</phase>
+                                <goals>
+                                    <goal>clean</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
                         <version>1.6.7</version>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
     <name>Spark BigQuery Connector Build Parent</name>
     <description>Parent project for all the Spark BigQuery Connector artifacts
@@ -49,6 +49,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
+        <revision>0.0.1-SNAPSHOT</revision>
 
         <avro.version>1.8.2</avro.version>
         <arrow.version>6.0.1</arrow.version>

--- a/spark-bigquery-pushdown/pom.xml
+++ b/spark-bigquery-pushdown/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spark-bigquery-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../spark-bigquery-parent</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11/pom.xml
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../spark-bigquery-pushdown-parent</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/pom.xml
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../spark-bigquery-pushdown-parent</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/spark-bigquery-pushdown/spark-3.1-bigquery-pushdown_2.12/pom.xml
+++ b/spark-bigquery-pushdown/spark-3.1-bigquery-pushdown_2.12/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../spark-bigquery-pushdown-parent</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/spark-bigquery-pushdown/spark-bigquery-dsv1-relation_2.11/pom.xml
+++ b/spark-bigquery-pushdown/spark-bigquery-dsv1-relation_2.11/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../spark-bigquery-pushdown-parent</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/spark-bigquery-pushdown/spark-bigquery-dsv1-relation_2.12/pom.xml
+++ b/spark-bigquery-pushdown/spark-bigquery-dsv1-relation_2.12/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../spark-bigquery-pushdown-parent</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.11/pom.xml
+++ b/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.11/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../spark-bigquery-pushdown-parent</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.12/pom.xml
+++ b/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.12/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../spark-bigquery-pushdown-parent</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/spark-bigquery-pushdown/spark-bigquery-pushdown-parent/pom.xml
+++ b/spark-bigquery-pushdown/spark-bigquery-pushdown-parent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>spark-bigquery-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../../spark-bigquery-parent</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/spark-bigquery-python-lib/pom.xml
+++ b/spark-bigquery-python-lib/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../spark-bigquery-parent</relativePath>
   </parent>
 

--- a/spark-bigquery-tests/pom.xml
+++ b/spark-bigquery-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
-    <version>0.24.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <relativePath>../spark-bigquery-parent</relativePath>
   </parent>
 


### PR DESCRIPTION
Should simplify the release process, see https://maven.apache.org/maven-ci-friendly.html