### PR TITLE
Added field level schema check in indirect mode and an option to ignoring the mode, during field comparison

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -678,6 +678,15 @@ The API Supports a number of options to configure the read
      </td>
      <td>Read</td>
    </tr>
+   <tr valign="top">
+     <td><code>enableModeCheckForSchemaFields</code>
+     </td>
+     <td>  Checks the mode of every field in destination schema to be equal to the mode in corresponding source field schema, while writing from one big query table to another.
+          <br/> Default value is true i.e., the check is done by default. If set to false the mode check is ignored.
+          <br/> This property is respected only in indirect write. In direct write the check is always done.
+     </td>
+     <td>Write</td>
+   </tr>
 </table>
 
 Options can also be set outside of the code, using the `--conf` parameter of `spark-submit` or `--properties` parameter

--- a/README.md
+++ b/README.md
@@ -672,6 +672,15 @@ The API Supports a number of options to configure the read
      </td>
      <td>Read</td>
    </tr>
+   <tr valign="top">
+     <td><code>enableModeCheckForSchemaFields</code>
+     </td>
+     <td>  Checks the mode of every field in destination schema to be equal to the mode in corresponding source field schema, while writing from one big query table to another.
+          <br/> Default value is true i.e., the check is done by default. If set to false the mode check is ignored.
+          <br/> This property is respected only in indirect write. In direct write the check is always done.
+     </td>
+     <td>Write</td>
+   </tr>
 </table>
 
 Options can also be set outside of the code, using the `--conf` parameter of `spark-submit` or `--properties` parameter

--- a/README.md
+++ b/README.md
@@ -672,15 +672,6 @@ The API Supports a number of options to configure the read
      </td>
      <td>Read</td>
    </tr>
