### PR TITLE
Completed implementation of BigQueryStrategy

### DIFF
--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/direct/BigQueryRDDFactory.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/direct/BigQueryRDDFactory.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spark.bigquery.direct;
 
+import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.StandardTableDefinition;
 import com.google.cloud.bigquery.TableDefinition;
@@ -82,14 +83,31 @@ public class BigQueryRDDFactory {
         bigQueryClient.materializeQueryToTable(
             sql, options.getMaterializationExpirationTimeInMinutes());
 
-    log.info("Querying table {}", actualTable.getFriendlyName());
+    TableDefinition actualTableDefinition = actualTable.getDefinition();
+
+    // We do require requiredColumns to be passed in for pushdown. If we don't, an
+    // ArrayIndexOutOfBounds
+    // exception is thrown
+    List<String> requiredColumns =
+        actualTableDefinition.getSchema().getFields().stream()
+            .map(Field::getName)
+            .collect(Collectors.toList());
+
+    log.info(
+        "Querying table {}, requiredColumns=[{}]",
+        actualTable.getFriendlyName(),
+        String.join(",", requiredColumns));
 
     ReadSessionCreator readSessionCreator =
         new ReadSessionCreator(
             options.toReadSessionCreatorConfig(), bigQueryClient, bigQueryReadClientFactory);
 
     return (RDD<InternalRow>)
-        createRddFromTable(actualTable.getTableId(), readSessionCreator, new String[0], "");
+        createRddFromTable(
+            actualTable.getTableId(),
+            readSessionCreator,
+            requiredColumns.toArray(new String[0]),
+            "");
   }
 
   // Creates BigQueryRDD from the BigQuery table that is passed in. Note that we return RDD<?>

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/direct/BigQueryRDDFactory.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/direct/BigQueryRDDFactory.java
@@ -96,7 +96,7 @@ public class BigQueryRDDFactory {
     log.info(
         "Querying table {}, requiredColumns=[{}]",
         actualTable.getFriendlyName(),
-        String.join(",", requiredColumns));
+        requiredColumns.toString());
 
     ReadSessionCreator readSessionCreator =
         new ReadSessionCreator(

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.java
@@ -143,6 +143,10 @@ public class DirectBigQueryRelation extends BigQueryRelation
         Filter.class);
   }
 
