### PR TITLE
adding the option to disable mode check for direct write 

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -1,3 +1,4 @@
+
 # Apache Spark SQL connector for Google BigQuery
 
 <!--- TODO(#2): split out into more documents. -->
@@ -683,7 +684,6 @@ The API Supports a number of options to configure the read
      </td>
      <td>  Checks the mode of every field in destination schema to be equal to the mode in corresponding source field schema, while writing from one big query table to another.
           <br/> Default value is true i.e., the check is done by default. If set to false the mode check is ignored.
-          <br/> This property is respected only in indirect write. In direct write the check is always done.
      </td>
      <td>Write</td>
   </tr>

--- a/README-template.md
+++ b/README-template.md
@@ -1,4 +1,3 @@
-
 # Apache Spark SQL connector for Google BigQuery
 
 <!--- TODO(#2): split out into more documents. -->

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryDataSourceWriterModule.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryDataSourceWriterModule.java
@@ -66,8 +66,8 @@ public class BigQueryDataSourceWriterModule implements Module {
         mode,
         sparkSchema,
         bigqueryDataWriteHelperRetrySettings,
-        com.google.common.base.Optional.fromJavaUtil(
-            config.getTraceId())); // needs to be serializable
+        com.google.common.base.Optional.fromJavaUtil(config.getTraceId()),
+        config.getEnableModeCheckForSchemaFields()); // needs to be serializable
   }
 
   @Singleton

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryDirectDataSourceWriterContext.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryDirectDataSourceWriterContext.java
@@ -52,6 +52,7 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
   private final String writeUUID;
   private final RetrySettings bigqueryDataWriterHelperRetrySettings;
   private final Optional<String> traceId;
+  private final boolean enableModeCheckForSchemaFields;
 
   private final BigQueryTable tableToWrite;
   private final String tablePathForBigQueryStorage;
@@ -74,7 +75,8 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
       SaveMode saveMode,
       StructType sparkSchema,
       RetrySettings bigqueryDataWriterHelperRetrySettings,