-   <tr valign="top">
-     <td><code>enableModeCheckForSchemaFields</code>
-     </td>
-     <td>  Checks the mode of every field in destination schema to be equal to the mode in corresponding source field schema, while writing from one big query table to another.
-          <br/> Default value is true i.e., the check is done by default. If set to false the mode check is ignored.
-          <br/> This property is respected only in indirect write. In direct write the check is always done.
-     </td>
-     <td>Write</td>
-   </tr>
 </table>
 
 Options can also be set outside of the code, using the `--conf` parameter of `spark-submit` or `--properties` parameter

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
@@ -466,8 +466,8 @@ public class BigQueryClient {
       Preconditions.checkArgument(
           BigQueryUtil.schemaEquals(
               destinationTableSchema,
-              sourceTableSchema, /* regardFieldOrder */
-              false,
+              sourceTableSchema,
+              /* regardFieldOrder */ false,
               options.getEnableModeCheckForSchemaFields()),
           new BigQueryConnectorException.InvalidSchemaException(
               "Destination table's schema is not compatible with dataframe's schema"));

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -152,6 +152,7 @@ public class SparkBigQueryConfig
   int materializationExpirationTimeInMinutes = DEFAULT_MATERIALIZATION_EXPRIRATION_TIME_IN_MINUTES;
   int maxReadRowsRetries = 3;
   boolean pushAllFilters = true;
+  boolean enableModeCheckForSchemaFields = true;
   private com.google.common.base.Optional<String> encodedCreateReadSessionRequest = empty();
   private com.google.common.base.Optional<String> storageReadEndpoint = empty();
   private int numBackgroundThreadsPerStream = 0;
@@ -334,6 +335,8 @@ public class SparkBigQueryConfig
             .transform(Integer::parseInt)
             .or(0);
     config.pushAllFilters = getAnyBooleanOption(globalOptions, options, "pushAllFilters", true);
+    config.enableModeCheckForSchemaFields =
+        getAnyBooleanOption(globalOptions, options, "enableModeCheckForSchemaFields", true);
     config.numPrebufferReadRowsResponses =
         getAnyOption(globalOptions, options, "bqPrebufferResponsesPerStream")
             .transform(Integer::parseInt)
@@ -706,6 +709,10 @@ public class SparkBigQueryConfig
 
   public boolean getPushAllFilters() {
     return pushAllFilters;
+  }
+
+  public boolean getEnableModeCheckForSchemaFields() {
+    return enableModeCheckForSchemaFields;
   }
 
   // in order to simplify the configuration, the BigQuery client settings are fixed. If needed

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -104,6 +104,7 @@ public class SparkBigQueryConfigTest {
         .isEqualTo(SparkBigQueryConfig.DEFAULT_CACHE_EXPIRATION_IN_MINUTES);
     assertThat(config.getTraceId().isPresent()).isFalse();
     assertThat(config.getBigQueryJobLabels()).isEmpty();
+    assertThat(config.getEnableModeCheckForSchemaFields()).isTrue();
   }
 
   @Test
@@ -144,6 +145,7 @@ public class SparkBigQueryConfigTest {
                 .put("traceJobId", "traceJobId")
                 .put("traceApplicationName", "traceApplicationName")
                 .put("bigQueryJobLabel.foo", "bar")
+                .put("enableModeCheckForSchemaFields", "false")
                 .build());
     SparkBigQueryConfig config =
         SparkBigQueryConfig.from(
@@ -188,6 +190,7 @@ public class SparkBigQueryConfigTest {
     assertThat(config.getTraceId()).isEqualTo(Optional.of("Spark:traceApplicationName:traceJobId"));
     assertThat(config.getBigQueryJobLabels()).hasSize(1);
     assertThat(config.getBigQueryJobLabels()).containsEntry("foo", "bar");
+    assertThat(config.getEnableModeCheckForSchemaFields()).isFalse();
   }
 
   @Test

--- a/spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/BigQueryWriteHelper.scala
+++ b/spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/BigQueryWriteHelper.scala
@@ -22,6 +22,7 @@ import com.google.cloud.bigquery._
 import com.google.cloud.bigquery.connector.common.{BigQueryClient, BigQueryUtil}
 import com.google.cloud.http.BaseHttpServiceException
 import com.google.cloud.spark.bigquery.SchemaConverters.getDescriptionOrCommentOfField
+import com.google.cloud.spark.bigquery.SchemaConverters.toBigQuerySchema
 import com.google.common.collect.ImmutableList
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path, RemoteIterator}
@@ -84,7 +85,11 @@ case class BigQueryWriteHelper(bigQueryClient: BigQueryClient,
       .asJava)
     val writeDisposition = SparkBigQueryUtil.saveModeToWriteDisposition(saveMode)
 
-    bigQueryClient.loadDataIntoTable(options, sourceUris, formatOptions, writeDisposition)
+    var sourceSchema: Schema = null
+    if (options.schema.isPresent) {
+      sourceSchema = toBigQuerySchema(options.schema.get())
+    }
+    bigQueryClient.loadDataIntoTable(options, sourceUris, formatOptions, writeDisposition, sourceSchema)
   }
 
   def friendlyTableName: String = BigQueryUtil.friendlyTableName(options.getTableId)

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark31ReadIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark31ReadIntegrationTest.java
@@ -15,8 +15,6 @@
  */
 package com.google.cloud.spark.bigquery.integration;
 