+  public BigQueryRDDFactory getBigQueryRDDFactory() {
+    return this.bigQueryRDDFactory;
+  }
+
   // VisibleForTesting
   String getCompiledFilter(Filter[] filters) {
     if (options.isCombinePushedDownFilters()) {

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/BigQuerySQLQuery.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/BigQuerySQLQuery.scala
@@ -147,4 +147,18 @@ abstract class BigQuerySQLQuery(
    */
   def expressionToStatement(expr: Expression): BigQuerySQLStatement =
     expressionConverter.convertStatement(expr, columnSet)
+
+  /** Finds a particular query type in the overall tree.
+   *
+   * @param query PartialFunction defining a positive result.
+   * @param T BigQuerySQLQuery type
+   * @return Option[T] for one positive match, or None if nothing found.
+   */
+  def find[T](query: PartialFunction[BigQuerySQLQuery, T]): Option[T] =
+    query
+      .lift(this)
+      .orElse(
+        if (this.children.isEmpty) None
+        else this.children.head.find(query)
+      )
 }

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/BigQuerySQLQuery.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/BigQuerySQLQuery.scala
@@ -158,7 +158,10 @@ abstract class BigQuerySQLQuery(
     query
       .lift(this)
       .orElse(
-        if (this.children.isEmpty) None
-        else this.children.head.find(query)
+        if (this.children.isEmpty) {
+          None
+        } else {
+          this.children.head.find(query)
+        }
       )
 }

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/BigQueryStrategy.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/BigQueryStrategy.scala
@@ -16,13 +16,118 @@
 
 package com.google.cloud.spark.bigquery.pushdowns
 
+import com.google.cloud.bigquery.connector.common.{BigQueryPushdownException, BigQueryPushdownUnsupportedException}
+import com.google.cloud.spark.bigquery.direct.BigQueryRDDFactory
+import com.google.cloud.spark.bigquery.direct.DirectBigQueryRelation
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.Strategy
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.execution.SparkPlan
+import org.apache.spark.sql.execution.datasources.LogicalRelation
 
-class BigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory, sparkPlanFactory: SparkPlanFactory) extends Strategy {
-  def apply(plan: LogicalPlan): Seq[SparkPlan] = {
-    // TODO: Create RDD by translating logical plan to custom BQ query and call SparkPlan with it
-    throw new NotImplementedError("BigQueryStrategy has not been implemented yet")
+/**
+ * Our hook into Spark that converts the logical plan into physical plan.
+ * We try to translate the Spark logical plan into SQL runnable on BigQuery.
+ * If the query generation fails for any reason, we return Nil and let Spark
+ * run other strategies to compute the physical plan.
+ *
+ * Passing SparkPlanFactory as the constructor parameter here for ease of unit testing
+ *
+ */
+class BigQueryStrategy(expressionConverter: SparkExpressionConverter, expressionFactory: SparkExpressionFactory, sparkPlanFactory: SparkPlanFactory) extends Strategy with Logging {
+
+  /** This iterator automatically increments every time it is used,
+   * and is for aliasing subqueries.
+   */
+  private final val alias = Iterator.from(0).map(n => s"SUBQUERY_$n")
+
+  /** Attempts to generate a SparkPlan from the provided LogicalPlan.
+   *
+   * @param plan The LogicalPlan provided by Spark.
+   * @return An Option of Seq[BigQueryPlan] that contains the PhysicalPlan if
+   *         query generation was successful, None if not.
+   */
+  override def apply(plan: LogicalPlan): Seq[SparkPlan] = {
+    try {
+      generateSparkPlanFromLogicalPlan(plan)
+    } catch {
+      case ue: BigQueryPushdownUnsupportedException =>
+        logWarning(s"BigQuery doesn't support this feature :${ue.getMessage}")
+        throw ue
+      case e: Exception =>
+        logInfo("Query pushdown failed: ", e)
+        Nil
+    }
+  }
+
+  def generateSparkPlanFromLogicalPlan(plan: LogicalPlan): Seq[SparkPlan] = {
+    val queryRoot = generateQueryFromPlan(plan)
+    val bigQueryRDDFactory = getRDDFactory(queryRoot.get)
+
+    val sparkPlan = sparkPlanFactory.createSparkPlan(queryRoot.get, bigQueryRDDFactory.get)
+    Seq(sparkPlan.get)
+  }
+
+  def getRDDFactory(queryRoot: BigQuerySQLQuery): Option[BigQueryRDDFactory] = {
+    val sourceQuery = queryRoot
+      .find {
+        case q: SourceQuery => q
+      }
+      // this should ideally never happen
+      .getOrElse(
+        throw new BigQueryPushdownException(
+          "Something went wrong: a query tree was generated with no SourceQuery."
+        )
+      )
+
+    Some(sourceQuery.bigQueryRDDFactory)
+  }
+
+  /** Attempts to generate the query from the LogicalPlan by pattern matching recursively.
+   * The queries are constructed from the bottom up, but the validation of
+   * supported nodes for translation happens on the way down.
+   *
+   * @param plan The LogicalPlan to be processed.
+   * @return An object of type Option[BQSQLQuery], which is None if the plan contains an
+   *         unsupported node type.
+   */
+  def generateQueryFromPlan(plan: LogicalPlan): Option[BigQuerySQLQuery] = {
+    plan match {
+      case l@LogicalRelation(bqRelation: DirectBigQueryRelation, _, _, _) =>
+        Some(SourceQuery(expressionConverter, expressionFactory, bqRelation.getBigQueryRDDFactory, bqRelation.getTableName, l.output, alias.next))
+
+      case UnaryOperationExtractor(child) =>
+        generateQueryFromPlan(child) map { subQuery =>
+          plan match {
+            case Filter(condition, _) =>
+              FilterQuery(expressionConverter, expressionFactory, Seq(condition), subQuery, alias.next)
+
+            case Project(fields, _) =>
+              ProjectQuery(expressionConverter, expressionFactory, fields, subQuery, alias.next)
+
+            case Aggregate(groups, fields, _) =>
+              AggregateQuery(expressionConverter, expressionFactory, fields, groups, subQuery, alias.next)
+
+            case Limit(limitExpr, Sort(orderExpr, true, _)) =>
+              SortLimitQuery(expressionConverter, expressionFactory, Some(limitExpr), orderExpr, subQuery, alias.next)
+
+            case Limit(limitExpr, _) =>
+              SortLimitQuery(expressionConverter, expressionFactory, Some(limitExpr), Seq.empty, subQuery, alias.next)
+
+            case Sort(orderExpr, true, Limit(limitExpr, _)) =>
+              SortLimitQuery(expressionConverter, expressionFactory, Some(limitExpr), orderExpr, subQuery, alias.next)
+
+            case Sort(orderExpr, true, _) =>
+              SortLimitQuery(expressionConverter, expressionFactory, None, orderExpr, subQuery, alias.next)
+
+            case _ => subQuery
+          }
+        }
+
+      case _ =>
+        throw new BigQueryPushdownUnsupportedException(
+          s"Query pushdown failed in generateQueries for node ${plan.nodeName} in ${plan.getClass.getName}"
+        )
+    }
   }
 }

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SourceQuery.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SourceQuery.scala
@@ -16,6 +16,7 @@
 
 package com.google.cloud.spark.bigquery.pushdowns
 
+import com.google.cloud.spark.bigquery.direct.BigQueryRDDFactory
 import org.apache.spark.sql.catalyst.expressions.Attribute
 
 /** The base query representing a BigQuery table
@@ -29,6 +30,7 @@ import org.apache.spark.sql.catalyst.expressions.Attribute
 case class SourceQuery(
     expressionConverter: SparkExpressionConverter,
     expressionFactory: SparkExpressionFactory,
+    bigQueryRDDFactory: BigQueryRDDFactory,
     tableName: String,
     outputAttributes: Seq[Attribute],
     alias: String)
@@ -37,4 +39,7 @@ case class SourceQuery(
     expressionFactory,
     alias,
     outputAttributes = Some(outputAttributes),
-    conjunctionStatement = ConstantString("`" + tableName + "`").toStatement + ConstantString("AS BQ_CONNECTOR_QUERY_ALIAS")) {}
+    conjunctionStatement = ConstantString("`" + tableName + "`").toStatement + ConstantString("AS BQ_CONNECTOR_QUERY_ALIAS")) {
+
+    override def find[T](query: PartialFunction[BigQuerySQLQuery, T]): Option[T] = query.lift(this)
+}

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/AggregateQuerySuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/AggregateQuerySuite.scala
@@ -1,12 +1,12 @@
 package com.google.cloud.spark.bigquery.pushdowns
 
-import com.google.cloud.spark.bigquery.pushdowns.TestConstants.{SUBQUERY_0_ALIAS, TABLE_NAME, expressionConverter, expressionFactory, schoolIdAttributeReference, schoolNameAttributeReference}
+import com.google.cloud.spark.bigquery.pushdowns.TestConstants.{SUBQUERY_0_ALIAS, TABLE_NAME, bigQueryRDDFactoryMock, expressionConverter, expressionFactory, schoolIdAttributeReference, schoolNameAttributeReference}
 import org.scalatest.funsuite.AnyFunSuite
 
 // Testing only the suffixStatement here since it is the only variable that is
 // different from the other queries.
 class AggregateQuerySuite extends AnyFunSuite{
-  private val sourceQuery = SourceQuery(expressionConverter, expressionFactory, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
+  private val sourceQuery = SourceQuery(expressionConverter, expressionFactory, bigQueryRDDFactoryMock, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
 
   test("suffixStatement with groups") {
     // Passing projectionColumns parameter as empty list for simplicity
@@ -18,5 +18,12 @@ class AggregateQuerySuite extends AnyFunSuite{
     // Passing projectionColumns parameter as empty list for simplicity
     val aggregateQuery = AggregateQuery(expressionConverter, expressionFactory, projectionColumns = Seq(), groups = Seq(), sourceQuery, SUBQUERY_0_ALIAS)
     assert(aggregateQuery.suffixStatement.toString == "LIMIT 1")
+  }
+
+  test("find") {
+    val aggregateQuery = AggregateQuery(expressionConverter, expressionFactory, projectionColumns = Seq(), groups = Seq(), sourceQuery, SUBQUERY_0_ALIAS)
+    val returnedQuery = aggregateQuery.find({ case q: SourceQuery => q })
+    assert(returnedQuery.isDefined)
+    assert(returnedQuery.get == sourceQuery)
   }
 }

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/BigQueryStrategySuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/BigQueryStrategySuite.scala
@@ -1,0 +1,96 @@
+package com.google.cloud.spark.bigquery.pushdowns
+
+import com.google.cloud.bigquery.connector.common.BigQueryPushdownUnsupportedException
+import com.google.cloud.spark.bigquery.direct.{BigQueryRDDFactory, DirectBigQueryRelation}
+import com.google.cloud.spark.bigquery.pushdowns.TestConstants._
+import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateExpression, Complete, Count}
+import org.apache.spark.sql.catalyst.expressions.{Alias, Ascending, EqualTo, Literal, SortOrder}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, Intersect, Limit, Project, Range, Sort}
+import org.apache.spark.sql.execution.datasources.LogicalRelation
+import org.apache.spark.sql.types.StructType
+import org.mockito.ArgumentMatchers.any
+import org.mockito.{Mock, MockitoAnnotations}
+import org.mockito.Mockito.when
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funsuite.AnyFunSuite
+
+class BigQueryStrategySuite extends AnyFunSuite with BeforeAndAfter {
+  @Mock
+  private var directBigQueryRelationMock: DirectBigQueryRelation = _
+
+  @Mock
+  var sparkPlanFactoryMock: SparkPlanFactory = _
+
+  private val sourceQuery = SourceQuery(expressionConverter, expressionFactory, bigQueryRDDFactoryMock, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
+
+  // Need a childPlan to pass. So, create the simplest possible
+  private val childPlan = Range.apply(2L, 100L, 4L, 8)
+
+  before {
+    MockitoAnnotations.initMocks(this)
+  }
+
+  test("getRDDFactory") {
+    val returnedRDDFactory = new BigQueryStrategy(expressionConverter, expressionFactory, sparkPlanFactoryMock).getRDDFactory(sourceQuery)
+    assert(returnedRDDFactory.isDefined)
+    assert(returnedRDDFactory.get == bigQueryRDDFactoryMock)
+  }
+
+  test("unsupported exception thrown in apply method") {
+    val unsupportedPlan = Intersect(childPlan, childPlan, isAll = true)
+    assertThrows[BigQueryPushdownUnsupportedException] {
+      new BigQueryStrategy(expressionConverter, expressionFactory, sparkPlanFactoryMock).apply(unsupportedPlan)
+    }
+  }
+
+  test("exception thrown in apply method") {
+    when(directBigQueryRelationMock.schema).thenReturn(StructType.apply(Seq()))
+    when(sparkPlanFactoryMock.createSparkPlan(any(classOf[BigQuerySQLQuery]),
+      any(classOf[BigQueryRDDFactory]))).thenThrow(new RuntimeException("Unable to create spark plan"))
+
+    val logicalRelation = LogicalRelation(directBigQueryRelationMock)
+    val returnedPlan = new BigQueryStrategy(expressionConverter, expressionFactory, sparkPlanFactoryMock).apply(logicalRelation)
+
+    assert(returnedPlan == Nil)
+  }
+
+  test("generateQueryFromPlan with filter, project, limit and sort plans") {
+    when(directBigQueryRelationMock.schema).thenReturn(StructType.apply(Seq()))
+    when(directBigQueryRelationMock.getTableName).thenReturn("MY_BIGQUERY_TABLE")
+
+    val logicalRelation = LogicalRelation(directBigQueryRelationMock)
+
+    val filterPlan = Filter(EqualTo.apply(schoolIdAttributeReference, Literal(1234L)), logicalRelation)
+    val projectPlan = Project(Seq(schoolNameAttributeReference), filterPlan)
+    val sortPlan = Sort(Seq(SortOrder.apply(schoolIdAttributeReference, Ascending)), global = true, projectPlan)
+    val limitPlan = Limit(Literal(10), sortPlan)
+
+    val returnedQueryOption = new BigQueryStrategy(expressionConverter, expressionFactory, sparkPlanFactoryMock).generateQueryFromPlan(limitPlan)
+    assert(returnedQueryOption.isDefined)
+
+    val returnedQuery = returnedQueryOption.get
+    assert(returnedQuery.getStatement().toString == "SELECT * FROM " +
+      "( SELECT * FROM ( SELECT ( SCHOOLNAME ) AS SUBQUERY_2_COL_0 FROM " +
+      "( SELECT * FROM ( SELECT * FROM `MY_BIGQUERY_TABLE` AS BQ_CONNECTOR_QUERY_ALIAS ) " +
+      "AS SUBQUERY_0 WHERE ( SCHOOLID = 1234 ) ) AS SUBQUERY_1 ) " +
+      "AS SUBQUERY_2 ORDER BY ( SCHOOLID ) ASC ) AS SUBQUERY_3 ORDER BY ( SCHOOLID ) ASC LIMIT 10")
+  }
+
+  test("generateQueryFromPlan with aggregate plan") {
+    when(directBigQueryRelationMock.schema).thenReturn(StructType.apply(Seq()))
+    when(directBigQueryRelationMock.getTableName).thenReturn("MY_BIGQUERY_TABLE")
+
+    val logicalRelation = LogicalRelation(directBigQueryRelationMock)
+
+    val aggregateExpression = Alias.apply(AggregateExpression.apply(Count.apply(schoolIdAttributeReference), Complete, isDistinct = false), "COUNT")()
+    val aggregatePlan = Aggregate(Seq(schoolNameAttributeReference), Seq(aggregateExpression), logicalRelation)
+
+    // Need to create a new BigQueryStrategy object so as to start from the original alias
+    val returnedQueryOption = new BigQueryStrategy(expressionConverter, expressionFactory, sparkPlanFactoryMock).generateQueryFromPlan(aggregatePlan)
+    assert(returnedQueryOption.isDefined)
+
+    val returnedQuery = returnedQueryOption.get
+    assert(returnedQuery.getStatement().toString == "SELECT ( COUNT ( SCHOOLID ) ) AS SUBQUERY_1_COL_0 FROM " +
+      "( SELECT * FROM `MY_BIGQUERY_TABLE` AS BQ_CONNECTOR_QUERY_ALIAS ) AS SUBQUERY_0 GROUP BY SCHOOLNAME")
+  }
+}

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/FilterQuerySuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/FilterQuerySuite.scala
@@ -22,7 +22,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class FilterQuerySuite extends AnyFunSuite {
 
-  private val sourceQuery = SourceQuery(expressionConverter, expressionFactory, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
+  private val sourceQuery = SourceQuery(expressionConverter, expressionFactory, bigQueryRDDFactoryMock, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
 
   private val greaterThanFilterCondition = GreaterThanOrEqual.apply(schoolIdAttributeReference, Literal(50))
   private val lessThanFilterCondition = LessThanOrEqual.apply(schoolIdAttributeReference, Literal(100))
@@ -69,5 +69,11 @@ class FilterQuerySuite extends AnyFunSuite {
   test("getStatement with alias") {
     assert(filterQuery.getStatement(useAlias = true).toString == "( SELECT * FROM ( SELECT * FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS ) " +
       "AS SUBQUERY_0 WHERE ( SUBQUERY_0.SCHOOLID >= 50 ) AND ( SUBQUERY_0.SCHOOLID <= 100 ) ) AS SUBQUERY_1")
+  }
+
+  test("find") {
+    val returnedQuery = filterQuery.find({ case q: SourceQuery => q })
+    assert(returnedQuery.isDefined)
+    assert(returnedQuery.get == sourceQuery)
   }
 }

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/ProjectQuerySuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/ProjectQuerySuite.scala
@@ -6,7 +6,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class ProjectQuerySuite extends AnyFunSuite{
 
-  private val sourceQuery = SourceQuery(expressionConverter, expressionFactory, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
+  private val sourceQuery = SourceQuery(expressionConverter, expressionFactory, bigQueryRDDFactoryMock, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
 
   // Conditions for filter query (> 50 AND < 100)
   private val greaterThanFilterCondition = GreaterThanOrEqual.apply(schoolIdAttributeReference, Literal(50))
@@ -62,5 +62,11 @@ class ProjectQuerySuite extends AnyFunSuite{
     assert(projectQuery.getStatement(useAlias = true).toString == "( SELECT ( SUBQUERY_1.SCHOOLID ) AS SUBQUERY_2_COL_0 FROM " +
       "( SELECT * FROM ( SELECT * FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS ) AS SUBQUERY_0 " +
       "WHERE ( SUBQUERY_0.SCHOOLID >= 50 ) AND ( SUBQUERY_0.SCHOOLID <= 100 ) ) AS SUBQUERY_1 ) AS SUBQUERY_2")
+  }
+
+  test("find") {
+    val returnedQuery = projectQuery.find({ case q: SourceQuery => q })
+    assert(returnedQuery.isDefined)
+    assert(returnedQuery.get == sourceQuery)
   }
 }

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SortLimitQuerySuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SortLimitQuerySuite.scala
@@ -1,13 +1,13 @@
 package com.google.cloud.spark.bigquery.pushdowns
 
-import com.google.cloud.spark.bigquery.pushdowns.TestConstants.{SUBQUERY_0_ALIAS, SUBQUERY_1_ALIAS, TABLE_NAME, expressionConverter, expressionFactory, schoolIdAttributeReference, schoolNameAttributeReference}
+import com.google.cloud.spark.bigquery.pushdowns.TestConstants.{SUBQUERY_0_ALIAS, SUBQUERY_1_ALIAS, TABLE_NAME, bigQueryRDDFactoryMock, expressionConverter, expressionFactory, schoolIdAttributeReference, schoolNameAttributeReference}
 import org.apache.spark.sql.catalyst.expressions.{Ascending, Literal, SortOrder}
 import org.scalatest.funsuite.AnyFunSuite
 
 // Testing only the suffixStatement here since it is the only variable that is
 // different from the other queries.
 class SortLimitQuerySuite extends AnyFunSuite{
-  private val sourceQuery = SourceQuery(expressionConverter, expressionFactory, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
+  private val sourceQuery = SourceQuery(expressionConverter, expressionFactory, bigQueryRDDFactoryMock, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
 
   test("suffixStatement with only limit") {
     val sortLimitQuery = SortLimitQuery(expressionConverter, expressionFactory, Some(Literal(10)), Seq(), sourceQuery, SUBQUERY_1_ALIAS)
@@ -24,5 +24,13 @@ class SortLimitQuerySuite extends AnyFunSuite{
     val sortOrder = SortOrder.apply(schoolIdAttributeReference, Ascending)
     val sortLimitQuery = SortLimitQuery(expressionConverter, expressionFactory, Some(Literal(10)), Seq(sortOrder), sourceQuery, SUBQUERY_1_ALIAS)
     assert(sortLimitQuery.suffixStatement.toString == "ORDER BY ( SUBQUERY_0.SCHOOLID ) ASC LIMIT 10")
+  }
+
+  test("find") {
+    val sortOrder = SortOrder.apply(schoolIdAttributeReference, Ascending)
+    val sortLimitQuery = SortLimitQuery(expressionConverter, expressionFactory, Some(Literal(10)), Seq(sortOrder), sourceQuery, SUBQUERY_1_ALIAS)
+    val returnedQuery = sortLimitQuery.find({ case q: SourceQuery => q })
+    assert(returnedQuery.isDefined)
+    assert(returnedQuery.get == sourceQuery)
   }
 }

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SourceQuerySuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SourceQuerySuite.scala
@@ -5,7 +5,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class SourceQuerySuite extends AnyFunSuite{
 
-  private val sourceQuery = SourceQuery(expressionConverter, expressionFactory, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
+  private val sourceQuery = SourceQuery(expressionConverter, expressionFactory, bigQueryRDDFactoryMock, TABLE_NAME, Seq(schoolIdAttributeReference, schoolNameAttributeReference), SUBQUERY_0_ALIAS)
 
   test("sourceStatement") {
     assert(sourceQuery.sourceStatement.toString == "`test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS")
@@ -44,5 +44,11 @@ class SourceQuerySuite extends AnyFunSuite{
 
   test("getStatement with alias") {
     assert(sourceQuery.getStatement(useAlias = true).toString == "( SELECT * FROM `test_project:test_dataset.test_table` AS BQ_CONNECTOR_QUERY_ALIAS ) AS SUBQUERY_0")
+  }
+
+  test("find") {
+    val returnedQuery = sourceQuery.find({ case q: SourceQuery => q })
+    assert(returnedQuery.isDefined)
+    assert(returnedQuery.get == sourceQuery)
   }
 }

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/TestConstants.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/TestConstants.scala
@@ -1,7 +1,9 @@
 package com.google.cloud.spark.bigquery.pushdowns
 
+import com.google.cloud.spark.bigquery.direct.BigQueryRDDFactory
 import org.apache.spark.sql.catalyst.expressions.{Alias, AttributeReference, ExprId, Expression}
 import org.apache.spark.sql.types.{LongType, Metadata, StringType}
+import org.mockito.Mock
 
 object TestConstants {
    val TABLE_NAME = "test_project:test_dataset.test_table"
@@ -18,4 +20,7 @@ object TestConstants {
          Alias(child, name)(exprId, qualifier, explicitMetadata)
       }
    }
+
+   @Mock
+   var bigQueryRDDFactoryMock: BigQueryRDDFactory = _
 }


### PR DESCRIPTION
1) Added a find method to `BigQuerySQLQuery` class so that we can search for the `SourceQuery` in the tree and get `BigQueryRDDFactory` from it. `BigQueryRDDFactory` will then be used to create the RDD

2) Implemented BigQueryStrategy by integrating with various other helper classes. Also, added unit tests for the same.

Sanity tested the implementation by running an aggregation integration test