### PR TITLE
removing conscrypt from shaded dependencies 

### DIFF
--- a/spark-bigquery-dsv1/spark-bigquery-with-dependencies-parent/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery-with-dependencies-parent/pom.xml
@@ -115,11 +115,6 @@
               </shadedPattern>
             </relocation>
             <relocation>
-              <pattern>org.conscrypt</pattern>
-              <shadedPattern>com.google.cloud.spark.bigquery.repackaged.org.conscrypt
-              </shadedPattern>
-            </relocation>
-            <relocation>
               <pattern>org.json</pattern>
               <shadedPattern>com.google.cloud.spark.bigquery.repackaged.org.json</shadedPattern>
             </relocation>

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-parent/pom.xml
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-parent/pom.xml
@@ -201,12 +201,6 @@
               </shadedPattern>
             </relocation>
             <relocation>
-              <pattern>org.conscrypt</pattern>
-              <shadedPattern>
-                com.google.cloud.spark.bigquery.repackaged.org.conscrypt
-              </shadedPattern>
-            </relocation>
-            <relocation>
               <pattern>org.json</pattern>
               <shadedPattern>
                 com.google.cloud.spark.bigquery.repackaged.org.json

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -253,6 +253,12 @@
                 <artifactId>mockito-core</artifactId>
                 <version>4.5.1</version>
             </dependency>
+            <dependency>
+                <groupId>org.conscrypt</groupId>
+                <artifactId>conscrypt-openjdk-uber</artifactId>
+                <version>2.5.1</version>
+                <scope>provided</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <dependencies>


### PR DESCRIPTION
removing conscrypt from shaded dependencies, so that it will be part of org/conscrypt since acceptance tests were failing in serverless with reason `failed to find class org/conscrypt/CryptoUpcalls`. Anyway we are not using the package `com.google.cloud.spark.bigquery.repackaged.org.conscrypt` anywhere in the code so it is safe to remove the shaded dependency
