### PR TITLE
Spark Catalog first implementaiton

### DIFF
--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfigurationUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfigurationUtil.java
@@ -116,10 +116,15 @@ public class BigQueryConfigurationUtil {
       Optional<String> fallbackProject,
       Optional<String> fallbackDataset) {
     String tableParam =
-        getOptionFromMultipleParams(options, ImmutableList.of("table", "path"), DEFAULT_FALLBACK).get();
+        getOptionFromMultipleParams(options, ImmutableList.of("table", "path"), DEFAULT_FALLBACK)
+            .get();
     Optional<String> datasetParam = getOption(options, "dataset").or(fallbackDataset);
     Optional<String> projectParam = getOption(options, "project").or(fallbackProject);
-    return parseTableId(tableParam, fallbackDataset.toJavaUtil(), fallbackProject.toJavaUtil());
+    return parseTableId(
+        tableParam,
+        datasetParam.toJavaUtil(),
+        projectParam.toJavaUtil(), /* datePartition */
+        java.util.Optional.empty());
   }
 
   public static TableId parseSimpleTableId(
@@ -130,7 +135,13 @@ public class BigQueryConfigurationUtil {
         options, Optional.fromJavaUtil(fallbackProject), Optional.fromJavaUtil(fallbackDataset));
   }
 
-  public static TableId parseSimpleTableId(Map<String, String> options) {
-    return parseSimpleTableId(options, empty().toJavaUtil(), empty().toJavaUtil());
+  public static TableId parseSimpleTableId(
+      ImmutableMap<String, String> globalOptions, Map<String, String> options) {
+    MaterializationConfiguration materializationConfiguration =
+        MaterializationConfiguration.from(globalOptions, options);
+    return parseSimpleTableId(
+        options,
+        materializationConfiguration.getMaterializationProject(),
+        materializationConfiguration.getMaterializationDataset());
   }
 }

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfigurationUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfigurationUtil.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigquery.connector.common;
+
+import static com.google.cloud.bigquery.connector.common.BigQueryUtil.firstPresent;
+import static com.google.cloud.bigquery.connector.common.BigQueryUtil.parseTableId;
+import static java.lang.String.format;
+
+import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.TableId;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/** Utilities to read configuration options */
+public class BigQueryConfigurationUtil {
+
+  public static final Supplier<com.google.common.base.Optional<String>> DEFAULT_FALLBACK =
+      () -> empty();
+
+  private BigQueryConfigurationUtil() {}
+
+  public static com.google.common.base.Supplier<String> defaultBilledProject() {
+    return () -> BigQueryOptions.getDefaultInstance().getProjectId();
+  }
+
+  public static String getRequiredOption(Map<String, String> options, String name) {
+    return getOption(options, name, DEFAULT_FALLBACK)
+        .toJavaUtil()
+        .orElseThrow(() -> new IllegalArgumentException(format("Option %s required.", name)));
+  }
+
+  public static String getRequiredOption(
+      Map<String, String> options, String name, com.google.common.base.Supplier<String> fallback) {
+    return getOption(options, name, DEFAULT_FALLBACK).or(fallback);
+  }
+
+  public static com.google.common.base.Optional<String> getOption(
+      Map<String, String> options, String name) {
+    return getOption(options, name, DEFAULT_FALLBACK);
+  }
+
+  public static com.google.common.base.Optional<String> getOption(
+      Map<String, String> options, String name, Supplier<Optional<String>> fallback) {
+    return fromJavaUtil(
+        firstPresent(
+            java.util.Optional.ofNullable(options.get(name.toLowerCase())),
+            fallback.get().toJavaUtil()));
+  }
+
+  public static com.google.common.base.Optional<String> getOptionFromMultipleParams(
+      Map<String, String> options,
+      Collection<String> names,
+      Supplier<com.google.common.base.Optional<String>> fallback) {
+    return names.stream()
+        .map(name -> getOption(options, name))
+        .filter(com.google.common.base.Optional::isPresent)
+        .findFirst()
+        .orElseGet(fallback);
+  }
+
+  public static com.google.common.base.Optional<String> getAnyOption(
+      ImmutableMap<String, String> globalOptions, Map<String, String> options, String name) {
+    return com.google.common.base.Optional.fromNullable(options.get(name.toLowerCase()))
+        .or(com.google.common.base.Optional.fromNullable(globalOptions.get(name)));
+  }
+
+  // gives the option to support old configurations as fallback
+  // Used to provide backward compatibility
+  public static com.google.common.base.Optional<String> getAnyOption(
+      ImmutableMap<String, String> globalOptions,
+      Map<String, String> options,
+      Collection<String> names) {
+    return names.stream()
+        .map(name -> getAnyOption(globalOptions, options, name))
+        .filter(optional -> optional.isPresent())
+        .findFirst()
+        .orElse(empty());
+  }
+
+  public static boolean getAnyBooleanOption(
+      ImmutableMap<String, String> globalOptions,
+      Map<String, String> options,
+      String name,
+      boolean defaultValue) {
+    return getAnyOption(globalOptions, options, name).transform(Boolean::valueOf).or(defaultValue);
+  }
+
+  public static com.google.common.base.Optional empty() {
+    return com.google.common.base.Optional.absent();
+  }
+
+  public static com.google.common.base.Optional fromJavaUtil(java.util.Optional o) {
+    return com.google.common.base.Optional.fromJavaUtil(o);
+  }
+
+  /** TableId that does not include partition decorator */
+  public static TableId parseSimpleTableId(
+      Map<String, String> options,
+      Optional<String> fallbackProject,
+      Optional<String> fallbackDataset) {
+    String tableParam =
+        getOptionFromMultipleParams(options, ImmutableList.of("table", "path"), DEFAULT_FALLBACK).get();
+    Optional<String> datasetParam = getOption(options, "dataset").or(fallbackDataset);
+    Optional<String> projectParam = getOption(options, "project").or(fallbackProject);
+    return parseTableId(tableParam, fallbackDataset.toJavaUtil(), fallbackProject.toJavaUtil());
+  }
+
+  public static TableId parseSimpleTableId(
+      Map<String, String> options,
+      java.util.Optional<String> fallbackProject,
+      java.util.Optional<String> fallbackDataset) {
+    return parseSimpleTableId(
+        options, Optional.fromJavaUtil(fallbackProject), Optional.fromJavaUtil(fallbackDataset));
+  }
+
+  public static TableId parseSimpleTableId(Map<String, String> options) {
+    return parseSimpleTableId(options, empty().toJavaUtil(), empty().toJavaUtil());
+  }
+}

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/IteratorMultiplexer.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/IteratorMultiplexer.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.bigquery.connector.common;
 
 import com.google.common.base.Preconditions;

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/MaterializationConfiguration.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/MaterializationConfiguration.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.bigquery.connector.common;
 
 import com.google.common.base.Optional;

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/MaterializationConfiguration.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/MaterializationConfiguration.java
@@ -1,0 +1,62 @@
+package com.google.cloud.bigquery.connector.common;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+
+public class MaterializationConfiguration {
+  public static final int DEFAULT_MATERIALIZATION_EXPIRATION_TIME_IN_MINUTES = 24 * 60;
+
+  private final com.google.common.base.Optional<String> materializationProject;
+  private final com.google.common.base.Optional<String> materializationDataset;
+  private final int materializationExpirationTimeInMinutes;
+
+  public static MaterializationConfiguration from(
+      ImmutableMap<String, String> globalOptions, Map<String, String> options) {
+    com.google.common.base.Optional<String> materializationProject =
+        BigQueryConfigurationUtil.getAnyOption(
+            globalOptions,
+            options,
+            ImmutableList.of("materializationProject", "viewMaterializationProject"));
+    com.google.common.base.Optional<String> materializationDataset =
+        BigQueryConfigurationUtil.getAnyOption(
+            globalOptions,
+            options,
+            ImmutableList.of("materializationDataset", "viewMaterializationDataset"));
+    int materializationExpirationTimeInMinutes =
+        BigQueryConfigurationUtil.getAnyOption(
+                globalOptions, options, "materializationExpirationTimeInMinutes")
+            .transform(Integer::parseInt)
+            .or(DEFAULT_MATERIALIZATION_EXPIRATION_TIME_IN_MINUTES);
+    if (materializationExpirationTimeInMinutes < 1) {
+      throw new IllegalArgumentException(
+          "materializationExpirationTimeInMinutes must have a positive value, the configured value is "
+              + materializationExpirationTimeInMinutes);
+    }
+
+    return new MaterializationConfiguration(
+        materializationProject, materializationDataset, materializationExpirationTimeInMinutes);
+  }
+
+  private MaterializationConfiguration(
+      Optional<String> materializationProject,
+      Optional<String> materializationDataset,
+      int materializationExpirationTimeInMinutes) {
+    this.materializationProject = materializationProject;
+    this.materializationDataset = materializationDataset;
+    this.materializationExpirationTimeInMinutes = materializationExpirationTimeInMinutes;
+  }
+
+  public Optional<String> getMaterializationProject() {
+    return materializationProject;
+  }
+
+  public Optional<String> getMaterializationDataset() {
+    return materializationDataset;
+  }
+
+  public int getMaterializationExpirationTimeInMinutes() {
+    return materializationExpirationTimeInMinutes;
+  }
+}

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryConfigurationUtilTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryConfigurationUtilTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigquery.connector.common;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.google.cloud.bigquery.TableId;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+public class BigQueryConfigurationUtilTest {
+
+  private static final ImmutableMap<String, String> EMPTY_GLOBAL_OPTIONS =
+      ImmutableMap.<String, String>of();
+
+  @Test
+  public void testParseSimpleTableId_tableOnly() {
+    TableId result =
+        BigQueryConfigurationUtil.parseSimpleTableId(
+            EMPTY_GLOBAL_OPTIONS, ImmutableMap.of("table", "project.dataset.table"));
+    assertThat(result.getProject()).isEqualTo("project");
+    assertThat(result.getDataset()).isEqualTo("dataset");
+    assertThat(result.getTable()).isEqualTo("table");
+  }
+
+  @Test
+  public void testParseSimpleTableId_pathOnly() {
+    TableId result =
+        BigQueryConfigurationUtil.parseSimpleTableId(
+            EMPTY_GLOBAL_OPTIONS, ImmutableMap.of("path", "project.dataset.table"));
+    assertThat(result.getProject()).isEqualTo("project");
+    assertThat(result.getDataset()).isEqualTo("dataset");
+    assertThat(result.getTable()).isEqualTo("table");
+  }
+
+  @Test
+  public void testParseSimpleTableId_tableAndDataset() {
+    TableId result =
+        BigQueryConfigurationUtil.parseSimpleTableId(
+            EMPTY_GLOBAL_OPTIONS, ImmutableMap.of("table", "table", "dataset", "dataset"));
+    assertThat(result.getProject()).isNull();
+    assertThat(result.getDataset()).isEqualTo("dataset");
+    assertThat(result.getTable()).isEqualTo("table");
+  }
+
+  @Test
+  public void testParseSimpleTableId_allParams() {
+    TableId result =
+        BigQueryConfigurationUtil.parseSimpleTableId(
+            EMPTY_GLOBAL_OPTIONS,
+            ImmutableMap.of("table", "table", "dataset", "dataset", "project", "project"));
+    assertThat(result.getProject()).isEqualTo("project");
+    assertThat(result.getDataset()).isEqualTo("dataset");
+    assertThat(result.getTable()).isEqualTo("table");
+  }
+
+  @Test
+  public void testParseSimpleTableId_fallbackDatasetIgnored() {
+    TableId result =
+        BigQueryConfigurationUtil.parseSimpleTableId(
+            ImmutableMap.of("materializationDataset", "fallback"),
+            ImmutableMap.of("table", "table", "dataset", "dataset"));
+    assertThat(result.getProject()).isNull();
+    assertThat(result.getDataset()).isEqualTo("dataset");
+    assertThat(result.getTable()).isEqualTo("table");
+  }
+
+  @Test
+  public void testParseSimpleTableId_fallbackDatasetUsed() {
+    TableId result =
+        BigQueryConfigurationUtil.parseSimpleTableId(
+            ImmutableMap.of("materializationDataset", "fallback"),
+            ImmutableMap.of("table", "table"));
+    assertThat(result.getProject()).isNull();
+    assertThat(result.getDataset()).isEqualTo("fallback");
+    assertThat(result.getTable()).isEqualTo("table");
+  }
+
+  @Test
+  public void testParseSimpleTableId_fallbackProjectIgnored() {
+    TableId result =
+        BigQueryConfigurationUtil.parseSimpleTableId(
+            ImmutableMap.of("materializationProject", "fallback"),
+            ImmutableMap.of("table", "table", "dataset", "dataset", "project", "project"));
+    assertThat(result.getProject()).isEqualTo("project");
+    assertThat(result.getDataset()).isEqualTo("dataset");
+    assertThat(result.getTable()).isEqualTo("table");
+  }
+
+  @Test
+  public void testParseSimpleTableId_fallbackProjectUsed() {
+    TableId result =
+        BigQueryConfigurationUtil.parseSimpleTableId(
+            ImmutableMap.of("materializationProject", "fallback"),
+            ImmutableMap.of("table", "table", "dataset", "dataset"));
+    assertThat(result.getProject()).isEqualTo("fallback");
+    assertThat(result.getDataset()).isEqualTo("dataset");
+    assertThat(result.getTable()).isEqualTo("table");
+  }
+
+  @Test
+  public void testParseSimpleTableId_missingDataset() {
+    assertThrows(
+        "Missing dataset exception was not thrown",
+        IllegalArgumentException.class,
+        () -> {
+          BigQueryConfigurationUtil.parseSimpleTableId(
+              EMPTY_GLOBAL_OPTIONS, ImmutableMap.of("table", "table"));
+        });
+  }
+}

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -58,7 +58,8 @@ public class SparkBigQueryConfigTest {
                 DEFAULT_PARALLELISM,
                 new SQLConf(),
                 SPARK_VERSION,
-                Optional.empty()));
+                Optional.empty(), /* tableIsMandatory */
+                true));
   }
 
   @Test
