### PR TITLE
Supporting load from query in spark-3.1-bigquery

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+* PR #745: Supporting load from query in spark-3.1-bigquery.
+
 ## 0.26.0 - 2022-07-18
 
 * All connectors support the DIRECT write method, using the BigQuery Storage Write API,

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryTable.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/main/java/com/google/cloud/spark/bigquery/v2/BigQueryTable.java
@@ -72,7 +72,8 @@ public class BigQueryTable implements Table, SupportsRead, SupportsWrite {
   private static BigQueryTable createInternal(
       Injector injector, TableId tableId, StructType sparkProvidedSchema) {
     BigQueryClient bigQueryClient = injector.getInstance(BigQueryClient.class);
-    TableInfo tableInfo = bigQueryClient.getTable(tableId);
+    SparkBigQueryConfig config = injector.getInstance(SparkBigQueryConfig.class);
+    TableInfo tableInfo = bigQueryClient.getReadTable(config.toReadTableOptions());
     if (tableInfo == null) {
       return new BigQueryTable(injector, tableId, sparkProvidedSchema);
     }

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark31ReadFromQueryIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark31ReadFromQueryIntegrationTest.java
@@ -15,10 +15,6 @@
  */
 package com.google.cloud.spark.bigquery.integration;
 
-import org.junit.Ignore;
-
-// Not supported yet
-@Ignore
 public class Spark31ReadFromQueryIntegrationTest extends ReadFromQueryIntegrationTestBase {
 
   // tests are from the super-class


### PR DESCRIPTION
changing the read table during load from BigQueryClient.getTable to BigQueryClient.getReadTable to materialize Query to Table