### PR TITLE
removing the schema level check for InDirect write 

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -681,7 +681,7 @@ The API Supports a number of options to configure the read
    <tr valign="top">
      <td><code>enableModeCheckForSchemaFields</code>
      </td>
-     <td>  Checks the mode of every field in destination schema to be equal to the mode in corresponding source field schema, while writing from one big query table to another.
+     <td>  Checks the mode of every field in destination schema to be equal to the mode in corresponding source field schema, during DIRECT write.
           <br/> Default value is true i.e., the check is done by default. If set to false the mode check is ignored.
      </td>
      <td>Write</td>

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
@@ -458,20 +458,7 @@ public class BigQueryClient {
       LoadDataOptions options,
       List<String> sourceUris,
       FormatOptions formatOptions,
-      JobInfo.WriteDisposition writeDisposition,
-      Schema sourceTableSchema) {
-    if (sourceTableSchema != null && tableExists(options.getTableId())) {
-      TableInfo destinationTable = getTable(options.getTableId());
-      Schema destinationTableSchema = destinationTable.getDefinition().getSchema();
-      Preconditions.checkArgument(
-          BigQueryUtil.schemaEquals(
-              destinationTableSchema,
-              sourceTableSchema,
-              /* regardFieldOrder */ false,
-              options.getEnableModeCheckForSchemaFields()),
-          new BigQueryConnectorException.InvalidSchemaException(
-              "Destination table's schema is not compatible with dataframe's schema"));
-    }
+      JobInfo.WriteDisposition writeDisposition) {
     LoadJobConfiguration.Builder jobConfiguration =
         jobConfigurationFactory
             .createLoadJobConfigurationBuilder(options, sourceUris, formatOptions)

--- a/spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/BigQueryWriteHelper.scala
+++ b/spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/BigQueryWriteHelper.scala
@@ -85,11 +85,7 @@ case class BigQueryWriteHelper(bigQueryClient: BigQueryClient,
       .asJava)
     val writeDisposition = SparkBigQueryUtil.saveModeToWriteDisposition(saveMode)
 
-    var sourceSchema: Schema = null
-    if (options.schema.isPresent) {
-      sourceSchema = toBigQuerySchema(options.schema.get())
-    }
-    bigQueryClient.loadDataIntoTable(options, sourceUris, formatOptions, writeDisposition, sourceSchema)
+    bigQueryClient.loadDataIntoTable(options, sourceUris, formatOptions, writeDisposition)
   }
 
   def friendlyTableName: String = BigQueryUtil.friendlyTableName(options.getTableId)

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryIndirectDataSourceWriterContext.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryIndirectDataSourceWriterContext.java
@@ -158,12 +158,7 @@ public class BigQueryIndirectDataSourceWriterContext implements DataSourceWriter
         SparkBigQueryUtil.saveModeToWriteDisposition(saveMode);
     FormatOptions formatOptions = config.getIntermediateFormat().getFormatOptions();
 
-    Schema sourceTableSchema = null;
-    if (sparkSchema != null) {
-      sourceTableSchema = SchemaConverters.toBigQuerySchema(sparkSchema);
-    }
-    bigQueryClient.loadDataIntoTable(
-        config, optimizedSourceUris, formatOptions, writeDisposition, sourceTableSchema);
+    bigQueryClient.loadDataIntoTable(config, optimizedSourceUris, formatOptions, writeDisposition);
   }
 
   void updateMetadataIfNeeded() {

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/SparkBigQueryIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/SparkBigQueryIntegrationTestBase.java
@@ -76,6 +76,11 @@ public class SparkBigQueryIntegrationTestBase {
               TestConstants.DIFF_IN_SCHEMA_SRC_TABLE_NAME));
       IntegrationTestUtils.runQuery(
           String.format(
+              TestConstants.DIFF_IN_SCHEMA_SRC_TABLE_WITH_DESCRIPTION,
+              testDataset,
+              TestConstants.DIFF_IN_SCHEMA_SRC_TABLE_NAME_WITH_DESCRIPTION));
+      IntegrationTestUtils.runQuery(
+          String.format(
               TestConstants.DIFF_IN_SCHEMA_DEST_TABLE,
               testDataset,
               TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME));

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/SparkBigQueryIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/SparkBigQueryIntegrationTestBase.java
@@ -79,11 +79,6 @@ public class SparkBigQueryIntegrationTestBase {
               TestConstants.DIFF_IN_SCHEMA_SRC_TABLE_WITH_DESCRIPTION,
               testDataset,
               TestConstants.DIFF_IN_SCHEMA_SRC_TABLE_NAME_WITH_DESCRIPTION));
