### PR TITLE
Create a new profile for query pushdown in the reactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,15 @@
       </modules>
     </profile>
     <profile>
+      <id>query_pushdown</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <modules>
+        <module>spark-bigquery-pushdown</module>
+      </modules>
+    </profile>
+    <profile>
       <id>dsv1</id>
       <activation>
         <activeByDefault>false</activeByDefault>
@@ -88,9 +97,6 @@
         </module>
         <module>spark-bigquery-dsv1/spark-bigquery-with-dependencies_2.11
         </module>
-        <module>spark-bigquery-pushdown/spark-bigquery-pushdown-parent</module>
-        <module>spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.11</module>
-        <module>spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11</module>
       </modules>
     </profile>
     <profile>
@@ -106,10 +112,6 @@
         </module>
         <module>spark-bigquery-dsv1/spark-bigquery-with-dependencies_2.12
         </module>
-        <module>spark-bigquery-pushdown/spark-bigquery-pushdown-parent</module>
-        <module>spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.12</module>
-        <module>spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12</module>
-        <module>spark-bigquery-pushdown/spark-3.1-bigquery-pushdown_2.12</module>
       </modules>
     </profile>
     <profile>


### PR DESCRIPTION
When I tried to add query pushdown modules in dsv2, I was seeing `Project spark-bigquery-pushdown-parent is duplicated in the reactor` in GCB.

So, created a separate profile for query pushdown

