### PR TITLE
Use a helper to handle custom data type to avoid Spark ML dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ dependency-reduced-pom.xml
 
 # ad-hoc tests, should not be added to git
 AdAdHocITSuite.scala
+
+.DS_Store

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SchemaConverters.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SchemaConverters.java
@@ -279,13 +279,11 @@ public class SchemaConverters {
   static Optional<DataType> getCustomDataType(Field field) {
     // metadata is kept in the description
     String description = field.getDescription();
-    if (description != null) {
-      // All supported types are serialized to records
-      if (LegacySQLTypeName.RECORD.equals(field.getType())) {
-        // we don't have many types, so we keep parsing to minimum
-        return SupportedCustomDataType.forDescription(description)
-            .map(SupportedCustomDataType::getSparkDataType);
-      }
+    // All supported types are serialized to record
+    if (description != null && LegacySQLTypeName.RECORD.equals(field.getType())) {
+      // we don't have many types, so we keep parsing to minimum
+      return SupportedCustomDataTypeHelper.forDescription(description)
+          .map(SupportedCustomDataType::getSparkDataType);
     }
     return Optional.empty();
   }

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SupportedCustomDataType.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SupportedCustomDataType.java
@@ -41,6 +41,12 @@ public enum SupportedCustomDataType {
     return typeMarker;
   }
 
+  /**
+   * @deprecated use {@link SupportedCustomDataTypeHelper#of(DataType)} instead to avoid unnecessary
+   *     dependency to Spark ML library
+   */
+  @SuppressWarnings({"unused", "java:S1133"})
+  @Deprecated
   public static Optional<SupportedCustomDataType> of(DataType dataType) {
     Preconditions.checkNotNull(dataType);
     return Stream.of(values())
@@ -48,6 +54,14 @@ public enum SupportedCustomDataType {
         .findFirst();
   }
 
+  /**
+   * Find the data type from its description.
+   *
+   * @deprecated use {@link SupportedCustomDataTypeHelper#forDescription(String)} instead to avoid
+   *     unnecessary dependency to Spark ML library
+   */
+  @SuppressWarnings({"unused", "java:S1133"})
+  @Deprecated
   public static Optional<SupportedCustomDataType> forDescription(String description) {
     Preconditions.checkNotNull(description, "description cannot be null");
     return Stream.of(values())

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SupportedCustomDataTypeHelper.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SupportedCustomDataTypeHelper.java
@@ -11,7 +11,6 @@ import org.apache.spark.sql.types.DataType;
  * ML library to avoid run-time exception even though the code doesn't need Spark ML library.
  */
 public enum SupportedCustomDataTypeHelper {
-
   SPARK_ML_VECTOR("vector"),
   SPARK_ML_MATRIX("matrix");
 

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SupportedCustomDataTypeHelper.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SupportedCustomDataTypeHelper.java
@@ -1,0 +1,51 @@
+package com.google.cloud.spark.bigquery;
+
+import com.google.common.base.Preconditions;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.apache.spark.sql.types.DataType;
+
+/**
+ * This helper is to avoid accessing {@link SupportedCustomDataType} class if not necessary. That
+ * class is mostly to support Spark ML specific types. That forces the user's code to include Spark
+ * ML library to avoid run-time exception even though the code doesn't need Spark ML library.
+ */
+public enum SupportedCustomDataTypeHelper {
+
+  SPARK_ML_VECTOR("vector"),
+  SPARK_ML_MATRIX("matrix");
+
+  private final String typeName;
+  private final String typeMarker;
+
+  SupportedCustomDataTypeHelper(String typeName) {
+    this.typeName = typeName;
+    this.typeMarker = "{spark.type=" + typeName + "}";
+  }
+
+  public static Optional<SupportedCustomDataType> of(DataType dataType) {
+    Preconditions.checkNotNull(dataType);
+    Optional<SupportedCustomDataTypeHelper> foundValue =
+        Stream.of(values())
+            .filter(
+                supportedCustomDataType ->
+                    supportedCustomDataType.typeName.equals(dataType.typeName()))
+            .findFirst();
+    return foundValue.map(SupportedCustomDataTypeHelper::toSupportedCustomDataType);
+  }
+
+  public static Optional<SupportedCustomDataType> forDescription(String description) {
+    Preconditions.checkNotNull(description, "description cannot be null");
+    Optional<SupportedCustomDataTypeHelper> foundValue =
+        Stream.of(values())
+            .filter(dataType -> description.endsWith(dataType.typeMarker))
+            .findFirst();
+    return foundValue.map(SupportedCustomDataTypeHelper::toSupportedCustomDataType);
+  }
+
+  private static SupportedCustomDataType toSupportedCustomDataType(
+      SupportedCustomDataTypeHelper type) {
+    if (type.equals(SPARK_ML_VECTOR)) return SupportedCustomDataType.SPARK_ML_VECTOR;
+    else return SupportedCustomDataType.SPARK_ML_MATRIX;
+  }
+}

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SupportedCustomDataTypeHelperTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SupportedCustomDataTypeHelperTest.java
@@ -1,0 +1,49 @@
+package com.google.cloud.spark.bigquery;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Optional;
+import org.apache.spark.ml.linalg.SQLDataTypes;
+import org.apache.spark.sql.types.DataTypes;
+import org.junit.Test;
+
+public class SupportedCustomDataTypeHelperTest {
+
+  @Test
+  public void testVectorFromDescription() {
+    Optional<SupportedCustomDataType> vector =
+        SupportedCustomDataTypeHelper.forDescription("{spark.type=vector}");
+    assertThat(vector.isPresent()).isTrue();
+    assertThat(vector.get())
+        .isEquivalentAccordingToCompareTo(SupportedCustomDataType.SPARK_ML_VECTOR);
+  }
+
+  @Test
+  public void testMatrixFromDescription() {
+    Optional<SupportedCustomDataType> matrix =
+        SupportedCustomDataTypeHelper.forDescription("{spark.type=matrix}");
+    assertThat(matrix.isPresent()).isTrue();
+    assertThat(matrix.get())
+        .isEquivalentAccordingToCompareTo(SupportedCustomDataType.SPARK_ML_MATRIX);
+  }
+
+  @Test
+  public void testUnsupportedFromDescription() {
+    Optional<SupportedCustomDataType> unsupported =
+        SupportedCustomDataTypeHelper.forDescription("{spark.type=unsupported}");
+    assertThat(unsupported.isPresent()).isFalse();
+  }
+
+  @Test
+  public void testOfDataType() {
+    Optional<SupportedCustomDataType> matrix =
+        SupportedCustomDataTypeHelper.of(SQLDataTypes.MatrixType());
+    assertThat(matrix.isPresent()).isTrue();
+    assertThat(matrix.get())
+        .isEquivalentAccordingToCompareTo(SupportedCustomDataType.SPARK_ML_MATRIX);
+
+    Optional<SupportedCustomDataType> notCustom =
+        SupportedCustomDataTypeHelper.of(DataTypes.StringType);
+    assertThat(notCustom.isPresent()).isFalse();
+  }
+}

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SupportedCustomDataTypeTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SupportedCustomDataTypeTest.java
@@ -36,4 +36,12 @@ public class SupportedCustomDataTypeTest {
         SupportedCustomDataType.of(SQLDataTypes.MatrixType());
     assertThat(matrix.isPresent()).isTrue();
   }
+
+  @Test
+  public void testGetTypeMarker() {
+    assertThat(SupportedCustomDataType.SPARK_ML_MATRIX.getTypeMarker())
+        .isEqualTo("{spark.type=matrix}");
+    assertThat(SupportedCustomDataType.SPARK_ML_VECTOR.getTypeMarker())
+        .isEqualTo("{spark.type=vector}");
+  }
 }

--- a/spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/BigQueryWriteHelper.scala
+++ b/spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/BigQueryWriteHelper.scala
@@ -93,7 +93,7 @@ case class BigQueryWriteHelper(bigQueryClient: BigQueryClient,
     val fieldsToUpdate = data.schema
       .filter {
         field =>
-          SupportedCustomDataType.of(field.dataType).isPresent ||
+          SupportedCustomDataTypeHelper.of(field.dataType).isPresent ||
             getDescriptionOrCommentOfField(field).isPresent}
       .map (field => (field.name, field))
       .toMap
@@ -119,10 +119,10 @@ case class BigQueryWriteHelper(bigQueryClient: BigQueryClient,
     val newField = field.toBuilder
     val bqDescription = getDescriptionOrCommentOfField(dataField)
 
-    if(bqDescription.isPresent){
+    if(bqDescription.isPresent) {
       newField.setDescription(bqDescription.get)
     } else {
-      val marker = SupportedCustomDataType.of(dataField.dataType).get.getTypeMarker
+      val marker = SupportedCustomDataTypeHelper.of(dataField.dataType).get.getTypeMarker
       val description = field.getDescription
       if (description == null) {
         newField.setDescription(marker)

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryIndirectDataSourceWriterContext.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryIndirectDataSourceWriterContext.java
@@ -27,7 +27,7 @@ import com.google.cloud.spark.bigquery.AvroSchemaConverter;
 import com.google.cloud.spark.bigquery.SchemaConverters;
 import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
 import com.google.cloud.spark.bigquery.SparkBigQueryUtil;
-import com.google.cloud.spark.bigquery.SupportedCustomDataType;
+import com.google.cloud.spark.bigquery.SupportedCustomDataTypeHelper;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Iterator;
@@ -166,7 +166,7 @@ public class BigQueryIndirectDataSourceWriterContext implements DataSourceWriter
         Stream.of(sparkSchema.fields())
             .filter(
                 field ->
-                    SupportedCustomDataType.of(field.dataType()).isPresent()
+                    SupportedCustomDataTypeHelper.of(field.dataType()).isPresent()
                         || SchemaConverters.getDescriptionOrCommentOfField(field).isPresent())
             .collect(Collectors.toMap(StructField::name, Function.identity()));
 
@@ -202,7 +202,7 @@ public class BigQueryIndirectDataSourceWriterContext implements DataSourceWriter
       newField.setDescription(bqDescription.get());
     } else {
       String description = field.getDescription();
-      String marker = SupportedCustomDataType.of(sparkSchemaField.dataType()).get().getTypeMarker();
+      String marker = SupportedCustomDataTypeHelper.of(sparkSchemaField.dataType()).get().getTypeMarker();
 
       if (description == null) {
         newField.setDescription(marker);


### PR DESCRIPTION
In this PR, I added a helper class that does type lookup to see if we actually need to load `SupportedCustomDataType`. This class imports data types from Spark ML which forces the client code to import this library as well. More explanation of the issue can be found https://github.com/GoogleCloudDataproc/spark-bigquery-connector/issues/599

In my application, I had:

- Spark Core 3.1.3
- Spark SQL 3.1.3
- spark-bigquery-with-dependencies 0.24.2

I faced the issue and fixed it by adding Spark ML 3.1.3.

Then applied this fix and installed it locally as version 0.25.0. Updated spark-bigquery-with-dependencies to 0.25.0 and removed Spark ML 3.1.3. It then worked as expected.

Hence, I believe this patch is valuable to have in the code.