-import org.junit.Test;
-
 public class Spark31ReadIntegrationTest extends ReadIntegrationTestBase {
 
   // tests are from the super-class

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryDirectDataSourceWriterContext.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryDirectDataSourceWriterContext.java
@@ -117,7 +117,8 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
       TableInfo destinationTable = bigQueryClient.getTable(destinationTableId);
       Schema tableSchema = destinationTable.getDefinition().getSchema();
       Preconditions.checkArgument(
-          BigQueryUtil.schemaEquals(tableSchema, bigQuerySchema, /* regardFieldOrder */ false),
+          BigQueryUtil.schemaEquals(
+              tableSchema, bigQuerySchema, /* regardFieldOrder */ false, true),
           new BigQueryConnectorException.InvalidSchemaException(
               "Destination table's schema is not compatible with dataframe's schema"));
       switch (saveMode) {

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryIndirectDataSourceWriterContext.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryIndirectDataSourceWriterContext.java
@@ -22,14 +22,12 @@ import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.TableDefinition;
 import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.connector.common.BigQueryClient;
-import com.google.cloud.bigquery.connector.common.BigQueryConnectorException;
 import com.google.cloud.bigquery.connector.common.BigQueryUtil;
 import com.google.cloud.spark.bigquery.AvroSchemaConverter;
 import com.google.cloud.spark.bigquery.SchemaConverters;
 import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
 import com.google.cloud.spark.bigquery.SparkBigQueryUtil;
 import com.google.cloud.spark.bigquery.SupportedCustomDataType;
-import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Iterator;
@@ -154,26 +152,22 @@ public class BigQueryIndirectDataSourceWriterContext implements DataSourceWriter
   }
 
   void loadDataToBigQuery(List<String> sourceUris) throws IOException {
-    if (bigQueryClient.tableExists(config.getTableId())) {
-      TableInfo destinationTable = bigQueryClient.getTable(config.getTableId());
-      Schema destinationTableSchema = destinationTable.getDefinition().getSchema();
-      Schema sourceTableSchema = SchemaConverters.toBigQuerySchema(sparkSchema);
-      Preconditions.checkArgument(
-          BigQueryUtil.schemaEquals(
-              destinationTableSchema,
-              sourceTableSchema, /* regardFieldOrder */
-              false,
-              config.getEnableModeCheckForSchemaFields()),
-          new BigQueryConnectorException.InvalidSchemaException(
-              "Destination table's schema is not compatible with dataframe's schema"));
-    }
     // Solving Issue #248
     List<String> optimizedSourceUris = SparkBigQueryUtil.optimizeLoadUriListForSpark(sourceUris);
     JobInfo.WriteDisposition writeDisposition =
         SparkBigQueryUtil.saveModeToWriteDisposition(saveMode);
     FormatOptions formatOptions = config.getIntermediateFormat().getFormatOptions();
 
-    bigQueryClient.loadDataIntoTable(config, optimizedSourceUris, formatOptions, writeDisposition);
+    Schema sourceTableSchema = null;
+    if (sparkSchema != null) {
+      sourceTableSchema = SchemaConverters.toBigQuerySchema(sparkSchema);
+    }
+    bigQueryClient.loadDataIntoTable(
+        config,
+        optimizedSourceUris,
+        formatOptions,
+        writeDisposition,
+        sourceTableSchema);
   }
 
   void updateMetadataIfNeeded() {

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryIndirectDataSourceWriterContext.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryIndirectDataSourceWriterContext.java
@@ -163,11 +163,7 @@ public class BigQueryIndirectDataSourceWriterContext implements DataSourceWriter
       sourceTableSchema = SchemaConverters.toBigQuerySchema(sparkSchema);
     }
     bigQueryClient.loadDataIntoTable(
-        config,
-        optimizedSourceUris,
-        formatOptions,
-        writeDisposition,
-        sourceTableSchema);
+        config, optimizedSourceUris, formatOptions, writeDisposition, sourceTableSchema);
   }
 
   void updateMetadataIfNeeded() {

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/SparkBigQueryIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/SparkBigQueryIntegrationTestBase.java
@@ -69,6 +69,16 @@ public class SparkBigQueryIntegrationTestBase {
               TestConstants.STRUCT_COLUMN_ORDER_TEST_TABLE_QUERY_TEMPLATE,
               testDataset,
               TestConstants.STRUCT_COLUMN_ORDER_TEST_TABLE_NAME));
