### PR TITLE
Integrated SparkPlanFactory with BigQueryStrategy

### DIFF
--- a/spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/BigQueryConnectorUtils.scala
+++ b/spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/BigQueryConnectorUtils.scala
@@ -29,7 +29,7 @@ object BigQueryConnectorUtils {
       .iterator().asScala.find(p => p.supportsSparkVersion(session.version))
       .getOrElse(sys.error(s"Query pushdown not supported for Spark version ${session.version}"))
 
-    sparkBigQueryPushdown.enable(session, new BigQueryStrategy(sparkBigQueryPushdown.createSparkExpressionConverter))
+    sparkBigQueryPushdown.enable(session, new BigQueryStrategy(sparkBigQueryPushdown.createSparkExpressionConverter, sparkBigQueryPushdown.createSparkExpressionFactory))
   }
 
   def disablePushdownSession(session: SparkSession): Unit = {

--- a/spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/BigQueryConnectorUtils.scala
+++ b/spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/BigQueryConnectorUtils.scala
@@ -29,7 +29,7 @@ object BigQueryConnectorUtils {
       .iterator().asScala.find(p => p.supportsSparkVersion(session.version))
       .getOrElse(sys.error(s"Query pushdown not supported for Spark version ${session.version}"))
 
-    sparkBigQueryPushdown.enable(session, new BigQueryStrategy(sparkBigQueryPushdown.createSparkExpressionConverter, sparkBigQueryPushdown.createSparkExpressionFactory))
+    sparkBigQueryPushdown.enable(session, new BigQueryStrategy(sparkBigQueryPushdown.createSparkExpressionConverter, sparkBigQueryPushdown.createSparkExpressionFactory, sparkBigQueryPushdown.createSparkPlanFactory))
   }
 
   def disablePushdownSession(session: SparkSession): Unit = {

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/BigQueryStrategy.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/BigQueryStrategy.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.Strategy
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.SparkPlan
 
-class BigQueryStrategy(expressionConverter: SparkExpressionConverter) extends Strategy {
+class BigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory) extends Strategy {
   def apply(plan: LogicalPlan): Seq[SparkPlan] = {
     // TODO: Create RDD by translating logical plan to custom BQ query and call SparkPlan with it
     throw new NotImplementedError("BigQueryStrategy has not been implemented yet")

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/BigQueryStrategy.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/BigQueryStrategy.scala
@@ -20,7 +20,7 @@ import org.apache.spark.sql.Strategy
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.execution.SparkPlan
 
-class BigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory) extends Strategy {
+class BigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory, sparkPlanFactory: SparkPlanFactory) extends Strategy {
   def apply(plan: LogicalPlan): Seq[SparkPlan] = {
     // TODO: Create RDD by translating logical plan to custom BQ query and call SparkPlan with it
     throw new NotImplementedError("BigQueryStrategy has not been implemented yet")

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkBigQueryPushdown.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkBigQueryPushdown.scala
@@ -26,4 +26,8 @@ trait SparkBigQueryPushdown {
   def disable(session: SparkSession): Unit
 
   def createSparkExpressionConverter: SparkExpressionConverter
+
+  def createSparkExpressionFactory: SparkExpressionFactory
+
+  def createBigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory): BigQueryStrategy
 }

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkBigQueryPushdown.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkBigQueryPushdown.scala
@@ -29,5 +29,7 @@ trait SparkBigQueryPushdown {
 
   def createSparkExpressionFactory: SparkExpressionFactory
 
-  def createBigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory): BigQueryStrategy
+  def createSparkPlanFactory(): SparkPlanFactory
+
+  def createBigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory, sparkPlanFactory: SparkPlanFactory): BigQueryStrategy
 }

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkPlanFactory.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkPlanFactory.scala
@@ -1,0 +1,14 @@
+package com.google.cloud.spark.bigquery.pushdowns
+
+import com.google.cloud.spark.bigquery.direct.BigQueryRDDFactory
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.execution.SparkPlan
+
+class SparkPlanFactory {
+  /**
+   * Generate SparkPlan from the output and RDD of the translated query
+   */
+  def createSparkPlan(queryRoot: BigQuerySQLQuery, bigQueryRDDFactory: BigQueryRDDFactory): Option[SparkPlan] = {
+    Some(BigQueryPlan(queryRoot.output, bigQueryRDDFactory.buildScanFromSQL(queryRoot.getStatement().toString)))
+  }
+}

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryPushdown.scala
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryPushdown.scala
@@ -34,4 +34,12 @@ class Spark24BigQueryPushdown extends SparkBigQueryPushdown {
   override def createSparkExpressionConverter: SparkExpressionConverter = {
     new Spark24ExpressionConverter
   }
+
+  override def createSparkExpressionFactory: SparkExpressionFactory = {
+    new Spark24ExpressionFactory
+  }
+
+  override def createBigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory): BigQueryStrategy = {
+    new Spark24BigQueryStrategy(expressionConverter, expressionFactory)
+  }
 }

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryPushdown.scala
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryPushdown.scala
@@ -39,7 +39,11 @@ class Spark24BigQueryPushdown extends SparkBigQueryPushdown {
     new Spark24ExpressionFactory
   }
 
-  override def createBigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory): BigQueryStrategy = {
-    new Spark24BigQueryStrategy(expressionConverter, expressionFactory)
+  override def createSparkPlanFactory(): SparkPlanFactory = {
+    new SparkPlanFactory
+  }
+
+  override def createBigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory, sparkPlanFactory: SparkPlanFactory): BigQueryStrategy = {
+    new Spark24BigQueryStrategy(expressionConverter, expressionFactory, sparkPlanFactory)
   }
 }

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryStrategy.scala
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryStrategy.scala
@@ -1,0 +1,5 @@
+package com.google.cloud.spark.bigquery.pushdowns
+
+class Spark24BigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory)
+  extends BigQueryStrategy(expressionConverter, expressionFactory) {
+}

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryStrategy.scala
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryStrategy.scala
@@ -1,5 +1,5 @@
 package com.google.cloud.spark.bigquery.pushdowns
 
