### PR TITLE
Created a Spark expression factory to avoid binary compatibility issues

### DIFF
--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/AggregateQuery.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/AggregateQuery.scala
@@ -29,12 +29,14 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, NamedExpression}
  */
 case class AggregateQuery(
    expressionConverter: SparkExpressionConverter,
+   expressionFactory: SparkExpressionFactory,
    projectionColumns: Seq[NamedExpression],
    groups: Seq[Expression],
    child: BigQuerySQLQuery,
    alias: String
  ) extends BigQuerySQLQuery(
   expressionConverter,
+  expressionFactory,
   alias,
   children = Seq(child),
   projections = if (projectionColumns.isEmpty) None else Some(projectionColumns)) {

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/BigQuerySQLQuery.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/BigQuerySQLQuery.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, AttributeRef
  */
 abstract class BigQuerySQLQuery(
   expressionConverter: SparkExpressionConverter,
+  expressionFactory: SparkExpressionFactory,
   alias: String,
   children: Seq[BigQuerySQLQuery] = Seq.empty,
   projections: Option[Seq[NamedExpression]] = None,
@@ -86,7 +87,7 @@ abstract class BigQuerySQLQuery(
             }
         )
     )
-    .map(p => renameColumns(p, alias))
+    .map(p => renameColumns(p, alias, expressionFactory))
 
   /** Convert processedProjections into a BigQuerySQLStatement */
   val columns: Option[BigQuerySQLStatement] =

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/FilterQuery.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/FilterQuery.scala
@@ -28,11 +28,13 @@ import org.apache.spark.sql.catalyst.expressions.Expression
  */
 case class FilterQuery(
     expressionConverter: SparkExpressionConverter,
+    expressionFactory: SparkExpressionFactory,
     conditions: Seq[Expression],
     child: BigQuerySQLQuery,
     alias: String)
   extends BigQuerySQLQuery(
     expressionConverter,
+    expressionFactory,
     alias,
     children = Seq(child)) {
 

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/ProjectQuery.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/ProjectQuery.scala
@@ -27,10 +27,12 @@ import org.apache.spark.sql.catalyst.expressions.NamedExpression
  */
 case class ProjectQuery(
      expressionConverter: SparkExpressionConverter,
+     expressionFactory: SparkExpressionFactory,
      projectionColumns: Seq[NamedExpression],
      child: BigQuerySQLQuery,
      alias: String)
   extends BigQuerySQLQuery(
     expressionConverter,
+    expressionFactory,
     alias, children = Seq(child),
     projections = Some(projectionColumns)) {}

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SortLimitQuery.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SortLimitQuery.scala
@@ -29,12 +29,14 @@ import org.apache.spark.sql.catalyst.expressions.Expression
  */
 case class SortLimitQuery(
    expressionConverter: SparkExpressionConverter,
+   expressionFactory: SparkExpressionFactory,
    limit: Option[Expression],
    orderBy: Seq[Expression],
    child: BigQuerySQLQuery,
    alias: String)
   extends BigQuerySQLQuery(
     expressionConverter,
+    expressionFactory,
     alias,
     children = Seq(child)) {
 

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SourceQuery.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SourceQuery.scala
@@ -28,11 +28,13 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
  */
 case class SourceQuery(
     expressionConverter: SparkExpressionConverter,
+    expressionFactory: SparkExpressionFactory,
     tableName: String,
     outputAttributes: Seq[Attribute],
     alias: String)
   extends BigQuerySQLQuery(
     expressionConverter,
+    expressionFactory,
     alias,
     outputAttributes = Some(outputAttributes),
     conjunctionStatement = ConstantString("`" + tableName + "`").toStatement + ConstantString("AS BQ_CONNECTOR_QUERY_ALIAS")) {}

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkBigQueryPushdownUtil.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkBigQueryPushdownUtil.scala
@@ -95,7 +95,7 @@ object SparkBigQueryPushdownUtil {
    * @param alias
    * @return
    */
-  def renameColumns(origOutput: Seq[NamedExpression], alias: String): Seq[NamedExpression] = {
+  def renameColumns(origOutput: Seq[NamedExpression], alias: String, expressionFactory: SparkExpressionFactory): Seq[NamedExpression] = {
     val col_names = Iterator.from(0).map(n => s"COL_$n")
 
     origOutput.map { expr =>
@@ -105,9 +105,9 @@ object SparkBigQueryPushdownUtil {
 
       expr match {
         case a@Alias(child: Expression, name: String) =>
-          Alias(child, altName)(a.exprId, Seq.empty[String], Some(metadata))
+          expressionFactory.createAlias(child, altName, a.exprId, Seq.empty[String], Some(metadata))
         case _ =>
-          Alias(expr, altName)(expr.exprId, Seq.empty[String], Some(metadata))
+          expressionFactory.createAlias(expr, altName, expr.exprId, Seq.empty[String], Some(metadata))
       }
     }
   }

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionFactory.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionFactory.scala
@@ -1,0 +1,14 @@
+package com.google.cloud.spark.bigquery.pushdowns
+
+import org.apache.spark.sql.catalyst.expressions.{Alias, ExprId, Expression}
+import org.apache.spark.sql.types.Metadata
+
+/**
+ * Factory for creating Spark expressions that are not binary compatible between
+ * different Spark versions.
+ *
+ * For example: Alias is not compatible between Spark 2.4 and Spark 3.1
+ */
+trait SparkExpressionFactory {
+  def createAlias(child: Expression, name: String, exprId: ExprId, qualifier: Seq[String], explicitMetadata: Option[Metadata]): Alias
+}

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/AggregateQuerySuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/AggregateQuerySuite.scala
@@ -1,22 +1,22 @@
 package com.google.cloud.spark.bigquery.pushdowns
 
-import com.google.cloud.spark.bigquery.pushdowns.TestConstants.{SUBQUERY_0_ALIAS, TABLE_NAME, expressionConverter, schoolIdAttributeReference, schoolNameAttributeReference}
+import com.google.cloud.spark.bigquery.pushdowns.TestConstants.{SUBQUERY_0_ALIAS, TABLE_NAME, expressionConverter, expressionFactory, schoolIdAttributeReference, schoolNameAttributeReference}
 import org.scalatest.funsuite.AnyFunSuite
 
 // Testing only the suffixStatement here since it is the only variable that is
 // different from the other queries.
 class AggregateQuerySuite extends AnyFunSuite{
-  private val sourceQuery = SourceQuery(expressionConverter, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
+  private val sourceQuery = SourceQuery(expressionConverter, expressionFactory, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
 
   test("suffixStatement with groups") {
     // Passing projectionColumns parameter as empty list for simplicity
-    val aggregateQuery = AggregateQuery(expressionConverter, projectionColumns = Seq(), groups = Seq(schoolNameAttributeReference), sourceQuery, SUBQUERY_0_ALIAS)
+    val aggregateQuery = AggregateQuery(expressionConverter, expressionFactory, projectionColumns = Seq(), groups = Seq(schoolNameAttributeReference), sourceQuery, SUBQUERY_0_ALIAS)
     assert(aggregateQuery.suffixStatement.toString == "GROUP BY SUBQUERY_0.SCHOOLNAME")
   }
 
   test("suffixStatement without groups") {
     // Passing projectionColumns parameter as empty list for simplicity
-    val aggregateQuery = AggregateQuery(expressionConverter, projectionColumns = Seq(), groups = Seq(), sourceQuery, SUBQUERY_0_ALIAS)
+    val aggregateQuery = AggregateQuery(expressionConverter, expressionFactory, projectionColumns = Seq(), groups = Seq(), sourceQuery, SUBQUERY_0_ALIAS)
     assert(aggregateQuery.suffixStatement.toString == "LIMIT 1")
   }
 }

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/FilterQuerySuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/FilterQuerySuite.scala
@@ -22,11 +22,11 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class FilterQuerySuite extends AnyFunSuite {
 
-  private val sourceQuery = SourceQuery(expressionConverter, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
+  private val sourceQuery = SourceQuery(expressionConverter, expressionFactory, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
 
   private val greaterThanFilterCondition = GreaterThanOrEqual.apply(schoolIdAttributeReference, Literal(50))
   private val lessThanFilterCondition = LessThanOrEqual.apply(schoolIdAttributeReference, Literal(100))
-  private val filterQuery = FilterQuery(expressionConverter, Seq(greaterThanFilterCondition, lessThanFilterCondition), sourceQuery, SUBQUERY_1_ALIAS)
+  private val filterQuery = FilterQuery(expressionConverter, expressionFactory, Seq(greaterThanFilterCondition, lessThanFilterCondition), sourceQuery, SUBQUERY_1_ALIAS)
 
   test("sourceStatement") {
     assert(filterQuery.sourceStatement.toString == "( SELECT * FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS ) AS SUBQUERY_0")

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/ProjectQuerySuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/ProjectQuerySuite.scala
@@ -6,15 +6,15 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class ProjectQuerySuite extends AnyFunSuite{
 
-  private val sourceQuery = SourceQuery(expressionConverter, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
+  private val sourceQuery = SourceQuery(expressionConverter, expressionFactory, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
 
   // Conditions for filter query (> 50 AND < 100)
   private val greaterThanFilterCondition = GreaterThanOrEqual.apply(schoolIdAttributeReference, Literal(50))
   private val lessThanFilterCondition = LessThanOrEqual.apply(schoolIdAttributeReference, Literal(100))
-  private val filterQuery = FilterQuery(expressionConverter, Seq(greaterThanFilterCondition, lessThanFilterCondition), sourceQuery, SUBQUERY_1_ALIAS)
+  private val filterQuery = FilterQuery(expressionConverter, expressionFactory, Seq(greaterThanFilterCondition, lessThanFilterCondition), sourceQuery, SUBQUERY_1_ALIAS)
 
   // Projecting the column SchoolId
-  private val projectQuery = ProjectQuery(expressionConverter, Seq(schoolIdAttributeReference), filterQuery, SUBQUERY_2_ALIAS)
+  private val projectQuery = ProjectQuery(expressionConverter, expressionFactory, Seq(schoolIdAttributeReference), filterQuery, SUBQUERY_2_ALIAS)
 
   test("sourceStatement") {
     assert(projectQuery.sourceStatement.toString == "( SELECT * FROM ( SELECT * FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS ) AS SUBQUERY_0 " +

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SortLimitQuerySuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SortLimitQuerySuite.scala
@@ -1,28 +1,28 @@
 package com.google.cloud.spark.bigquery.pushdowns
 
-import com.google.cloud.spark.bigquery.pushdowns.TestConstants.{SUBQUERY_0_ALIAS, SUBQUERY_1_ALIAS, TABLE_NAME, expressionConverter, schoolIdAttributeReference, schoolNameAttributeReference}
+import com.google.cloud.spark.bigquery.pushdowns.TestConstants.{SUBQUERY_0_ALIAS, SUBQUERY_1_ALIAS, TABLE_NAME, expressionConverter, expressionFactory, schoolIdAttributeReference, schoolNameAttributeReference}
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Literal, SortOrder}
 import org.scalatest.funsuite.AnyFunSuite
 
 // Testing only the suffixStatement here since it is the only variable that is
 // different from the other queries.
 class SortLimitQuerySuite extends AnyFunSuite{
-  private val sourceQuery = SourceQuery(expressionConverter, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
+  private val sourceQuery = SourceQuery(expressionConverter, expressionFactory, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
 
   test("suffixStatement with only limit") {
-    val sortLimitQuery = SortLimitQuery(expressionConverter, Some(Literal(10)), Seq(), sourceQuery, SUBQUERY_1_ALIAS)
+    val sortLimitQuery = SortLimitQuery(expressionConverter, expressionFactory, Some(Literal(10)), Seq(), sourceQuery, SUBQUERY_1_ALIAS)
     assert(sortLimitQuery.suffixStatement.toString == "LIMIT 10")
   }
 
   test("suffixStatement with only orderBy") {
     val sortOrder = SortOrder.apply(schoolIdAttributeReference, Ascending)
-    val sortLimitQuery = SortLimitQuery(expressionConverter, None, Seq(sortOrder), sourceQuery, SUBQUERY_1_ALIAS)
+    val sortLimitQuery = SortLimitQuery(expressionConverter, expressionFactory, None, Seq(sortOrder), sourceQuery, SUBQUERY_1_ALIAS)
     assert(sortLimitQuery.suffixStatement.toString == "ORDER BY ( SUBQUERY_0.SCHOOLID ) ASC")
   }
 
   test("suffixStatement with both orderBy and limit") {
     val sortOrder = SortOrder.apply(schoolIdAttributeReference, Ascending)
-    val sortLimitQuery = SortLimitQuery(expressionConverter, Some(Literal(10)), Seq(sortOrder), sourceQuery, SUBQUERY_1_ALIAS)
+    val sortLimitQuery = SortLimitQuery(expressionConverter, expressionFactory, Some(Literal(10)), Seq(sortOrder), sourceQuery, SUBQUERY_1_ALIAS)
     assert(sortLimitQuery.suffixStatement.toString == "ORDER BY ( SUBQUERY_0.SCHOOLID ) ASC LIMIT 10")
   }
 }

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SourceQuerySuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SourceQuerySuite.scala
@@ -5,7 +5,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class SourceQuerySuite extends AnyFunSuite{
 
-  private val sourceQuery = SourceQuery(expressionConverter, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
+  private val sourceQuery = SourceQuery(expressionConverter, expressionFactory, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
 
   test("sourceStatement") {
     assert(sourceQuery.sourceStatement.toString == "`test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS")

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkBigQueryPushdownUtilSuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkBigQueryPushdownUtilSuite.scala
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spark.bigquery.pushdowns
 
+import com.google.cloud.spark.bigquery.pushdowns.TestConstants.expressionFactory
 import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, ExprId}
 import org.apache.spark.sql.types.LongType
 import org.scalatest.funsuite.AnyFunSuite
@@ -68,7 +69,7 @@ class SparkBigQueryPushdownUtilSuite extends AnyFunSuite {
   test("renameColumns") {
     val namedExpr1 = AttributeReference.apply("SchoolID", LongType)(ExprId.apply(1))
     val namedExpr2 = Alias.apply(namedExpr1, "SID")(ExprId.apply(2))
-    val returnedExpressions = SparkBigQueryPushdownUtil.renameColumns(List(namedExpr1, namedExpr2), "SUBQUERY_2")
+    val returnedExpressions = SparkBigQueryPushdownUtil.renameColumns(List(namedExpr1, namedExpr2), "SUBQUERY_2", expressionFactory)
     assert(2 == returnedExpressions.size)
     assert("SUBQUERY_2_COL_0" == returnedExpressions.head.name)
     assert(namedExpr1.exprId == returnedExpressions.head.exprId)

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/TestConstants.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/TestConstants.scala
@@ -1,7 +1,7 @@
 package com.google.cloud.spark.bigquery.pushdowns
 
-import org.apache.spark.sql.catalyst.expressions.{AttributeReference, ExprId}
-import org.apache.spark.sql.types.{LongType, StringType}
+import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, ExprId, Expression}
+import org.apache.spark.sql.types.{LongType, Metadata, StringType}
 
 object TestConstants {
    val TABLE_NAME = "test_project:test_dataset.test_table"
@@ -12,4 +12,10 @@ object TestConstants {
    val expressionConverter: SparkExpressionConverter = new SparkExpressionConverter {}
    val schoolIdAttributeReference: AttributeReference = AttributeReference.apply("SchoolID", LongType)(ExprId.apply(1))
    val schoolNameAttributeReference: AttributeReference = AttributeReference.apply("SchoolName", StringType)(ExprId.apply(2))
+
+   val expressionFactory: SparkExpressionFactory = new SparkExpressionFactory {
+      override def createAlias(child: Expression, name: String, exprId: ExprId, qualifier: Seq[String], explicitMetadata: Option[Metadata]): Alias = {
+         Alias(child, name)(exprId, qualifier, explicitMetadata)
+      }
+   }
 }

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24ExpressionFactory.scala
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24ExpressionFactory.scala
@@ -1,0 +1,10 @@
+package com.google.cloud.spark.bigquery.pushdowns
+
+import org.apache.spark.sql.catalyst.expressions.{Alias, ExprId, Expression}
+import org.apache.spark.sql.types.Metadata
+
+class Spark24ExpressionFactory extends SparkExpressionFactory {
+  override def createAlias(child: Expression, name: String, exprId: ExprId, qualifier: Seq[String], explicitMetadata: Option[Metadata]): Alias = {
+    Alias(child, name)(exprId, qualifier, explicitMetadata)
+  }
+}

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24ExpressionFactory.scala
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24ExpressionFactory.scala
@@ -1,0 +1,10 @@
+package com.google.cloud.spark.bigquery.pushdowns
+
+import org.apache.spark.sql.catalyst.expressions.{Alias, ExprId, Expression}
+import org.apache.spark.sql.types.Metadata
+
+class Spark24ExpressionFactory extends SparkExpressionFactory {
+  override def createAlias(child: Expression, name: String, exprId: ExprId, qualifier: Seq[String], explicitMetadata: Option[Metadata]): Alias = {
+    Alias(child, name)(exprId, qualifier, explicitMetadata)
+  }
+}

--- a/spark-bigquery-pushdown/spark-3.1-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark31ExpressionFactory.scala
+++ b/spark-bigquery-pushdown/spark-3.1-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark31ExpressionFactory.scala
@@ -1,0 +1,10 @@
+package com.google.cloud.spark.bigquery.pushdowns
+
+import org.apache.spark.sql.catalyst.expressions.{Alias, ExprId, Expression}
+import org.apache.spark.sql.types.Metadata
+
+class Spark31ExpressionFactory extends SparkExpressionFactory {
+  override def createAlias(child: Expression, name: String, exprId: ExprId, qualifier: Seq[String], explicitMetadata: Option[Metadata]): Alias = {
+    Alias(child, name)(exprId, qualifier, explicitMetadata)
+  }
+}


### PR DESCRIPTION
Ran into an issue where one of the Spark expressions called `Alias` is not binary compatible between Spark versions. See https://stackoverflow.com/questions/66106096/delta-lake-insert-into-sql-in-pyspark-is-failing-with-java-lang-nosuchmethoder

So, created a Spark expression factory that can create Alias for specific Spark versions

Note that even though there are 18 changed files, most of the changes are pretty small. Basically, changing the method parameters