### PR TITLE
Add BIGLAKE_CONNECTION_ID as an env variable in the nightly script

### DIFF
--- a/cloudbuild/nightly.yaml
+++ b/cloudbuild/nightly.yaml
@@ -14,6 +14,7 @@ steps:
       - 'TEMPORARY_GCS_BUCKET=${_TEMPORARY_GCS_BUCKET}'
       - 'ACCEPTANCE_TEST_BUCKET=${_ACCEPTANCE_TEST_BUCKET}'
       - 'SERVERLESS_NETWORK_URI=${_SERVERLESS_NETWORK_URI}'
+      - 'BIGLAKE_CONNECTION_ID=${_BIGLAKE_CONNECTION_ID}'
       - 'CODECOV_TOKEN=${_CODECOV_TOKEN}'
   - name: 'gcr.io/cloud-builders/gsutil'
     entrypoint: 'bash'


### PR DESCRIPTION
The nightly build is failing with an NPE because `BIGLAKE_CONNECTION_ID` is not set.

This PR fixes that