@@ -73,7 +74,8 @@ public class SparkBigQueryConfigTest {
             DEFAULT_PARALLELISM,
             new SQLConf(),
             SPARK_VERSION,
-            Optional.empty());
+            Optional.empty(), /* tableIsMandatory */
+            true);
     assertThat(config.getTableId()).isEqualTo(TableId.of("dataset", "table"));
     assertThat(config.getFilter()).isEqualTo(Optional.empty());
     assertThat(config.getSchema()).isEqualTo(Optional.empty());
@@ -155,7 +157,8 @@ public class SparkBigQueryConfigTest {
             DEFAULT_PARALLELISM,
             new SQLConf(),
             SPARK_VERSION,
-            Optional.empty());
+            Optional.empty(), /* tableIsMandatory */
+            true);
     assertThat(config.getTableId()).isEqualTo(TableId.of("test_p", "test_d", "test_t"));
     assertThat(config.getFilter()).isEqualTo(Optional.of("test > 0"));
     assertThat(config.getSchema()).isEqualTo(Optional.empty());
@@ -212,7 +215,8 @@ public class SparkBigQueryConfigTest {
             DEFAULT_PARALLELISM,
             new SQLConf(),
             SPARK_VERSION,
-            Optional.empty());
+            Optional.empty(), /* tableIsMandatory */
+            true);
     assertThat(config.getCacheExpirationTimeInMinutes()).isEqualTo(0);
   }
 