-class Spark24BigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory)
-  extends BigQueryStrategy(expressionConverter, expressionFactory) {
+class Spark24BigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory, sparkPlanFactory: SparkPlanFactory)
+  extends BigQueryStrategy(expressionConverter, expressionFactory, sparkPlanFactory) {
 }

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryPushdown.scala
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryPushdown.scala
@@ -34,4 +34,12 @@ class Spark24BigQueryPushdown extends SparkBigQueryPushdown {
   override def createSparkExpressionConverter: SparkExpressionConverter = {
     new Spark24ExpressionConverter
   }
+
+  override def createSparkExpressionFactory: SparkExpressionFactory = {
+    new Spark24ExpressionFactory
+  }
+
+  override def createBigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory): BigQueryStrategy = {
+    new Spark24BigQueryStrategy(expressionConverter, expressionFactory)
+  }
 }

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryPushdown.scala
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryPushdown.scala
@@ -39,7 +39,11 @@ class Spark24BigQueryPushdown extends SparkBigQueryPushdown {
     new Spark24ExpressionFactory
   }
 
-  override def createBigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory): BigQueryStrategy = {
-    new Spark24BigQueryStrategy(expressionConverter, expressionFactory)
+  override def createSparkPlanFactory(): SparkPlanFactory = {
+    new SparkPlanFactory
+  }
+
+  override def createBigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory, sparkPlanFactory: SparkPlanFactory): BigQueryStrategy = {
+    new Spark24BigQueryStrategy(expressionConverter, expressionFactory, sparkPlanFactory)
   }
 }

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryStrategy.scala
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryStrategy.scala
@@ -1,0 +1,5 @@
+package com.google.cloud.spark.bigquery.pushdowns
+
+class Spark24BigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory)
+  extends BigQueryStrategy(expressionConverter, expressionFactory) {
+}

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryStrategy.scala
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryStrategy.scala
@@ -1,5 +1,5 @@
 package com.google.cloud.spark.bigquery.pushdowns
 
-class Spark24BigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory)
-  extends BigQueryStrategy(expressionConverter, expressionFactory) {
+class Spark24BigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory, sparkPlanFactory: SparkPlanFactory)
+  extends BigQueryStrategy(expressionConverter, expressionFactory, sparkPlanFactory) {
 }

--- a/spark-bigquery-pushdown/spark-3.1-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark31BigQueryPushdown.scala
+++ b/spark-bigquery-pushdown/spark-3.1-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark31BigQueryPushdown.scala
@@ -39,7 +39,11 @@ class Spark31BigQueryPushdown extends SparkBigQueryPushdown {
     new Spark31ExpressionFactory
   }
 
-  override def createBigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory): BigQueryStrategy = {
-    new Spark31BigQueryStrategy(expressionConverter, expressionFactory)
+  override def createSparkPlanFactory(): SparkPlanFactory = {
+    new SparkPlanFactory
+  }
+
+  override def createBigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory, sparkPlanFactory: SparkPlanFactory): BigQueryStrategy = {
+    new Spark31BigQueryStrategy(expressionConverter, expressionFactory, sparkPlanFactory)
   }
 }

--- a/spark-bigquery-pushdown/spark-3.1-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark31BigQueryPushdown.scala
+++ b/spark-bigquery-pushdown/spark-3.1-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark31BigQueryPushdown.scala
@@ -34,4 +34,12 @@ class Spark31BigQueryPushdown extends SparkBigQueryPushdown {
   override def createSparkExpressionConverter: SparkExpressionConverter = {
     new Spark31ExpressionConverter
   }
+
+  override def createSparkExpressionFactory: SparkExpressionFactory = {
+    new Spark31ExpressionFactory
+  }
+
+  override def createBigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory): BigQueryStrategy = {
+    new Spark31BigQueryStrategy(expressionConverter, expressionFactory)
+  }
 }

--- a/spark-bigquery-pushdown/spark-3.1-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark31BigQueryStrategy.scala
+++ b/spark-bigquery-pushdown/spark-3.1-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark31BigQueryStrategy.scala
@@ -1,5 +1,5 @@
 package com.google.cloud.spark.bigquery.pushdowns
 
-class Spark31BigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory)
-  extends BigQueryStrategy(expressionConverter, expressionFactory) {
+class Spark31BigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory, sparkPlanFactory: SparkPlanFactory)
+  extends BigQueryStrategy(expressionConverter, expressionFactory, sparkPlanFactory) {
 }

--- a/spark-bigquery-pushdown/spark-3.1-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark31BigQueryStrategy.scala
+++ b/spark-bigquery-pushdown/spark-3.1-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark31BigQueryStrategy.scala
@@ -1,0 +1,5 @@
+package com.google.cloud.spark.bigquery.pushdowns
+
+class Spark31BigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory)
+  extends BigQueryStrategy(expressionConverter, expressionFactory) {
+}


### PR DESCRIPTION
This PR is built on top of #621 and injects the SparkPlanFactory class into BigQueryStrategy.

This is done to extract out the logic of creating the SparkPlan in a separate class and to facilitate easier unit testing