### PR TITLE
Exclude com.github.luben.zstd from being shaded

### DIFF
--- a/spark-bigquery-dsv1/spark-bigquery-with-dependencies-parent/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery-with-dependencies-parent/pom.xml
@@ -50,6 +50,7 @@
             <relocation>
               <pattern>com.github</pattern>
               <shadedPattern>com.google.cloud.spark.bigquery.repackaged.com.github</shadedPattern>
+              <!-- Need to exclude the zstd library from being repackaged because of https://github.com/luben/zstd-jni#limitations -->
               <excludes>
                 <exclude>com.github.luben.zstd.**</exclude>
               </excludes>

--- a/spark-bigquery-dsv1/spark-bigquery-with-dependencies-parent/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery-with-dependencies-parent/pom.xml
@@ -50,6 +50,9 @@
             <relocation>
               <pattern>com.github</pattern>
               <shadedPattern>com.google.cloud.spark.bigquery.repackaged.com.github</shadedPattern>
+              <excludes>
+                <exclude>com.github.luben.zstd.**</exclude>
+              </excludes>
             </relocation>
             <relocation>
               <pattern>com.google</pattern>

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-parent/pom.xml
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-parent/pom.xml
@@ -94,6 +94,7 @@
             <relocation>
               <pattern>com.github</pattern>
               <shadedPattern>com.google.cloud.spark.bigquery.repackaged.com.github</shadedPattern>
+              <!-- Need to exclude the zstd library from being repackaged because of https://github.com/luben/zstd-jni#limitations -->
               <excludes>
                 <exclude>com.github.luben.zstd.**</exclude>
               </excludes>

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-parent/pom.xml
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-parent/pom.xml
@@ -94,6 +94,9 @@
             <relocation>
               <pattern>com.github</pattern>
               <shadedPattern>com.google.cloud.spark.bigquery.repackaged.com.github</shadedPattern>
+              <excludes>
+                <exclude>com.github.luben.zstd.**</exclude>
+              </excludes>
             </relocation>
             <relocation>
               <pattern>com.google</pattern>


### PR DESCRIPTION
According to https://github.com/luben/zstd-jni#limitations, the zstd-jni library should not be relocated. 

With this change, ZSTD Arrow compression can now be used without running into NoClassDefFoundError

Thank you @emkornfield! 