### PR TITLE
Removed 2:45 minutes from the spark 2.4 integration test time 

### DIFF
--- a/spark-bigquery-dsv2/spark-2.4-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark24DirectWriteIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-2.4-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark24DirectWriteIntegrationTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration;
+
+import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
+
+public class Spark24DirectWriteIntegrationTest extends WriteIntegrationTestBase {
+
+  public Spark24DirectWriteIntegrationTest() {
+    super(SparkBigQueryConfig.WriteMethod.DIRECT);
+  }
+
+  // tests from superclass
+}

--- a/spark-bigquery-dsv2/spark-2.4-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark24IndirectWriteIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-2.4-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark24IndirectWriteIntegrationTest.java
@@ -16,24 +16,11 @@
 package com.google.cloud.spark.bigquery.integration;
 
 import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
-import java.util.Arrays;
-import java.util.Collection;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
-@RunWith(Parameterized.class)
-public class Spark24WriteIntegrationTest extends WriteIntegrationTestBase {
+public class Spark24IndirectWriteIntegrationTest extends WriteIntegrationTestBase {
 
-  @Parameterized.Parameters(name = "{0}")
-  public static Collection<SparkBigQueryConfig.WriteMethod[]> formats() {
-    return Arrays.asList(
-        new SparkBigQueryConfig.WriteMethod[][] {
-          {SparkBigQueryConfig.WriteMethod.DIRECT}, {SparkBigQueryConfig.WriteMethod.INDIRECT}
-        });
-  }
-
-  public Spark24WriteIntegrationTest(SparkBigQueryConfig.WriteMethod writeMethod) {
-    super(writeMethod);
+  public Spark24IndirectWriteIntegrationTest() {
+    super(SparkBigQueryConfig.WriteMethod.INDIRECT);
   }
 
   // tests from superclass


### PR DESCRIPTION
This was done by splitting the write test to two classes