### PR TITLE
Expose the cache expiration time as a parameter #518

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,14 @@ The API Supports a number of options to configure the read
      </td>
      <td>Read</td>
    </tr>
+   <tr valign="top">
+     <td><code>cacheExpirationTimeInMinutes</code>
+     </td>
+     <td>  The expiration time of the in-memory cache storing query information.
+          <br/> (Optional. Defaults to 15 minutes)
+     </td>
+     <td>Read</td>
+   </tr>
 </table>
 
 Options can also be set outside of the code, using the `--conf` parameter of `spark-submit` or `--properties` parameter

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
@@ -34,7 +34,6 @@ import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TableResult;
 import com.google.cloud.http.BaseHttpServiceException;
 import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
@@ -58,20 +57,20 @@ import org.threeten.bp.Duration;
 public class BigQueryClient {
   private static final Logger log = LoggerFactory.getLogger(BigQueryClient.class);
 
-  private static Cache<String, TableInfo> destinationTableCache =
-      CacheBuilder.newBuilder().expireAfterWrite(15, TimeUnit.MINUTES).maximumSize(1000).build();
-
   private final BigQuery bigQuery;
+  private final Cache<String, TableInfo> destinationTableCache;
   private final Optional<String> materializationProject;
   private final Optional<String> materializationDataset;
 
   public BigQueryClient(
       BigQuery bigQuery,
       Optional<String> materializationProject,
-      Optional<String> materializationDataset) {
+      Optional<String> materializationDataset,
+      Cache<String, TableInfo> destinationTableCache) {
     this.bigQuery = bigQuery;
     this.materializationProject = materializationProject;
     this.materializationDataset = materializationDataset;
+    this.destinationTableCache = destinationTableCache;
   }
 
   /**

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryConfig.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryConfig.java
@@ -19,6 +19,7 @@ public class BigQueryClientFactoryConfig implements BigQueryConfig {
   private final RetrySettings bigQueryClientRetrySettings;
   private final BigQueryProxyConfig bigQueryProxyConfig;
   private final Optional<String> endpoint;
+  private final int cacheExpirationTimeInMinutes;
 
   BigQueryClientFactoryConfig(BigQueryConfig bigQueryConfig) {
     this.credentialsKey = bigQueryConfig.getCredentialsKey();
@@ -35,6 +36,7 @@ public class BigQueryClientFactoryConfig implements BigQueryConfig {
     this.bigQueryClientRetrySettings = bigQueryConfig.getBigQueryClientRetrySettings();
     this.bigQueryProxyConfig = bigQueryConfig.getBigQueryProxyConfig();
     this.endpoint = bigQueryConfig.getEndpoint();
+    this.cacheExpirationTimeInMinutes = bigQueryConfig.getCacheExpirationTimeInMinutes();
   }
 
   @Override
@@ -103,6 +105,11 @@ public class BigQueryClientFactoryConfig implements BigQueryConfig {
   }
 
   @Override
+  public int getCacheExpirationTimeInMinutes() {
+    return cacheExpirationTimeInMinutes;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -124,7 +131,8 @@ public class BigQueryClientFactoryConfig implements BigQueryConfig {
         && Objects.equal(materializationDataset, that.materializationDataset)
         && Objects.equal(bigQueryClientRetrySettings, that.bigQueryClientRetrySettings)
         && Objects.equal(bigQueryProxyConfig, that.bigQueryProxyConfig)
-        && Objects.equal(endpoint, that.endpoint);
+        && Objects.equal(endpoint, that.endpoint)
+        && Objects.equal(cacheExpirationTimeInMinutes, that.cacheExpirationTimeInMinutes);
   }
 
   @Override
@@ -142,6 +150,7 @@ public class BigQueryClientFactoryConfig implements BigQueryConfig {
         bigQueryClientReadTimeout,
         bigQueryClientRetrySettings,
         bigQueryProxyConfig,
-        endpoint);
+        endpoint,
+        cacheExpirationTimeInMinutes);
   }
 }

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfig.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfig.java
@@ -45,4 +45,6 @@ public interface BigQueryConfig {
   BigQueryProxyConfig getBigQueryProxyConfig();
 
   Optional<String> getEndpoint();
+
+  int getCacheExpirationTimeInMinutes();
 }

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryTest.java
@@ -390,6 +390,11 @@ public class BigQueryClientFactoryTest {
     }
 
     @Override
+    public int getCacheExpirationTimeInMinutes() {
+      return 0;
+    }
+
+    @Override
     public boolean equals(Object o) {
       if (this == o) {
         return true;

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -100,6 +100,8 @@ public class SparkBigQueryConfigTest {
     assertThat(config.getArrowCompressionCodec())
         .isEqualTo(CompressionCodec.COMPRESSION_UNSPECIFIED);
     assertThat(config.getWriteMethod()).isEqualTo(SparkBigQueryConfig.WriteMethod.INDIRECT);
+    assertThat(config.getCacheExpirationTimeInMinutes())
+        .isEqualTo(SparkBigQueryConfig.DEFAULT_CACHE_EXPIRATION_IN_MINUTES);
   }
 
   @Test
@@ -136,6 +138,7 @@ public class SparkBigQueryConfigTest {
                 .put("httpMaxRetry", "5")
                 .put("arrowCompressionCodec", "ZSTD")
                 .put("writeMethod", "direct")
+                .put("cacheExpirationTimeInMinutes", "100")
                 .build());
     SparkBigQueryConfig config =
         SparkBigQueryConfig.from(
@@ -176,6 +179,7 @@ public class SparkBigQueryConfigTest {
     assertThat(config.getBigQueryClientRetrySettings().getMaxAttempts()).isEqualTo(5);
     assertThat(config.getArrowCompressionCodec()).isEqualTo(CompressionCodec.ZSTD);
     assertThat(config.getWriteMethod()).isEqualTo(SparkBigQueryConfig.WriteMethod.DIRECT);
+    assertThat(config.getCacheExpirationTimeInMinutes()).isEqualTo(100);
   }
 
   @Test


### PR DESCRIPTION
Introduces new parameter `cacheExpirationTimeInMinutes` that defines the TTL of the in-memory cache for materialization to table. The TTL had been by default set to 15 minutes, it remained unchanged.

Tested in SparkBigQueryConfigTest.