### PR TITLE
Fix docs about default values for httpConnectTimeout and httpReadTimeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ The API Supports a number of options to configure the read
      <td> The timeout in milliseconds to establish a connection with BigQuery. Can be alternatively set in the
           Spark configuration (<code>spark.conf.set("httpConnectTimeout", ...)</code>) or in Hadoop Configuration
           (<code>fs.gs.http.connect-timeout</code>).
-          <br/> (Optional. Default is 60000 ms. 0 for an infinite timeout, a negative number for 20000)
+          <br/> (Optional. Default is 20000 ms. 0 for an infinite timeout, a negative number for 20000)
      </td>
      <td>Read/Write</td>
    </tr>
@@ -625,7 +625,7 @@ The API Supports a number of options to configure the read
      <td> The timeout in milliseconds to read data from an established connection. Can be alternatively set in the
           Spark configuration (<code>spark.conf.set("httpReadTimeout", ...)</code>) or in Hadoop Configuration
           (<code>fs.gs.http.read-timeout</code>).
-          <br/> (Optional. Default is 60000 ms. 0 for an infinite timeout, a negative number for 20000)
+          <br/> (Optional. Default is 20000 ms. 0 for an infinite timeout, a negative number for 20000)
      </td>
      <td>Read</td>
    </tr>


### PR DESCRIPTION
Hi!

This PR fixes writing mistakes. Refer to [http-connectors](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/77aa69b2c66f5e2a46ef8f27bb2c210cc16201ef/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemConfiguration.java#L229-L235), the default values for `httpConnectTimeout` and `httpReadTimeout` are 20000 milliseconds.