-      Optional<String> traceId)
+      Optional<String> traceId,
+      boolean enableModeCheckForSchemaFields)
       throws IllegalArgumentException {
     this.bigQueryClient = bigQueryClient;
     this.writeClientFactory = bigQueryWriteClientFactory;
@@ -83,6 +85,7 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
     this.sparkSchema = sparkSchema;
     this.bigqueryDataWriterHelperRetrySettings = bigqueryDataWriterHelperRetrySettings;
     this.traceId = traceId;
+    this.enableModeCheckForSchemaFields = enableModeCheckForSchemaFields;
     Schema bigQuerySchema = toBigQuerySchema(sparkSchema);
     try {
       this.protoSchema = toProtoSchema(sparkSchema);
@@ -118,7 +121,10 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
       Schema tableSchema = destinationTable.getDefinition().getSchema();
       Preconditions.checkArgument(
           BigQueryUtil.schemaEquals(
-              tableSchema, bigQuerySchema, /* regardFieldOrder */ false, true),
+              tableSchema,
+              bigQuerySchema, /* regardFieldOrder */
+              false,
+              enableModeCheckForSchemaFields),
           new BigQueryConnectorException.InvalidSchemaException(
               "Destination table's schema is not compatible with dataframe's schema"));
       switch (saveMode) {

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/test/java/com/google/cloud/spark/bigquery/v2/context/BigQueryDirectDataSourceWriterContextTest.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/test/java/com/google/cloud/spark/bigquery/v2/context/BigQueryDirectDataSourceWriterContextTest.java
@@ -145,6 +145,7 @@ public class BigQueryDirectDataSourceWriterContextTest {
         saveMode,
         sparkSchema,
         bigqueryDataWriterHelperRetrySettings,
-        Optional.absent());
+        Optional.absent(),
+        true);
   }
 }

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -275,7 +275,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   @Test
   @Ignore("DSv2 only")
   public void testDirectWriteToBigQueryWithDiffInSchema() {
-    assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
+    assertThat(writeMethod).isEqualTo(WriteMethod.DIRECT);
     spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =
         spark
@@ -298,7 +298,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   @Ignore("DSv2 only")
   public void testDirectWriteToBigQueryWithDiffInSchemaAndDisableModeCheck()
       throws Exception {
-    assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
+    assertThat(writeMethod).isEqualTo(WriteMethod.DIRECT);
     spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =
         spark
@@ -323,7 +323,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
 
   @Test
   public void testInDirectWriteToBigQueryWithDiffInSchemaAndModeCheck() {
-    assumeThat(writeMethod, equalTo(SparkBigQueryConfig.WriteMethod.INDIRECT));
+    assertThat(writeMethod).isEqualTo(SparkBigQueryConfig.WriteMethod.INDIRECT);
     spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =
         spark
@@ -346,7 +346,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   @Test
   public void testIndirectWriteToBigQueryWithDiffInSchemaNullableFieldAndDisableModeCheck()
       throws Exception {
-    assumeThat(writeMethod, equalTo(SparkBigQueryConfig.WriteMethod.INDIRECT));
+    assertThat(writeMethod).isEqualTo(SparkBigQueryConfig.WriteMethod.INDIRECT);
     spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =
         spark

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -297,7 +297,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   @Test
   @Ignore("DSv2 only")
   public void testDirectWriteToBigQueryWithDiffInSchemaAndDisableModeCheck()
-      throws InterruptedException {
+      throws Exception {
     assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
     spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =
@@ -345,7 +345,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
 
   @Test
   public void testIndirectWriteToBigQueryWithDiffInSchemaNullableFieldAndDisableModeCheck()
-      throws InterruptedException {
+      throws Exception {
     assumeThat(writeMethod, equalTo(SparkBigQueryConfig.WriteMethod.INDIRECT));
     spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -275,7 +275,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   @Test
   @Ignore("DSv2 only")
   public void testDirectWriteToBigQueryWithDiffInSchema() {
-    assertThat(writeMethod).isEqualTo(WriteMethod.DIRECT);
+    assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
     spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =
         spark
@@ -297,7 +297,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   @Test
   @Ignore("DSv2 only")
   public void testDirectWriteToBigQueryWithDiffInSchemaAndDisableModeCheck() throws Exception {
-    assertThat(writeMethod).isEqualTo(WriteMethod.DIRECT);
+    assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
     spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =
         spark
@@ -322,7 +322,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
 
   @Test
   public void testInDirectWriteToBigQueryWithDiffInSchemaAndModeCheck() {
-    assertThat(writeMethod).isEqualTo(SparkBigQueryConfig.WriteMethod.INDIRECT);
+    assumeThat(writeMethod, equalTo(SparkBigQueryConfig.WriteMethod.INDIRECT));
     spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =
         spark
@@ -345,7 +345,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   @Test
   public void testIndirectWriteToBigQueryWithDiffInSchemaNullableFieldAndDisableModeCheck()
       throws Exception {
-    assertThat(writeMethod).isEqualTo(SparkBigQueryConfig.WriteMethod.INDIRECT);
+    assumeThat(writeMethod, equalTo(SparkBigQueryConfig.WriteMethod.INDIRECT));
     spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =
         spark

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -296,8 +296,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
 
   @Test
   @Ignore("DSv2 only")
-  public void testDirectWriteToBigQueryWithDiffInSchemaAndDisableModeCheck()
-      throws Exception {
+  public void testDirectWriteToBigQueryWithDiffInSchemaAndDisableModeCheck() throws Exception {
     assertThat(writeMethod).isEqualTo(WriteMethod.DIRECT);
     spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =


### PR DESCRIPTION
In PR#613, we have added the field level schema check for indirect write, matching it with that of direct write.
Also we have added an option **enableModeCheckForSchemaFields** which can be used to surpass the mode check for schema fields which was only supported in indirect write.
This PR is to support the same option in direct write as well