@@ -239,7 +243,8 @@ public class SparkBigQueryConfigTest {
                     DEFAULT_PARALLELISM,
                     new SQLConf(),
                     SPARK_VERSION,
-                    Optional.empty()));
+                    Optional.empty(), /* tableIsMandatory */
+                    true));
 
     assertThat(exception)
         .hasMessageThat()
@@ -270,7 +275,8 @@ public class SparkBigQueryConfigTest {
                     DEFAULT_PARALLELISM,
                     new SQLConf(),
                     SPARK_VERSION,
-                    Optional.empty()));
+                    Optional.empty(), /* tableIsMandatory */
+                    true));
 
     assertThat(exception)
         .hasMessageThat()
@@ -302,7 +308,8 @@ public class SparkBigQueryConfigTest {
             DEFAULT_PARALLELISM,
             new SQLConf(),
             SPARK_VERSION,
-            Optional.empty());
+            Optional.empty(), /* tableIsMandatory */
+            true);
 
     assertThat(config.isViewsEnabled()).isTrue();
     assertThat(config.getTemporaryGcsBucket()).isEqualTo(Optional.of("bucket"));
@@ -325,7 +332,8 @@ public class SparkBigQueryConfigTest {
             DEFAULT_PARALLELISM,
             new SQLConf(),
             SPARK_VERSION,
-            Optional.empty());
+            Optional.empty(), /* tableIsMandatory */
+            true);
 
     assertThat(config.getTableId().getTable()).isEqualTo("table$20201010");
     assertThat(config.getTableIdWithoutThePartition().getTable()).isEqualTo("table");
@@ -347,7 +355,8 @@ public class SparkBigQueryConfigTest {
             DEFAULT_PARALLELISM,
             new SQLConf(),
             SPARK_VERSION,
-            Optional.empty());
+            Optional.empty(), /* tableIsMandatory */
+            true);
 
     assertThat(config.getTableIdWithoutThePartition().getTable())
         .isEqualTo(config.getTableId().getTable());

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryProxyAndHttpConfigTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryProxyAndHttpConfigTest.java
@@ -180,7 +180,8 @@ public class SparkBigQueryProxyAndHttpConfigTest {
             10,
             new SQLConf(),
             "2.4.0",
-            Optional.empty());
+            Optional.empty(), /* tableIsMandatory */
+            true);
 
     SparkBigQueryProxyAndHttpConfig config =
         (SparkBigQueryProxyAndHttpConfig) sparkConfig.getBigQueryProxyConfig();
@@ -210,7 +211,8 @@ public class SparkBigQueryProxyAndHttpConfigTest {
             10,
             new SQLConf(),
             "2.4.0",
-            Optional.empty());
+            Optional.empty(), /* tableIsMandatory */
+            true);
 
     SparkBigQueryProxyAndHttpConfig config =
         (SparkBigQueryProxyAndHttpConfig) sparkConfig.getBigQueryProxyConfig();
@@ -237,7 +239,8 @@ public class SparkBigQueryProxyAndHttpConfigTest {
             10,
             new SQLConf(),
             "2.4.0",
-            Optional.empty());
+            Optional.empty(), /* tableIsMandatory */
+            true);
 
     SparkBigQueryProxyAndHttpConfig config =
         (SparkBigQueryProxyAndHttpConfig) sparkConfig.getBigQueryProxyConfig();

--- a/spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
+++ b/spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/BigQueryRelationProvider.scala
@@ -140,7 +140,7 @@ class BigQueryRelationProvider(
       sqlContext.sparkContext.defaultParallelism,
       sqlContext.sparkSession.sessionState.conf,
       sqlContext.sparkContext.version,
-      Optional.ofNullable(schema.orNull))
+      Optional.ofNullable(schema.orNull), /* tableIsMandatory */ true)
   }
 
   override def shortName: String = "bigquery"