+      IntegrationTestUtils.runQuery(
+          String.format(
+              TestConstants.DIFF_IN_SCHEMA_SRC_TABLE,
+              testDataset,
+              TestConstants.DIFF_IN_SCHEMA_SRC_TABLE_NAME));
+      IntegrationTestUtils.runQuery(
+          String.format(
+              TestConstants.DIFF_IN_SCHEMA_DEST_TABLE,
+              testDataset,
+              TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME));
     }
 
     @Override

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/TestConstants.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/TestConstants.java
@@ -103,6 +103,8 @@ public class TestConstants {
   static final String STRUCT_COLUMN_ORDER_TEST_TABLE_NAME = "struct_column_order";
   static final String ALL_TYPES_TABLE_NAME = "all_types";
   static final String ALL_TYPES_VIEW_NAME = "all_types_view";
+  static final String DIFF_IN_SCHEMA_SRC_TABLE_NAME = "src_table";
+  static final String DIFF_IN_SCHEMA_DEST_TABLE_NAME = "dest_table";
   static DataType BQ_NUMERIC = DataTypes.createDecimalType(38, 9);
   public static int BIG_NUMERIC_COLUMN_POSITION = 11;
 
@@ -223,6 +225,22 @@ public class TestConstants {
               "   struct(\"1:str1\" as str1, \"1:str2\" as str2, \"1:str3\" as str3)",
               " ] as string_struct_arr",
               ") as nums")
+          .collect(Collectors.joining("\n"));
+
+  public static String DIFF_IN_SCHEMA_SRC_TABLE =
+      Stream.of(
+              "create table %s.%s (",
+              "int_req int64 not null,",
+              "int_null int64,",
+              ") as",
+              "",
+              "select",
+              "42 as int_req,",
+              "null as int_null")
+          .collect(Collectors.joining("\n"));
+
+  public static String DIFF_IN_SCHEMA_DEST_TABLE =
+      Stream.of("create table %s.%s (", "int_req int64,", "int_null int64,", ")", "")
           .collect(Collectors.joining("\n"));
 
   public static List<Column> ALL_TYPES_TABLE_COLS =

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -32,6 +32,7 @@ import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.spark.bigquery.SchemaConverters;
 import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
+import com.google.cloud.spark.bigquery.SparkBigQueryConfig.WriteMethod;
 import com.google.cloud.spark.bigquery.integration.model.Data;
 import com.google.cloud.spark.bigquery.integration.model.Friend;
 import com.google.cloud.spark.bigquery.integration.model.Link;
@@ -249,6 +250,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   @Test
   @Ignore("DSv2 only")
   public void testDirectWriteToBigQueryWithDiffInSchema() {
+    assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
     spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =
         spark
@@ -263,13 +265,14 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
             df.write()
                 .format("bigquery")
                 .mode(SaveMode.Append)
-                .option("writeMethod", "direct")
+                .option("writeMethod", writeMethod.toString())
                 .save(testDataset + "." + TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME));
   }
 
   @Test
   @Ignore("DSv2 only")
   public void testDirectWriteToBigQueryWithDiffInSchemaAndDisableModeCheck() {
+    assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
     spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =
         spark
@@ -284,7 +287,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
             df.write()
                 .format("bigquery")
                 .mode(SaveMode.Append)
-                .option("writeMethod", "direct")
+                .option("writeMethod", writeMethod.toString())
                 .option("enableModeCheckForSchemaFields", false)
                 .save(testDataset + "." + TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME));
   }
@@ -292,6 +295,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   @Test
   @Ignore("DSv2 only")
   public void testInDirectWriteToBigQueryWithDiffInSchemaAndModeCheck() {
+    assumeThat(writeMethod, equalTo(SparkBigQueryConfig.WriteMethod.INDIRECT));
     spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =
         spark
@@ -306,13 +310,14 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
             df.write()
                 .format("bigquery")
                 .mode(SaveMode.Append)
-                .option("writeMethod", "indirect")
+                .option("writeMethod", writeMethod.toString())
                 .option("enableModeCheckForSchemaFields", true)
                 .save(testDataset + "." + TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME));
   }
 
   @Test
-  public void testIndirectWriteToBigQueryWithDiffInSchemaNullableFieldAndDisableModeCheckk() {
+  public void testIndirectWriteToBigQueryWithDiffInSchemaNullableFieldAndDisableModeCheck() {
+    assumeThat(writeMethod, equalTo(SparkBigQueryConfig.WriteMethod.INDIRECT));
     spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =
         spark
@@ -324,7 +329,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
     df.write()
         .format("bigquery")
         .mode(SaveMode.Append)
-        .option("writeMethod", "indirect")
+        .option("writeMethod", writeMethod.toString())
         .option("enableModeCheckForSchemaFields", false)
         .save(testDataset + "." + TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
   }

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -47,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.spark.SparkException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
@@ -137,7 +136,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   }
 
   protected void writeToBigQuery(Dataset<Row> df, SaveMode mode) {
-    writeToBigQuery(df, mode, "parquet");
+    writeToBigQuery(df, mode, "avro");
   }
 
   protected void writeToBigQuery(Dataset<Row> df, SaveMode mode, String format) {
@@ -293,7 +292,6 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   }
 
   @Test
-  @Ignore("DSv2 only")
   public void testInDirectWriteToBigQueryWithDiffInSchemaAndModeCheck() {
     assumeThat(writeMethod, equalTo(SparkBigQueryConfig.WriteMethod.INDIRECT));
     spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
@@ -305,7 +303,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
             .load();
 
     assertThrows(
-        SparkException.class,
+        Exception.class,
         () ->
             df.write()
                 .format("bigquery")


### PR DESCRIPTION
Added field level schema check in indirect mode while writing data to BigQuery and an option (enableModeCheckForSchemaFields) to ignoring the mode, during field comparison
