### PR TITLE
Add interface SupportsQueryPushdown that is implemented by BigQueryDataSourceReader

### DIFF
--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SupportsQueryPushdown.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SupportsQueryPushdown.java
@@ -1,0 +1,7 @@
+package com.google.cloud.spark.bigquery;
+
+import com.google.cloud.spark.bigquery.direct.BigQueryRDDFactory;
+
+public interface SupportsQueryPushdown {
+  public BigQueryRDDFactory getBigQueryRDDFactory();
+}

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SupportsQueryPushdown.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SupportsQueryPushdown.java
@@ -1,7 +1,23 @@
+/*
+ * Copyright 2022 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.cloud.spark.bigquery;
 
 import com.google.cloud.spark.bigquery.direct.BigQueryRDDFactory;
 
 public interface SupportsQueryPushdown {
-  public BigQueryRDDFactory getBigQueryRDDFactory();
+  BigQueryRDDFactory getBigQueryRDDFactory();
 }

--- a/spark-bigquery-dsv2/spark-2.4-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryDataSourceReader.java
+++ b/spark-bigquery-dsv2/spark-2.4-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryDataSourceReader.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.spark.bigquery.v2;
 
+import com.google.cloud.spark.bigquery.SupportsQueryPushdown;
+import com.google.cloud.spark.bigquery.direct.BigQueryRDDFactory;
 import com.google.cloud.spark.bigquery.v2.context.BigQueryDataSourceReaderContext;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -29,7 +31,8 @@ public class BigQueryDataSourceReader
         SupportsPushDownRequiredColumns,
         SupportsPushDownFilters,
         SupportsReportStatistics,
-        SupportsScanColumnarBatch {
+        SupportsScanColumnarBatch,
+        SupportsQueryPushdown {
 
   private BigQueryDataSourceReaderContext context;
 
@@ -81,5 +84,10 @@ public class BigQueryDataSourceReader
   @Override
   public boolean enableBatchRead() {
     return context.enableBatchRead();
+  }
+
+  @Override
+  public BigQueryRDDFactory getBigQueryRDDFactory() {
+    return context.getBigQueryRddFactory();
   }
 }

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryDataSourceReaderContext.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryDataSourceReaderContext.java
@@ -32,7 +32,9 @@ import com.google.cloud.bigquery.storage.v1.ReadSession;
 import com.google.cloud.bigquery.storage.v1.ReadStream;
 import com.google.cloud.spark.bigquery.ReadRowsResponseToInternalRowIteratorConverter;
 import com.google.cloud.spark.bigquery.SchemaConverters;
+import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
 import com.google.cloud.spark.bigquery.SparkFilterUtils;
+import com.google.cloud.spark.bigquery.direct.BigQueryRDDFactory;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -47,6 +49,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.StructField;
@@ -82,6 +85,9 @@ public class BigQueryDataSourceReaderContext {
   private final BigQueryClientFactory bigQueryReadClientFactory;
   private final BigQueryTracerFactory bigQueryTracerFactory;
   private final ReadSessionCreator readSessionCreator;
+  private final SparkBigQueryConfig options;
+  private final SQLContext sqlContext;
+  private final BigQueryRDDFactory bigQueryRDDFactory;
   private final Optional<String> globalFilter;
   private final String applicationId;
   private Optional<StructType> schema;
@@ -97,7 +103,9 @@ public class BigQueryDataSourceReaderContext {
       ReadSessionCreatorConfig readSessionCreatorConfig,
       Optional<String> globalFilter,
       Optional<StructType> schema,
-      String applicationId) {
+      String applicationId,
+      SparkBigQueryConfig options,
+      SQLContext sqlContext) {
     this.table = table;
     this.tableId = table.getTableId();
     this.readSessionCreatorConfig = readSessionCreatorConfig;
@@ -122,6 +130,10 @@ public class BigQueryDataSourceReaderContext {
       fields.put(field.name(), field);
     }
     this.applicationId = applicationId;
+    this.options = options;
+    this.sqlContext = sqlContext;
+    this.bigQueryRDDFactory =
+        new BigQueryRDDFactory(bigQueryClient, bigQueryReadClientFactory, options, sqlContext);
   }
 
   public StructType readSchema() {
@@ -309,5 +321,9 @@ public class BigQueryDataSourceReaderContext {
 
   public String getFullTableName() {
     return BigQueryUtil.friendlyTableName(tableId);
+  }
+
+  public BigQueryRDDFactory getBigQueryRddFactory() {
+    return this.bigQueryRDDFactory;
   }
 }

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryDataSourceReaderModule.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryDataSourceReaderModule.java
@@ -64,6 +64,8 @@ public class BigQueryDataSourceReaderModule implements Module {
         config.toReadSessionCreatorConfig(),
         config.getFilter(),
         config.getSchema(),
-        sparkSession.sparkContext().applicationId());
+        sparkSession.sparkContext().applicationId(),
+        config,
+        sparkSession.sqlContext());
   }
 }


### PR DESCRIPTION
We will use the interface SupportsQueryPushdown for integrating with DSv2 connector for Spark 2.4 in the next PR. 

We need the `BigQueryRDDFactory` object for [SourceQuery](https://github.com/GoogleCloudDataproc/spark-bigquery-connector/blob/master/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SourceQuery.scala#L33) in pushdown