@@ -155,7 +155,7 @@ trait GuiceInjectorCreator {
     val injector = Guice.createInjector(
       new BigQueryClientModule,
       new SparkBigQueryConnectorModule(
-        spark, parameters.asJava, Optional.ofNullable(schema.orNull), DataSourceVersion.V1))
+        spark, parameters.asJava, Optional.ofNullable(schema.orNull), DataSourceVersion.V1, /* tableIsMandatory */ true))
     injector
   }
 }

--- a/spark-bigquery-dsv1/src/test/scala/com/google/cloud/spark/bigquery/SparkBigQueryOptionsSuite.scala
+++ b/spark-bigquery-dsv1/src/test/scala/com/google/cloud/spark/bigquery/SparkBigQueryOptionsSuite.scala
@@ -32,11 +32,11 @@ class SparkBigQueryConfigSuite extends FunSuite {
   hadoopConfiguration.set(SparkBigQueryConfig.GCS_CONFIG_PROJECT_ID_PROPERTY, "hadoop_project")
 
   val parameters = Map("table" -> "dataset.table")
-  val emptyMap : ImmutableMap[String, String] = ImmutableMap.of()
+  val emptyMap: ImmutableMap[String, String] = ImmutableMap.of()
   val sparkVersion = "2.4.0"
-  
+
   private def asDataSourceOptionsMap(map: Map[String, String]) = {
-    (map ++ map.map { case (key, value) => (key.toLowerCase, value) } .toMap).asJava
+    (map ++ map.map { case (key, value) => (key.toLowerCase, value) }.toMap).asJava
   }
 
   test("taking credentials file from GCS hadoop config") {
@@ -48,7 +48,8 @@ class SparkBigQueryConfigSuite extends FunSuite {
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getCredentialsFile
     }
   }
@@ -62,7 +63,8 @@ class SparkBigQueryConfigSuite extends FunSuite {
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getCredentialsFile
     }
   }
@@ -75,7 +77,8 @@ class SparkBigQueryConfigSuite extends FunSuite {
       1,
       new SQLConf,
       sparkVersion,
-      Optional.empty()) // schema
+      /* schema */ Optional.empty(),
+      /* tableIsMandatory */ true)
     assert(!options.getCredentialsFile.isPresent)
   }
 
@@ -88,7 +91,8 @@ class SparkBigQueryConfigSuite extends FunSuite {
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getTableId.getProject
     }
   }
@@ -102,7 +106,8 @@ class SparkBigQueryConfigSuite extends FunSuite {
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getTableId.getProject
     }
   }
@@ -116,24 +121,26 @@ class SparkBigQueryConfigSuite extends FunSuite {
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getTableId.getProject
     }
   }
 
   test("Invalid data format") {
-      val thrown = intercept[Exception] {
-        SparkBigQueryConfig.from(
-          asDataSourceOptionsMap(parameters + ("readDataFormat" -> "abc")),
-          emptyMap, // allConf
-          new Configuration,
-          1,
-          new SQLConf,
-          sparkVersion,
-          Optional.empty()) // schema
-      }
-      assert (thrown.getMessage ==
-        "Data read format 'ABC' is not supported. Supported formats are 'ARROW,AVRO'")
+    val thrown = intercept[Exception] {
+      SparkBigQueryConfig.from(
+        asDataSourceOptionsMap(parameters + ("readDataFormat" -> "abc")),
+        emptyMap, // allConf
+        new Configuration,
+        1,
+        new SQLConf,
+        sparkVersion,
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
+    }
+    assert(thrown.getMessage ==
+      "Data read format 'ABC' is not supported. Supported formats are 'ARROW,AVRO'")
   }
 
   test("data format - no value set") {
@@ -145,7 +152,8 @@ class SparkBigQueryConfigSuite extends FunSuite {
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getReadDataFormat.toString
     }
   }
@@ -159,7 +167,8 @@ class SparkBigQueryConfigSuite extends FunSuite {
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getReadDataFormat.toString
     }
   }
@@ -173,7 +182,8 @@ class SparkBigQueryConfigSuite extends FunSuite {
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getMaterializationProject
     }
   }
@@ -184,13 +194,14 @@ class SparkBigQueryConfigSuite extends FunSuite {
         asDataSourceOptionsMap(parameters + (
           "materializationProject" -> "foo",
           "viewMaterializationProject" -> "bar")
-          ),
+        ),
         emptyMap, // allConf
         new Configuration,
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getMaterializationProject
     }
   }
@@ -204,7 +215,8 @@ class SparkBigQueryConfigSuite extends FunSuite {
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getMaterializationProject
     }
   }
@@ -218,7 +230,8 @@ class SparkBigQueryConfigSuite extends FunSuite {
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getMaterializationProject
     }
   }
@@ -232,7 +245,8 @@ class SparkBigQueryConfigSuite extends FunSuite {
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getMaxParallelism
     }
   }
@@ -246,7 +260,8 @@ class SparkBigQueryConfigSuite extends FunSuite {
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getMaxParallelism
     }
   }
@@ -260,7 +275,8 @@ class SparkBigQueryConfigSuite extends FunSuite {
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getMaxParallelism
     }
   }
@@ -274,11 +290,12 @@ class SparkBigQueryConfigSuite extends FunSuite {
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getMaxParallelism
     }
   }
-  
+
   test("loadSchemaUpdateOption - allowFieldAddition") {
     assertResult(Seq(JobInfo.SchemaUpdateOption.ALLOW_FIELD_ADDITION)) {
       val options = SparkBigQueryConfig.from(
@@ -288,7 +305,8 @@ class SparkBigQueryConfigSuite extends FunSuite {
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getLoadSchemaUpdateOptions.asScala.toSeq
     }
   }
@@ -302,7 +320,8 @@ class SparkBigQueryConfigSuite extends FunSuite {
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getLoadSchemaUpdateOptions.asScala.toSeq
     }
   }
@@ -319,7 +338,8 @@ class SparkBigQueryConfigSuite extends FunSuite {
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getLoadSchemaUpdateOptions.asScala.toSeq
     }
   }
@@ -333,7 +353,8 @@ class SparkBigQueryConfigSuite extends FunSuite {
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getLoadSchemaUpdateOptions.isEmpty
     }
   }
@@ -346,9 +367,9 @@ class SparkBigQueryConfigSuite extends FunSuite {
       "spark.datasource.bigquery.key3" -> "external val3")
     val normalizedConf = SparkBigQueryConfig.normalizeConf(originalConf.asJava)
 