-      IntegrationTestUtils.runQuery(
-          String.format(
-              TestConstants.DIFF_IN_SCHEMA_DEST_TABLE,
-              testDataset,
-              TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME));
     }
 
     @Override

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/TestConstants.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/TestConstants.java
@@ -104,6 +104,7 @@ public class TestConstants {
   static final String ALL_TYPES_TABLE_NAME = "all_types";
   static final String ALL_TYPES_VIEW_NAME = "all_types_view";
   static final String DIFF_IN_SCHEMA_SRC_TABLE_NAME = "src_table";
+  static final String DIFF_IN_SCHEMA_SRC_TABLE_NAME_WITH_DESCRIPTION = "src_table_with_description";
   static final String DIFF_IN_SCHEMA_DEST_TABLE_NAME = "dest_table";
   static DataType BQ_NUMERIC = DataTypes.createDecimalType(38, 9);
   public static int BIG_NUMERIC_COLUMN_POSITION = 11;
@@ -232,6 +233,18 @@ public class TestConstants {
               "create table %s.%s (",
               "int_req int64 not null,",
               "int_null int64,",
+              ") as",
+              "",
+              "select",
+              "42 as int_req,",
+              "null as int_null")
+          .collect(Collectors.joining("\n"));
+
+  public static String DIFF_IN_SCHEMA_SRC_TABLE_WITH_DESCRIPTION =
+      Stream.of(
+              "create table %s.%s (",
+              "int_req int64 not null,",
+              "int_null int64 OPTIONS(description='An INTEGER field with description'),",
               ") as",
               "",
               "select",

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -97,6 +97,13 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
     this.testTable = "test_" + System.nanoTime();
   }
 
+  private String createDiffInSchemaDestTable() {
+    String destTableName = TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME + "_" + System.nanoTime();
+    IntegrationTestUtils.runQuery(
+        String.format(TestConstants.DIFF_IN_SCHEMA_DEST_TABLE, testDataset, destTableName));
+    return destTableName;
+  }
+
   // Write tests. We have four save modes: Append, ErrorIfExists, Ignore and
   // Overwrite. For each there are two behaviours - the table exists or not.
   // See more at http://spark.apache.org/docs/2.3.2/api/java/org/apache/spark/sql/SaveMode.html
@@ -269,14 +276,6 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
         .save();
     assertThat(testTableNumberOfRows()).isEqualTo(2);
     assertThat(initialDataValuesExist()).isTrue();
-  }
-
-  private String createDiffInSchemaDestTable() {
-    String destTableName = TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME + "_" + System.nanoTime();
-    ;
-    IntegrationTestUtils.runQuery(
-        String.format(TestConstants.DIFF_IN_SCHEMA_DEST_TABLE, testDataset, destTableName));
-    return destTableName;
   }
 
   @Test

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -315,7 +315,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
             "select * from %s.%s",
             testDataset.toString(), TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
     int numOfRows = (int) bq.query(QueryJobConfiguration.of(query)).getTotalRows();
-    assertThat(numOfRows).isEqualTo(1);
+    assertThat(numOfRows).isGreaterThan(0);
   }
 
   @Test
@@ -363,7 +363,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
             "select * from %s.%s",
             testDataset.toString(), TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
     int numOfRows = (int) bq.query(QueryJobConfiguration.of(query)).getTotalRows();
-    assertThat(numOfRows).isEqualTo(1);
+    assertThat(numOfRows).isGreaterThan(0);
   }
 
   @Test
@@ -389,7 +389,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
             "select * from %s.%s",
             testDataset.toString(), TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
     int numOfRows = (int) bq.query(QueryJobConfiguration.of(query)).getTotalRows();
-    assertThat(numOfRows).isEqualTo(1);
+    assertThat(numOfRows).isGreaterThan(0);
   }
 
   @Test
