### PR TITLE
changes to support cacheExpirationTimeInMinutes=0, if user wants to disable cache

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,8 @@ each building only a subset of the project's artifacts. The profiles are:
 Example: In order to compile **just** the Scala 2.12 connector run
 `./mvnw install -Pdsv1_2.12`.
 
+**Note**: Need java 1.8 and make sure **/usr/libexec/java_home** set to java 1.8 before building any module.
+
 **Important**: If no profile is selected, then only the common artifacts are run.
 
 The integration and acceptance tests are disabled by default. In order to run it please add the

--- a/README.md
+++ b/README.md
@@ -667,6 +667,7 @@ The API Supports a number of options to configure the read
      <td><code>cacheExpirationTimeInMinutes</code>
      </td>
      <td>  The expiration time of the in-memory cache storing query information.
+          <br/> To disable caching, set the value to 0.
           <br/> (Optional. Defaults to 15 minutes)
      </td>
      <td>Read</td>

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -366,7 +366,7 @@ public class SparkBigQueryConfig
         getAnyOption(globalOptions, options, "cacheExpirationTimeInMinutes")
             .transform(Integer::parseInt)
             .or(DEFAULT_CACHE_EXPIRATION_IN_MINUTES);
-    if (config.cacheExpirationTimeInMinutes < 1) {
+    if (config.cacheExpirationTimeInMinutes < 0) {
       throw new IllegalArgumentException(
           "cacheExpirationTimeInMinutes must have a positive value, the configured value is "
               + config.cacheExpirationTimeInMinutes);

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -191,6 +191,29 @@ public class SparkBigQueryConfigTest {
   }
 
   @Test
+  public void testCacheExpirationSetToZero() {
+    Configuration hadoopConfiguration = new Configuration();
+    DataSourceOptions options =
+        new DataSourceOptions(
+            ImmutableMap.<String, String>builder()
+                .put("table", "test_t")
+                .put("dataset", "test_d")
+                .put("project", "test_p")
+                .put("cacheExpirationTimeInMinutes", "0")
+                .build());
+    SparkBigQueryConfig config =
+        SparkBigQueryConfig.from(
+            options.asMap(),
+            ImmutableMap.of(),
+            hadoopConfiguration,
+            DEFAULT_PARALLELISM,
+            new SQLConf(),
+            SPARK_VERSION,
+            Optional.empty());
+    assertThat(config.getCacheExpirationTimeInMinutes()).isEqualTo(0);
+  }
+
+  @Test
   public void testInvalidCompressionCodec() {
     Configuration hadoopConfiguration = new Configuration();
     DataSourceOptions options =

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -214,6 +214,37 @@ public class SparkBigQueryConfigTest {
   }
 
   @Test
+  public void testCacheExpirationSetToNegative() {
+    Configuration hadoopConfiguration = new Configuration();
+    DataSourceOptions options =
+        new DataSourceOptions(
+            ImmutableMap.<String, String>builder()
+                .put("table", "test_t")
+                .put("dataset", "test_d")
+                .put("project", "test_p")
+                .put("cacheExpirationTimeInMinutes", "-1")
+                .build());
+
+    IllegalArgumentException exception =
+        Assert.assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                SparkBigQueryConfig.from(
+                    options.asMap(),
+                    ImmutableMap.of(),
+                    hadoopConfiguration,
+                    DEFAULT_PARALLELISM,
+                    new SQLConf(),
+                    SPARK_VERSION,
+                    Optional.empty()));
+
+    assertThat(exception)
+        .hasMessageThat()
+        .contains(
+            "cacheExpirationTimeInMinutes must have a positive value, the configured value is -1");
+  }
+
+  @Test
   public void testInvalidCompressionCodec() {
     Configuration hadoopConfiguration = new Configuration();
     DataSourceOptions options =


### PR DESCRIPTION
Fix to the issue: https://github.com/GoogleCloudDataproc/spark-bigquery-connector/issues/593

changes to support cacheExpirationTimeInMinutes=0, if user wants to disable cache
Added unit test
Ran integration tests