### PR TITLE
Changing the cast type to Numeric instead of Bytes

### DIFF
--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
@@ -287,9 +287,9 @@ abstract class SparkExpressionConverter {
                * BigQuery doesn't support casting from Integer to Bytes (https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#cast_as_bytes)
                * So handling this case separately.
                */
-              case (_: IntegerType ,_: ByteType) =>
+              case (_: IntegerType | _: LongType | _: FloatType | _: DoubleType | _: DecimalType ,_: ByteType) =>
                 ConstantString("CAST") +
-                  blockStatement(convertStatement(child, fields) + ConstantString("AS INT64"))
+                  blockStatement(convertStatement(child, fields) + ConstantString("AS NUMERIC"))
               case _ =>
                 ConstantString("CAST") +
                   blockStatement(convertStatement(child, fields) + "AS" + cast)

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
@@ -384,7 +384,6 @@ abstract class SparkExpressionConverter {
        */
       case _: Rank | _: DenseRank | _: PercentRank | _: RowNumber =>
         ConstantString(expression.prettyName.toUpperCase) + ConstantString("()")
-//      case _: Grouping
       case _ => null
     })
   }

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
@@ -804,6 +804,34 @@ class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
     assert(bigQuerySQLStatement.get.toString == "CAST ( SCHOOLID AS NUMERIC )")
   }
 
+  test("convertMiscellaneousExpressions with Cast from Long to Bytes") {
+    val castExpression = Cast.apply(AttributeReference.apply("SchoolID", LongType)(ExprId.apply(2)), ByteType)
+    val bigQuerySQLStatement = expressionConverter.convertMiscellaneousExpressions(castExpression, fields)
+    assert(bigQuerySQLStatement.isDefined)
+    assert(bigQuerySQLStatement.get.toString == "CAST ( SCHOOLID AS NUMERIC )")
+  }
+
+  test("convertMiscellaneousExpressions with Cast from Float to Bytes") {
+    val castExpression = Cast.apply(AttributeReference.apply("SchoolID", FloatType)(ExprId.apply(2)), ByteType)
+    val bigQuerySQLStatement = expressionConverter.convertMiscellaneousExpressions(castExpression, fields)
+    assert(bigQuerySQLStatement.isDefined)
+    assert(bigQuerySQLStatement.get.toString == "CAST ( SCHOOLID AS NUMERIC )")
+  }
+
+  test("convertMiscellaneousExpressions with Cast from Double to Bytes") {
+    val castExpression = Cast.apply(AttributeReference.apply("SchoolID", DoubleType)(ExprId.apply(2)), ByteType)
+    val bigQuerySQLStatement = expressionConverter.convertMiscellaneousExpressions(castExpression, fields)
+    assert(bigQuerySQLStatement.isDefined)
+    assert(bigQuerySQLStatement.get.toString == "CAST ( SCHOOLID AS NUMERIC )")
+  }
+
+  test("convertMiscellaneousExpressions with Cast from Decimal to Bytes") {
+    val castExpression = Cast.apply(AttributeReference.apply("SchoolID", DecimalType(10, 5))(ExprId.apply(2)), ByteType)
+    val bigQuerySQLStatement = expressionConverter.convertMiscellaneousExpressions(castExpression, fields)
+    assert(bigQuerySQLStatement.isDefined)
+    assert(bigQuerySQLStatement.get.toString == "CAST ( SCHOOLID AS NUMERIC )")
+  }
+
   test("convertMiscellaneousExpressions with Cast from String to Date") {
     val castExpression = Cast.apply(AttributeReference.apply("attendance_date", StringType)(ExprId.apply(2)), DateType)
     val bigQuerySQLStatement = expressionConverter.convertMiscellaneousExpressions(castExpression, fields)

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
@@ -797,6 +797,13 @@ class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
     assert(bigQuerySQLStatement.get.toString == "CAST ( SCHOOLID AS FLOAT64 )")
   }
 
+  test("convertMiscellaneousExpressions with Cast from Integer to Bytes") {
+    val castExpression = Cast.apply(AttributeReference.apply("SchoolID", IntegerType)(ExprId.apply(2)), ByteType)
+    val bigQuerySQLStatement = expressionConverter.convertMiscellaneousExpressions(castExpression, fields)
+    assert(bigQuerySQLStatement.isDefined)
+    assert(bigQuerySQLStatement.get.toString == "CAST ( SCHOOLID AS NUMERIC )")
+  }
+
   test("convertMiscellaneousExpressions with Cast from String to Date") {
     val castExpression = Cast.apply(AttributeReference.apply("attendance_date", StringType)(ExprId.apply(2)), DateType)
     val bigQuerySQLStatement = expressionConverter.convertMiscellaneousExpressions(castExpression, fields)


### PR DESCRIPTION
Changing the cast type to Numeric instead of Bytes if the expression is of Integer, Long, Float, Double and Decimal type