@@ -415,7 +415,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
             "select * from %s.%s",
             testDataset.toString(), TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
     int numOfRows = (int) bq.query(QueryJobConfiguration.of(query)).getTotalRows();
-    assertThat(numOfRows).isEqualTo(1);
+    assertThat(numOfRows).isGreaterThan(0);
   }
 
   @Test

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -59,7 +59,6 @@ import org.apache.spark.sql.types.MetadataBuilder;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import scala.Some;
 
@@ -273,7 +272,6 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   }
 
   @Test
-  @Ignore("DSv2 only")
   public void testDirectWriteToBigQueryWithDiffInSchema() {
     assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
     Dataset<Row> df =
@@ -294,7 +292,6 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   }
 
   @Test
-  @Ignore("DSv2 only")
   public void testDirectWriteToBigQueryWithDiffInSchemaAndDisableModeCheck() throws Exception {
     assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
     Dataset<Row> df =
@@ -319,7 +316,6 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   }
 
   @Test
-  @Ignore("DSv2 only")
   public void testDirectWriteToBigQueryWithDiffInDescription() throws Exception {
     assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
     Dataset<Row> df =

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -276,7 +276,6 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   @Ignore("DSv2 only")
   public void testDirectWriteToBigQueryWithDiffInSchema() {
     assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
-    spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =
         spark
             .read()
@@ -298,7 +297,6 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   @Ignore("DSv2 only")
   public void testDirectWriteToBigQueryWithDiffInSchemaAndDisableModeCheck() throws Exception {
     assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
-    spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =
         spark
             .read()
@@ -317,14 +315,13 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
             "select * from %s.%s",
             testDataset.toString(), TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
     int numOfRows = (int) bq.query(QueryJobConfiguration.of(query)).getTotalRows();
-    assertThat(numOfRows).isGreaterThan(0);
+    assertThat(numOfRows).isEqualTo(1);
   }
 
   @Test
   @Ignore("DSv2 only")
   public void testDirectWriteToBigQueryWithDiffInDescription() throws Exception {
     assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
-    spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =
         spark
             .read()
@@ -347,7 +344,6 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   @Test
   public void testInDirectWriteToBigQueryWithDiffInSchemaAndModeCheck() throws Exception {
     assumeThat(writeMethod, equalTo(SparkBigQueryConfig.WriteMethod.INDIRECT));
-    spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =
         spark
             .read()
@@ -359,6 +355,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
         .format("bigquery")
         .mode(SaveMode.Append)
         .option("writeMethod", writeMethod.toString())
+        .option("temporaryGcsBucket", temporaryGcsBucket)
         .option("enableModeCheckForSchemaFields", true)
         .save(testDataset + "." + TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
     String query =
@@ -366,14 +363,13 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
             "select * from %s.%s",
             testDataset.toString(), TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
     int numOfRows = (int) bq.query(QueryJobConfiguration.of(query)).getTotalRows();
-    assertThat(numOfRows).isGreaterThan(0);
+    assertThat(numOfRows).isEqualTo(1);
   }
 
   @Test
   public void testIndirectWriteToBigQueryWithDiffInSchemaNullableFieldAndDisableModeCheck()
       throws Exception {
     assumeThat(writeMethod, equalTo(SparkBigQueryConfig.WriteMethod.INDIRECT));
-    spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =
         spark
             .read()
@@ -385,6 +381,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
         .format("bigquery")
         .mode(SaveMode.Append)
         .option("writeMethod", writeMethod.toString())
+        .option("temporaryGcsBucket", temporaryGcsBucket)
         .option("enableModeCheckForSchemaFields", false)
         .save(testDataset + "." + TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
     String query =
@@ -392,13 +389,12 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
             "select * from %s.%s",
             testDataset.toString(), TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
     int numOfRows = (int) bq.query(QueryJobConfiguration.of(query)).getTotalRows();
-    assertThat(numOfRows).isGreaterThan(0);
+    assertThat(numOfRows).isEqualTo(1);
   }
 
   @Test
   public void testInDirectWriteToBigQueryWithDiffInDescription() throws Exception {
     assumeThat(writeMethod, equalTo(WriteMethod.INDIRECT));
-    spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =
         spark
             .read()
@@ -411,6 +407,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
     df.write()
         .format("bigquery")
         .mode(SaveMode.Append)
+        .option("temporaryGcsBucket", temporaryGcsBucket)
         .option("writeMethod", writeMethod.toString())
         .save(testDataset + "." + TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
     String query =
@@ -418,7 +415,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
             "select * from %s.%s",
             testDataset.toString(), TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
     int numOfRows = (int) bq.query(QueryJobConfiguration.of(query)).getTotalRows();
-    assertThat(numOfRows).isGreaterThan(0);
+    assertThat(numOfRows).isEqualTo(1);
   }
 
   @Test

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -271,9 +271,18 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
     assertThat(initialDataValuesExist()).isTrue();
   }
 
+  private String createDiffInSchemaDestTable() {
+    String destTableName = TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME + "_" + System.nanoTime();
+    ;
+    IntegrationTestUtils.runQuery(
+        String.format(TestConstants.DIFF_IN_SCHEMA_DEST_TABLE, testDataset, destTableName));
+    return destTableName;
+  }
+
   @Test
   public void testDirectWriteToBigQueryWithDiffInSchema() {
     assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
+    String destTableName = createDiffInSchemaDestTable();
     Dataset<Row> df =
         spark
             .read()
@@ -288,12 +297,13 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
                 .format("bigquery")
                 .mode(SaveMode.Append)
                 .option("writeMethod", writeMethod.toString())
-                .save(testDataset + "." + TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME));
+                .save(testDataset + "." + destTableName));
   }
 
   @Test
   public void testDirectWriteToBigQueryWithDiffInSchemaAndDisableModeCheck() throws Exception {
     assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
+    String destTableName = createDiffInSchemaDestTable();
     Dataset<Row> df =
         spark
             .read()
@@ -306,18 +316,16 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
         .mode(SaveMode.Append)
         .option("writeMethod", writeMethod.toString())
         .option("enableModeCheckForSchemaFields", false)
-        .save(testDataset + "." + TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
-    String query =
-        String.format(
-            "select * from %s.%s",
-            testDataset.toString(), TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
+        .save(testDataset + "." + destTableName);
+    String query = String.format("select * from %s.%s", testDataset.toString(), destTableName);
     int numOfRows = (int) bq.query(QueryJobConfiguration.of(query)).getTotalRows();
-    assertThat(numOfRows).isGreaterThan(0);
+    assertThat(numOfRows).isEqualTo(1);
   }
 
   @Test
   public void testDirectWriteToBigQueryWithDiffInDescription() throws Exception {
     assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
+    String destTableName = createDiffInSchemaDestTable();
     Dataset<Row> df =
         spark
             .read()
@@ -334,12 +342,13 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
                 .format("bigquery")
                 .mode(SaveMode.Append)
                 .option("writeMethod", writeMethod.toString())
-                .save(testDataset + "." + TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME));
+                .save(testDataset + "." + destTableName));
   }
 
   @Test
   public void testInDirectWriteToBigQueryWithDiffInSchemaAndModeCheck() throws Exception {
     assumeThat(writeMethod, equalTo(SparkBigQueryConfig.WriteMethod.INDIRECT));
+    String destTableName = createDiffInSchemaDestTable();
     Dataset<Row> df =
         spark
             .read()
@@ -353,19 +362,17 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
         .option("writeMethod", writeMethod.toString())
         .option("temporaryGcsBucket", temporaryGcsBucket)
         .option("enableModeCheckForSchemaFields", true)
-        .save(testDataset + "." + TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
-    String query =
-        String.format(
-            "select * from %s.%s",
-            testDataset.toString(), TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
+        .save(testDataset + "." + destTableName);
+    String query = String.format("select * from %s.%s", testDataset.toString(), destTableName);
     int numOfRows = (int) bq.query(QueryJobConfiguration.of(query)).getTotalRows();
-    assertThat(numOfRows).isGreaterThan(0);
+    assertThat(numOfRows).isEqualTo(1);
   }
 
   @Test
   public void testIndirectWriteToBigQueryWithDiffInSchemaNullableFieldAndDisableModeCheck()
       throws Exception {
     assumeThat(writeMethod, equalTo(SparkBigQueryConfig.WriteMethod.INDIRECT));
+    String destTableName = createDiffInSchemaDestTable();
     Dataset<Row> df =
         spark
             .read()
@@ -379,18 +386,16 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
         .option("writeMethod", writeMethod.toString())
         .option("temporaryGcsBucket", temporaryGcsBucket)
         .option("enableModeCheckForSchemaFields", false)
-        .save(testDataset + "." + TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
-    String query =
-        String.format(
-            "select * from %s.%s",
-            testDataset.toString(), TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
+        .save(testDataset + "." + destTableName);
+    String query = String.format("select * from %s.%s", testDataset.toString(), destTableName);
     int numOfRows = (int) bq.query(QueryJobConfiguration.of(query)).getTotalRows();
-    assertThat(numOfRows).isGreaterThan(0);
+    assertThat(numOfRows).isEqualTo(1);
   }
 
   @Test
   public void testInDirectWriteToBigQueryWithDiffInDescription() throws Exception {
     assumeThat(writeMethod, equalTo(WriteMethod.INDIRECT));
+    String destTableName = createDiffInSchemaDestTable();
     Dataset<Row> df =
         spark
             .read()
@@ -405,13 +410,10 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
         .mode(SaveMode.Append)
         .option("temporaryGcsBucket", temporaryGcsBucket)
         .option("writeMethod", writeMethod.toString())
-        .save(testDataset + "." + TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
-    String query =
-        String.format(
-            "select * from %s.%s",
-            testDataset.toString(), TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
+        .save(testDataset + "." + destTableName);
+    String query = String.format("select * from %s.%s", testDataset.toString(), destTableName);
     int numOfRows = (int) bq.query(QueryJobConfiguration.of(query)).getTotalRows();
-    assertThat(numOfRows).isGreaterThan(0);
+    assertThat(numOfRows).isEqualTo(1);
   }
 
   @Test

--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -317,11 +317,11 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
             "select * from %s.%s",
             testDataset.toString(), TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
     int numOfRows = (int) bq.query(QueryJobConfiguration.of(query)).getTotalRows();
-    assertThat(numOfRows).isEqualTo(1);
+    assertThat(numOfRows).isGreaterThan(0);
   }
 
   @Test
-  public void testInDirectWriteToBigQueryWithDiffInSchemaAndModeCheck() {
+  public void testInDirectWriteToBigQueryWithDiffInSchemaAndModeCheck() throws Exception {
     assumeThat(writeMethod, equalTo(SparkBigQueryConfig.WriteMethod.INDIRECT));
     spark.conf().set("temporaryGcsBucket", temporaryGcsBucket);
     Dataset<Row> df =
@@ -331,15 +331,18 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
             .option("table", testDataset + "." + TestConstants.DIFF_IN_SCHEMA_SRC_TABLE_NAME)
             .load();
 
-    assertThrows(
-        Exception.class,
-        () ->
-            df.write()
-                .format("bigquery")
-                .mode(SaveMode.Append)
-                .option("writeMethod", writeMethod.toString())
-                .option("enableModeCheckForSchemaFields", true)
-                .save(testDataset + "." + TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME));
+    df.write()
+        .format("bigquery")
+        .mode(SaveMode.Append)
+        .option("writeMethod", writeMethod.toString())
+        .option("enableModeCheckForSchemaFields", true)
+        .save(testDataset + "." + TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
+    String query =
+        String.format(
+            "select * from %s.%s",
+            testDataset.toString(), TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
+    int numOfRows = (int) bq.query(QueryJobConfiguration.of(query)).getTotalRows();
+    assertThat(numOfRows).isGreaterThan(0);
   }
 
   @Test
@@ -365,7 +368,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
             "select * from %s.%s",
             testDataset.toString(), TestConstants.DIFF_IN_SCHEMA_DEST_TABLE_NAME);
     int numOfRows = (int) bq.query(QueryJobConfiguration.of(query)).getTotalRows();
-    assertThat(numOfRows).isEqualTo(1);
+    assertThat(numOfRows).isGreaterThan(0);
   }
 
   @Test


### PR DESCRIPTION
removing the schema level check for InDirect write and enabling the option enableModeCheckForSchemaFields only for Direct write