### PR TITLE
Handle the exception in load when job is not created

### DIFF
--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
@@ -514,6 +514,10 @@ public class BigQueryClient {
             finishedJob.getJobId());
       }
     } catch (Exception e) {
+      if (finishedJob == null) {
+        log.error("Unable to create the job to load to {}", BigQueryUtil.friendlyTableName(options.getTableId()));
+        throw e;
+      }
       TimePartitioning.Type partitionType = options.getPartitionTypeOrDefault();
 
       if (e.getMessage()

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
@@ -515,7 +515,9 @@ public class BigQueryClient {
       }
     } catch (Exception e) {
       if (finishedJob == null) {
-        log.error("Unable to create the job to load to {}", BigQueryUtil.friendlyTableName(options.getTableId()));
+        log.error(
+            "Unable to create the job to load to {}",
+            BigQueryUtil.friendlyTableName(options.getTableId()));
         throw e;
       }
       TimePartitioning.Type partitionType = options.getPartitionTypeOrDefault();


### PR DESCRIPTION
I added a check to see if the `finishedJob` is `null`. If it is, then just re-throw the exception thrown by the `google-cloud-bigquery` library.