-    assert(normalizedConf.get("key1")  == "val1")
-    assert(normalizedConf.get("key2")  == "val2")
-    assert(normalizedConf.get("key3")  == "external val3")
+    assert(normalizedConf.get("key1") == "val1")
+    assert(normalizedConf.get("key2") == "val2")
+    assert(normalizedConf.get("key3") == "external val3")
   }
 
   test("Set persistentGcsPath") {
@@ -360,7 +381,8 @@ class SparkBigQueryConfigSuite extends FunSuite {
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getPersistentGcsPath
     }
   }
@@ -374,7 +396,8 @@ class SparkBigQueryConfigSuite extends FunSuite {
         1,
         new SQLConf,
         sparkVersion,
-        Optional.empty()) // schema
+        /* schema */ Optional.empty(),
+        /* tableIsMandatory */ true)
       options.getPersistentGcsBucket
     }
   }

--- a/spark-bigquery-dsv2/spark-2.4-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryDataSourceV2.java
+++ b/spark-bigquery-dsv2/spark-2.4-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryDataSourceV2.java
@@ -39,7 +39,7 @@ public class BigQueryDataSourceV2 extends BaseBigQuerySource
   @Override
   public DataSourceReader createReader(StructType schema, DataSourceOptions options) {
     Injector injector =
-        InjectorFactory.createInjector(schema, options.asMap())
+        InjectorFactory.createInjector(schema, options.asMap(), /* tableIsMandatory */ true)
             .createChildInjector(new BigQueryDataSourceReaderModule());
     BigQueryDataSourceReader reader =
         new BigQueryDataSourceReader(injector.getInstance(BigQueryDataSourceReaderContext.class));
@@ -58,7 +58,8 @@ public class BigQueryDataSourceV2 extends BaseBigQuerySource
   @Override
   public Optional<DataSourceWriter> createWriter(
       String writeUUID, StructType schema, SaveMode mode, DataSourceOptions options) {
-    Injector injector = InjectorFactory.createInjector(schema, options.asMap());
+    Injector injector =
+        InjectorFactory.createInjector(schema, options.asMap(), /* tableIsMandatory */ true);
     Optional<DataSourceWriterContext> dataSourceWriterContext =
         DataSourceWriterContext.create(injector, writeUUID, schema, mode, options.asMap());
     return dataSourceWriterContext.map(ctx -> new BigQueryDataSourceWriter(ctx));

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryCatalog.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryCatalog.java
@@ -1,4 +1,101 @@
 package com.google.cloud.spark.bigquery.v2;
 
-public class BigQueryCatalog {
+import com.google.inject.Injector;
+import java.util.Map;
+import org.apache.spark.sql.catalyst.analysis.NamespaceAlreadyExistsException;
+import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
+import org.apache.spark.sql.connector.catalog.CatalogExtension;
+import org.apache.spark.sql.connector.catalog.CatalogPlugin;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.NamespaceChange;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableChange;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+
+public class BigQueryCatalog implements CatalogExtension {
+
+  private String name = "bigquery";
+  private Injector injector;
+  private CatalogPlugin delegate;
+
+  @Override
+  public void initialize(String name, CaseInsensitiveStringMap options) {
+    this.name = name;
+    this.injector =
+        InjectorFactory.createInjector(/*schema*/ null, options, /* tableIsMandatory */ false);
+  }
+
+  @Override
+  public void setDelegateCatalog(CatalogPlugin delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public String[][] listNamespaces() throws NoSuchNamespaceException {
+    return new String[0][];
+  }
+
+  @Override
+  public String[][] listNamespaces(String[] namespace) throws NoSuchNamespaceException {
+    return new String[0][];
+  }
+
+  @Override
+  public Map<String, String> loadNamespaceMetadata(String[] namespace)
+      throws NoSuchNamespaceException {
+    return null;
+  }
+
+  @Override
+  public void createNamespace(String[] namespace, Map<String, String> metadata)
+      throws NamespaceAlreadyExistsException {}
+
+  @Override
+  public void alterNamespace(String[] namespace, NamespaceChange... changes)
+      throws NoSuchNamespaceException {}
+
+  @Override
+  public boolean dropNamespace(String[] namespace) throws NoSuchNamespaceException {
+    return false;
+  }
+
+  @Override
+  public Identifier[] listTables(String[] namespace) throws NoSuchNamespaceException {
+    return new Identifier[0];
+  }
+
+  @Override
+  public Table loadTable(Identifier ident) throws NoSuchTableException {
+    return BigQueryTable.fromIdentifier(injector, ident);
+  }
+
+  @Override
+  public Table createTable(
+      Identifier ident, StructType schema, Transform[] partitions, Map<String, String> properties)
+      throws TableAlreadyExistsException, NoSuchNamespaceException {
+    return null;
+  }
+
+  @Override
+  public Table alterTable(Identifier ident, TableChange... changes) throws NoSuchTableException {
+    return null;
+  }
+
+  @Override
+  public boolean dropTable(Identifier ident) {
+    return false;
+  }
+
+  @Override
+  public void renameTable(Identifier oldIdent, Identifier newIdent)
+      throws NoSuchTableException, TableAlreadyExistsException {}
+
+  @Override
+  public String name() {
+    return name;
+  }
 }

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryCatalog.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryCatalog.java
@@ -51,27 +51,34 @@ public class BigQueryCatalog implements CatalogExtension {
 
   @Override
   public String[][] listNamespaces() throws NoSuchNamespaceException {
+    // TODO: add implementation
     return new String[0][];
   }
 
   @Override
   public String[][] listNamespaces(String[] namespace) throws NoSuchNamespaceException {
+    // TODO: add implementation
     return new String[0][];
   }
 
   @Override
   public Map<String, String> loadNamespaceMetadata(String[] namespace)
       throws NoSuchNamespaceException {
+    // TODO: add implementation
     return null;
   }
 
   @Override
   public void createNamespace(String[] namespace, Map<String, String> metadata)
-      throws NamespaceAlreadyExistsException {}
+      throws NamespaceAlreadyExistsException {
+    // TODO: add implementation
+  }
 
   @Override
   public void alterNamespace(String[] namespace, NamespaceChange... changes)
-      throws NoSuchNamespaceException {}
+      throws NoSuchNamespaceException {
+    // TODO: add implementation
+  }
 
   @Override
   public boolean dropNamespace(String[] namespace) throws NoSuchNamespaceException {
@@ -80,11 +87,13 @@ public class BigQueryCatalog implements CatalogExtension {
 
   @Override
   public Identifier[] listTables(String[] namespace) throws NoSuchNamespaceException {
+    // TODO: add implementation
     return new Identifier[0];
   }
 
   @Override
   public Table loadTable(Identifier ident) throws NoSuchTableException {
+    // TODO: add implementation
     return BigQueryTable.fromIdentifier(injector, ident);
   }
 
@@ -92,22 +101,27 @@ public class BigQueryCatalog implements CatalogExtension {
   public Table createTable(
       Identifier ident, StructType schema, Transform[] partitions, Map<String, String> properties)
       throws TableAlreadyExistsException, NoSuchNamespaceException {
+    // TODO: add implementation
     return null;
   }
 
   @Override
   public Table alterTable(Identifier ident, TableChange... changes) throws NoSuchTableException {
+    // TODO: add implementation
     return null;
   }
 
   @Override
   public boolean dropTable(Identifier ident) {
+    // TODO: add implementation
     return false;
   }
 
   @Override
   public void renameTable(Identifier oldIdent, Identifier newIdent)
-      throws NoSuchTableException, TableAlreadyExistsException {}
+      throws NoSuchTableException, TableAlreadyExistsException {
+    // TODO: add implementation
+  }
 
   @Override
   public String name() {

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryCatalog.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryCatalog.java
@@ -1,0 +1,4 @@
+package com.google.cloud.spark.bigquery.v2;
+
+public class BigQueryCatalog {
+}

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryCatalog.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryCatalog.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.spark.bigquery.v2;
 
 import com.google.inject.Injector;

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryIdentifier.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryIdentifier.java
@@ -24,6 +24,10 @@ public class BigQueryIdentifier implements Identifier {
     return tableId.getTable();
   }
 
+  public TableId getTableId() {
+    return tableId;
+  }
+
   @Override
   public String toString() {
     return "BigQueryIdentifier{" + "tableId=" + BigQueryUtil.friendlyTableName(tableId) + '}';

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryIdentifier.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryIdentifier.java
@@ -1,0 +1,29 @@
+package com.google.cloud.spark.bigquery.v2;
+
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.connector.common.BigQueryUtil;
+import org.apache.spark.sql.connector.catalog.Identifier;
+
+public class BigQueryIdentifier implements Identifier {
+
+  private final TableId tableId;
+
+  public BigQueryIdentifier(TableId tableId) {
+    this.tableId = tableId;
+  }
+
+  @Override
+  public String[] namespace() {
+    return new String[0];
+  }
+
+  @Override
+  public String name() {
+    return BigQueryUtil.friendlyTableName(tableId);
+  }
+
+  @Override
+  public String toString() {
+    return "BigQueryIdentifier{" + "tableId=" + BigQueryUtil.friendlyTableName(tableId) + '}';
+  }
+}

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryIdentifier.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryIdentifier.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.spark.bigquery.v2;
 
 import com.google.cloud.bigquery.TableId;

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryIdentifier.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryIdentifier.java
@@ -14,12 +14,14 @@ public class BigQueryIdentifier implements Identifier {
 
   @Override
   public String[] namespace() {
-    return new String[0];
+    return tableId.getProject() == null
+        ? new String[] {tableId.getDataset()}
+        : new String[] {tableId.getProject(), tableId.getDataset()};
   }
 
   @Override
   public String name() {
-    return BigQueryUtil.friendlyTableName(tableId);
+    return tableId.getTable();
   }
 
   @Override

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryTable.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryTable.java
@@ -15,16 +15,15 @@
  */
 package com.google.cloud.spark.bigquery.v2;
 
+import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.connector.common.BigQueryClient;
 import com.google.cloud.spark.bigquery.SchemaConverters;
 import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
 import com.google.cloud.spark.bigquery.v2.context.BigQueryDataSourceReaderContext;
 import com.google.cloud.spark.bigquery.v2.context.BigQueryDataSourceReaderModule;
-import com.google.cloud.spark.bigquery.v2.context.DataSourceWriterContext;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Injector;
-import java.util.Optional;
 import java.util.Set;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.connector.catalog.SupportsRead;
@@ -84,13 +83,13 @@ public class BigQueryTable implements Table, SupportsRead, SupportsWrite {
 
   @Override
   public WriteBuilder newWriteBuilder(LogicalWriteInfo info) {
-    CaseInsensitiveStringMap options = info.options();
     // SaveMode is not provided by spark 3, it is handled by the DataFrameWriter
-    SaveMode mode = SaveMode.Append;
-    Optional<DataSourceWriterContext> dataSourceWriterContext =
-        DataSourceWriterContext.create(injector, info.queryId(), info.schema(), mode, options);
     // The case where mode == SaveMode.Ignore is handled by Spark, so we can assume we can get the
     // context
-    return new BigQueryWriteBuilder(dataSourceWriterContext.get());
+    return new BigQueryWriteBuilder(injector, info, SaveMode.Append);
+  }
+
+  TableId getTableId() {
+    return tableInfo.getTableId();
   }
 }

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryTable.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryTable.java
@@ -18,14 +18,19 @@ package com.google.cloud.spark.bigquery.v2;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.connector.common.BigQueryClient;
+import com.google.cloud.spark.bigquery.DataSourceVersion;
 import com.google.cloud.spark.bigquery.SchemaConverters;
 import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
 import com.google.cloud.spark.bigquery.v2.context.BigQueryDataSourceReaderContext;
 import com.google.cloud.spark.bigquery.v2.context.BigQueryDataSourceReaderModule;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Injector;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
+import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.SupportsRead;
 import org.apache.spark.sql.connector.catalog.SupportsWrite;
 import org.apache.spark.sql.connector.catalog.Table;
@@ -43,24 +48,55 @@ public class BigQueryTable implements Table, SupportsRead, SupportsWrite {
           TableCapability.BATCH_READ, TableCapability.BATCH_WRITE, TableCapability.TRUNCATE);
 
   private Injector injector;
-  private SparkBigQueryConfig config;
-  private StructType schema;
   private TableInfo tableInfo;
+  private StructType schema;
 
-  public BigQueryTable(Injector injector, StructType sparkProvidedSchema) {
+  private BigQueryTable(Injector injector, TableInfo tableInfo, StructType schema) {
     this.injector = injector;
-    this.config = injector.getInstance(SparkBigQueryConfig.class);
+    this.tableInfo = tableInfo;
+    this.schema = schema;
+  }
+
+  public static BigQueryTable fromConfigurationAnsSchema(
+      Injector injector, StructType sparkProvidedSchema) throws NoSuchTableException {
+    SparkBigQueryConfig config = injector.getInstance(SparkBigQueryConfig.class);
+    return createInternal(injector, config.getTableId(), sparkProvidedSchema);
+  }
+
+  public static BigQueryTable fromIdentifier(Injector injector, Identifier ident)
+      throws NoSuchTableException {
     BigQueryClient bigQueryClient = injector.getInstance(BigQueryClient.class);
-    this.tableInfo = bigQueryClient.getTable(config.getTableId());
-    this.schema =
+    return createInternal(
+        injector, ((BigQueryIdentifier) ident).getTableId(), /*sparkProvidedSchema*/ null);
+  }
+
+  private static BigQueryTable createInternal(
+      Injector injector, TableId tableId, StructType sparkProvidedSchema)
+      throws NoSuchTableException {
+    BigQueryClient bigQueryClient = injector.getInstance(BigQueryClient.class);
+    TableInfo tableInfo = bigQueryClient.getTable(tableId);
+    if (tableInfo == null) {
+      throw new NoSuchTableException(new BigQueryIdentifier(tableId));
+    }
+    StructType schema =
         sparkProvidedSchema != null
             ? sparkProvidedSchema
             : SchemaConverters.toSpark(tableInfo.getDefinition().getSchema());
+    return new BigQueryTable(injector, tableInfo, schema);
   }
 
   @Override
   public ScanBuilder newScanBuilder(CaseInsensitiveStringMap options) {
-    Injector readerInjector = injector.createChildInjector(new BigQueryDataSourceReaderModule());
+    SparkBigQueryConfig tableScanConfig =
+        SparkBigQueryConfig.from(
+            options,
+            injector.getInstance(DataSourceVersion.class),
+            injector.getInstance(SparkSession.class),
+            Optional.of(schema), /*tableIsMandatory*/
+            true);
+    Injector readerInjector =
+        injector.createChildInjector(
+            new BigQueryDataSourceReaderModule(Optional.of(tableScanConfig)));
     BigQueryDataSourceReaderContext ctx =
         readerInjector.getInstance(BigQueryDataSourceReaderContext.class);
     return new BigQueryScanBuilder(ctx);

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryTable.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryTable.java
@@ -57,7 +57,7 @@ public class BigQueryTable implements Table, SupportsRead, SupportsWrite {
     this.schema = schema;
   }
 
-  public static BigQueryTable fromConfigurationAnsSchema(
+  public static BigQueryTable fromConfigurationAndSchema(
       Injector injector, StructType sparkProvidedSchema) throws NoSuchTableException {
     SparkBigQueryConfig config = injector.getInstance(SparkBigQueryConfig.class);
     return createInternal(injector, config.getTableId(), sparkProvidedSchema);

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryTableProvider.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryTableProvider.java
@@ -60,7 +60,7 @@ public class BigQueryTableProvider extends BaseBigQuerySource
     try {
       Injector injector =
           InjectorFactory.createInjector(schema, properties, /* tableIsMandatory */ true);
-      BigQueryTable table = BigQueryTable.fromConfigurationAnsSchema(injector, schema);
+      BigQueryTable table = BigQueryTable.fromConfigurationAndSchema(injector, schema);
       return table;
     } catch (NoSuchTableException e) {
       throw new BigQueryConnectorException("Table was not found", e);

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryTableProvider.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryTableProvider.java
@@ -90,13 +90,6 @@ public class BigQueryTableProvider extends BaseBigQuerySource
     if (spark.conf().contains(DEFAULT_CATALOG)) {
       return;
     }
-    ImmutableMap<String, String> config =
-        ImmutableMap.of(
-            "type", "hive",
-            "default-namespace", "default",
-            "cache-enabled", "false" // the source should not use a cache
-            );
     spark.conf().set(DEFAULT_CATALOG, BigQueryCatalog.class.getCanonicalName());
-    config.forEach((key, value) -> spark.conf().set(DEFAULT_CATALOG + "." + key, value));
   }
 }

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark31DirectWriteIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark31DirectWriteIntegrationTest.java
@@ -17,7 +17,6 @@ package com.google.cloud.spark.bigquery.integration;
 
 import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
 import org.junit.Ignore;
-import org.junit.Test;
 
 // temporary ignore
 @Ignore

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark31DirectWriteIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark31DirectWriteIntegrationTest.java
@@ -17,6 +17,7 @@ package com.google.cloud.spark.bigquery.integration;
 
 import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
 import org.junit.Ignore;
+import org.junit.Test;
 
 // temporary ignore
 @Ignore
@@ -28,4 +29,8 @@ public class Spark31DirectWriteIntegrationTest extends WriteIntegrationTestBase 
 
   // tests from superclass
 
+  @Test
+  public void testFoo() throws Exception {
+    testWriteToBigQuery_ErrorIfExistsSaveMode();
+  }
 }

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark31DirectWriteIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark31DirectWriteIntegrationTest.java
@@ -29,8 +29,4 @@ public class Spark31DirectWriteIntegrationTest extends WriteIntegrationTestBase 
 
   // tests from superclass
 
-  @Test
-  public void testFoo() throws Exception {
-    testWriteToBigQuery_ErrorIfExistsSaveMode();
-  }
 }

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark31ReadByFormatIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark31ReadByFormatIntegrationTest.java
@@ -15,11 +15,18 @@
  */
 package com.google.cloud.spark.bigquery.integration;
 
+import org.junit.Test;
+
 public class Spark31ReadByFormatIntegrationTest extends ReadByFormatIntegrationTestBase {
 
   public Spark31ReadByFormatIntegrationTest() {
-    super("ARROW");
+    super("ARROW", /* userProvidedSchemaAllowed */ false);
   }
 
   // tests are from the super-class
+
+  @Test
+  public void foo() {
+    testCachedViewWithDifferentColumnsForSelectAndFilter();
+  }
 }

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark31ReadIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark31ReadIntegrationTest.java
@@ -15,8 +15,6 @@
  */
 package com.google.cloud.spark.bigquery.integration;
 
-import org.junit.Test;
-
 public class Spark31ReadIntegrationTest extends ReadIntegrationTestBase {
   public Spark31ReadIntegrationTest() {
     super(/* userProvidedSchemaAllowed */ false);

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark31ReadIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark31ReadIntegrationTest.java
@@ -24,8 +24,4 @@ public class Spark31ReadIntegrationTest extends ReadIntegrationTestBase {
 
   // tests are from the super-class
 
-  @Test
-  public void foo() {
-    testKnownSizeInBytes();
-  }
 }

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark31ReadIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark31ReadIntegrationTest.java
@@ -15,8 +15,17 @@
  */
 package com.google.cloud.spark.bigquery.integration;
 
+import org.junit.Test;
+
 public class Spark31ReadIntegrationTest extends ReadIntegrationTestBase {
+  public Spark31ReadIntegrationTest() {
+    super(/* userProvidedSchemaAllowed */ false);
+  }
 
   // tests are from the super-class
 
+  @Test
+  public void foo() {
+    testKnownSizeInBytes();
+  }
 }

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/InjectorFactory.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/InjectorFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.spark.bigquery.v2;
 
 import com.google.cloud.bigquery.connector.common.BigQueryClientModule;

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/InjectorFactory.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/InjectorFactory.java
@@ -13,11 +13,12 @@ import org.apache.spark.sql.types.StructType;
 public class InjectorFactory {
   private InjectorFactory() {}
 
-  public static Injector createInjector(StructType schema, Map<String, String> options) {
+  public static Injector createInjector(
+      StructType schema, Map<String, String> options, boolean tableIsMandatory) {
     SparkSession spark = SparkSession.active();
     return Guice.createInjector(
         new BigQueryClientModule(),
         new SparkBigQueryConnectorModule(
-            spark, options, Optional.ofNullable(schema), DataSourceVersion.V2));
+            spark, options, Optional.ofNullable(schema), DataSourceVersion.V2, tableIsMandatory));
   }
 }

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/ReadByFormatIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/ReadByFormatIntegrationTestBase.java
@@ -195,7 +195,7 @@ public class ReadByFormatIntegrationTestBase extends SparkBigQueryIntegrationTes
 
   @Test
   public void testColumnOrderOfStruct() {
-    assumeTrue("user provided schema is no allowed for this connector", userProvidedSchemaAllowed);
+    assumeTrue("user provided schema is not allowed for this connector", userProvidedSchemaAllowed);
     StructType schema = Encoders.bean(ColumnOrderTestClass.class).schema();
 
     Dataset<ColumnOrderTestClass> dataset =

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/ReadByFormatIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/ReadByFormatIntegrationTestBase.java
@@ -16,6 +16,7 @@
 package com.google.cloud.spark.bigquery.integration;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 import com.google.cloud.spark.bigquery.integration.model.ColumnOrderTestClass;
 import com.google.common.collect.ImmutableSet;
@@ -32,11 +33,17 @@ import org.junit.Test;
 
 public class ReadByFormatIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
 
-  protected String dataFormat;
+  protected final String dataFormat;
+  protected final boolean userProvidedSchemaAllowed;
 
   public ReadByFormatIntegrationTestBase(String dataFormat) {
+    this(dataFormat, true);
+  }
+
+  public ReadByFormatIntegrationTestBase(String dataFormat, boolean userProvidedSchemaAllowed) {
     super();
     this.dataFormat = dataFormat;
+    this.userProvidedSchemaAllowed = userProvidedSchemaAllowed;
   }
 
   @Test
@@ -188,6 +195,7 @@ public class ReadByFormatIntegrationTestBase extends SparkBigQueryIntegrationTes
 
   @Test
   public void testColumnOrderOfStruct() {
+    assumeTrue("user provided schema is no allowed for this connector", userProvidedSchemaAllowed);
     StructType schema = Encoders.bean(ColumnOrderTestClass.class).schema();
 
     Dataset<ColumnOrderTestClass> dataset =

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/ReadIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/ReadIntegrationTestBase.java
@@ -86,7 +86,6 @@ public class ReadIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
   private static final String LARGE_TABLE_FIELD = "is_male";
   private static final long LARGE_TABLE_NUM_ROWS = 33271914L;
   private static final String NON_EXISTENT_TABLE = "non-existent.non-existent.non-existent";
-  private static final String STRUCT_COLUMN_ORDER_TEST_TABLE_NAME = "struct_column_order";
   private static final String ALL_TYPES_TABLE_NAME = "all_types";
 
   protected final boolean userProvidedSchemaAllowed;
@@ -245,7 +244,7 @@ public class ReadIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
 
   @Test
   public void testUserDefinedSchema() {
-    assumeTrue("user provided schema is no allowed for this connector", userProvidedSchemaAllowed);
+    assumeTrue("user provided schema is not allowed for this connector", userProvidedSchemaAllowed);
     // TODO(pmkc): consider a schema that wouldn't cause cast errors if read.
     StructType expectedSchema =
         new StructType(

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/ReadIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/ReadIntegrationTestBase.java
@@ -18,6 +18,7 @@ package com.google.cloud.spark.bigquery.integration;
 import static com.google.cloud.spark.bigquery.integration.IntegrationTestUtils.metadata;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assume.assumeTrue;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -88,6 +89,17 @@ public class ReadIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
   private static final String STRUCT_COLUMN_ORDER_TEST_TABLE_NAME = "struct_column_order";
   private static final String ALL_TYPES_TABLE_NAME = "all_types";
   private static final String ALL_TYPES_VIEW_NAME = "all_types_view";
+
+  protected final boolean userProvidedSchemaAllowed;
+
+  public ReadIntegrationTestBase() {
+    this(true);
+  }
+
+  public ReadIntegrationTestBase(boolean userProvidedSchemaAllowed) {
+    super();
+    this.userProvidedSchemaAllowed = userProvidedSchemaAllowed;
+  }
 
   /** Generate a test to verify that the given DataFrame is equal to a known result. */
   private void testShakespeare(Dataset<Row> df) {
@@ -234,6 +246,7 @@ public class ReadIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
 
   @Test
   public void testUserDefinedSchema() {
+    assumeTrue("user provided schema is no allowed for this connector", userProvidedSchemaAllowed);
     // TODO(pmkc): consider a schema that wouldn't cause cast errors if read.
     StructType expectedSchema =
         new StructType(

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/ReadIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/ReadIntegrationTestBase.java
@@ -88,7 +88,6 @@ public class ReadIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
   private static final String NON_EXISTENT_TABLE = "non-existent.non-existent.non-existent";
   private static final String STRUCT_COLUMN_ORDER_TEST_TABLE_NAME = "struct_column_order";
   private static final String ALL_TYPES_TABLE_NAME = "all_types";
-  private static final String ALL_TYPES_VIEW_NAME = "all_types_view";
 
   protected final boolean userProvidedSchemaAllowed;
 


### PR DESCRIPTION
Spark Catalog API implementation is required for supporting write capabilities in spark 3. The main difference is that in previous version is a configuration scan on each load or save, while with the catalog there's a catalog creation based on the configuration (without getting a specific table) and them referring to the table when creating the ScanBuilder. 

This required breaking some of the configuration parsing logic, originally concentrated in SparkBigQueryConfig into new classes.