### PR TITLE
Remove the explicit dependency on netty-tcnative-boringssl-static

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ The API Supports a number of options to configure the read
   <tr valign="top">
    <td><code>datePartition</code>
    </td>
-   <td>The date partition the data is going to be written to. Should be a date string 
+   <td>The date partition the data is going to be written to. Should be a date string
        given in the format <code>YYYYMMDD</code>. Can be used to overwrite the data of
 	   a single partition, like this: <code><br/>df.write.format("bigquery")
        <br/>&nbsp;&nbsp;.option("datePartition", "20220331")

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -62,7 +62,6 @@
         <grpc.version>1.44.1</grpc.version>
         <guava.version>31.1-jre</guava.version>
         <jackson.version>2.13.1</jackson.version>
-        <netty-tcnative-boringssl-static.version>2.0.48.Final</netty-tcnative-boringssl-static.version>
         <netty.version>4.1.73.Final</netty.version>
         <paranamer.version>2.8</paranamer.version>
         <protobuf.version>3.19.4</protobuf.version>
@@ -195,16 +194,6 @@
                 <version>${netty.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-tcnative-boringssl-static</artifactId>
-                <version>${netty-tcnative-boringssl-static.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-tcnative-classes</artifactId>
-                <version>${netty-tcnative-boringssl-static.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.inject</groupId>


### PR DESCRIPTION
As can be seen [here](https://github.com/netty/netty/blob/netty-4.1.73.Final/bom/pom.xml#L68) and [here](https://github.com/netty/netty/blob/netty-4.1.73.Final/bom/pom.xml#L306), we can get the correctly matched netty and netty-tcnative versions from the netty-bom itself