### PR TITLE
Escape single quote in Contains, EndsWith and StartsWith

### DIFF
--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
@@ -18,6 +18,7 @@ package com.google.cloud.spark.bigquery.pushdowns
 
 import com.google.cloud.bigquery.connector.common.BigQueryPushdownUnsupportedException
 import com.google.cloud.spark.bigquery.pushdowns.SparkBigQueryPushdownUtil.{addAttributeStatement, blockStatement, makeStatement}
+import org.apache.commons.lang.{StringEscapeUtils, StringUtils}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.expressions.aggregate._
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -181,13 +182,13 @@ abstract class SparkExpressionConverter {
       }
 
       case Contains(child, Literal(pattern: UTF8String, StringType)) =>
-        ConstantString("CONTAINS_SUBSTR") + blockStatement(convertStatement(child, fields) + "," + s"'${pattern.toString}'")
+        ConstantString("CONTAINS_SUBSTR") + blockStatement(convertStatement(child, fields) + "," + s"'${pattern.toString.replace( "'", "\\'")}'")
 
       case EndsWith(child, Literal(pattern: UTF8String, StringType)) =>
-        ConstantString("ENDS_WITH") + blockStatement(convertStatement(child, fields) + "," + s"'${pattern.toString}'")
+        ConstantString("ENDS_WITH") + blockStatement(convertStatement(child, fields) + "," + s"'${pattern.toString.replace( "'", "\\'")}'")
 
       case StartsWith(child, Literal(pattern: UTF8String, StringType)) =>
-        ConstantString("STARTS_WITH") + blockStatement(convertStatement(child, fields) + "," + s"'${pattern.toString}'")
+        ConstantString("STARTS_WITH") + blockStatement(convertStatement(child, fields) + "," + s"'${pattern.toString.replace( "'", "\\'")}'")
 
       case _ => null
     })

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
@@ -355,24 +355,24 @@ class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
   }
 
   test("convertBooleanExpressions with Contains") {
-    val containsExpression = Contains.apply(schoolIdAttributeReference, Literal("1234"))
-    val bigQuerySQLStatement = expressionConverter.convertBooleanExpressions(containsExpression, fields)
+    val containsExpression = Contains.apply(schoolIdAttributeReference, Literal("123'4"))
+    var bigQuerySQLStatement = expressionConverter.convertBooleanExpressions(containsExpression, fields)
     assert(bigQuerySQLStatement.isDefined)
-    assert(bigQuerySQLStatement.get.toString == "CONTAINS_SUBSTR ( SUBQUERY_2.SCHOOLID , '1234' )")
+    assert(bigQuerySQLStatement.get.toString == "CONTAINS_SUBSTR ( SUBQUERY_2.SCHOOLID , '123\\'4' )")
   }
 
   test("convertBooleanExpressions with Ends With") {
-    val endsWithExpression = EndsWith.apply(schoolIdAttributeReference, Literal("1234"))
-    val bigQuerySQLStatement = expressionConverter.convertBooleanExpressions(endsWithExpression, fields)
+    val endsWithExpression = EndsWith.apply(schoolIdAttributeReference, Literal("123'4"))
+    var bigQuerySQLStatement = expressionConverter.convertBooleanExpressions(endsWithExpression, fields)
     assert(bigQuerySQLStatement.isDefined)
-    assert(bigQuerySQLStatement.get.toString == "ENDS_WITH ( SUBQUERY_2.SCHOOLID , '1234' )")
+    assert(bigQuerySQLStatement.get.toString == "ENDS_WITH ( SUBQUERY_2.SCHOOLID , '123\\'4' )")
   }
 
   test("convertBooleanExpressions with Starts With") {
-    val startsWithExpression = StartsWith.apply(schoolIdAttributeReference, Literal("1234"))
-    val bigQuerySQLStatement = expressionConverter.convertBooleanExpressions(startsWithExpression, fields)
+    val startsWithExpression = StartsWith.apply(schoolIdAttributeReference, Literal("123'4"))
+    var bigQuerySQLStatement = expressionConverter.convertBooleanExpressions(startsWithExpression, fields)
     assert(bigQuerySQLStatement.isDefined)
-    assert(bigQuerySQLStatement.get.toString == "STARTS_WITH ( SUBQUERY_2.SCHOOLID , '1234' )")
+    assert(bigQuerySQLStatement.get.toString == "STARTS_WITH ( SUBQUERY_2.SCHOOLID , '123\\'4' )")
   }
 
   test("convertBooleanExpressions with non Boolean expression") {

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverterSuite.scala
@@ -356,21 +356,21 @@ class SparkExpressionConverterSuite extends AnyFunSuite with BeforeAndAfter {
 
   test("convertBooleanExpressions with Contains") {
     val containsExpression = Contains.apply(schoolIdAttributeReference, Literal("123'4"))
-    var bigQuerySQLStatement = expressionConverter.convertBooleanExpressions(containsExpression, fields)
+    val bigQuerySQLStatement = expressionConverter.convertBooleanExpressions(containsExpression, fields)
     assert(bigQuerySQLStatement.isDefined)
     assert(bigQuerySQLStatement.get.toString == "CONTAINS_SUBSTR ( SUBQUERY_2.SCHOOLID , '123\\'4' )")
   }
 
   test("convertBooleanExpressions with Ends With") {
     val endsWithExpression = EndsWith.apply(schoolIdAttributeReference, Literal("123'4"))
-    var bigQuerySQLStatement = expressionConverter.convertBooleanExpressions(endsWithExpression, fields)
+    val bigQuerySQLStatement = expressionConverter.convertBooleanExpressions(endsWithExpression, fields)
     assert(bigQuerySQLStatement.isDefined)
     assert(bigQuerySQLStatement.get.toString == "ENDS_WITH ( SUBQUERY_2.SCHOOLID , '123\\'4' )")
   }
 
   test("convertBooleanExpressions with Starts With") {
     val startsWithExpression = StartsWith.apply(schoolIdAttributeReference, Literal("123'4"))
-    var bigQuerySQLStatement = expressionConverter.convertBooleanExpressions(startsWithExpression, fields)
+    val bigQuerySQLStatement = expressionConverter.convertBooleanExpressions(startsWithExpression, fields)
     assert(bigQuerySQLStatement.isDefined)
     assert(bigQuerySQLStatement.get.toString == "STARTS_WITH ( SUBQUERY_2.SCHOOLID , '123\\'4' )")
   }


### PR DESCRIPTION
Previously, if the Literal pattern in Contains, EndsWith and StartsWith had a single quote, the pushdown would fail

With this change, the query is generated correctly 

Shakespeare.py example: df = df.where("word_count > 0 AND word NOT LIKE '%\\'%'") gets correctly generated as 

```
SELECT * FROM ( SELECT ( SUBQUERY_2.SUBQUERY_2_COL_0 ) AS SUBQUERY_3_COL_0 , ( SUM ( SUBQUERY_2.SUBQUERY_2_COL_1 ) ) AS SUBQUERY_3_COL_1 FROM ( SELECT ( SUBQUERY_1.WORD ) AS SUBQUERY_2_COL_0 , ( SUBQUERY_1.WORD_COUNT ) AS SUBQUERY_2_COL_1 FROM ( SELECT * FROM ( SELECT * FROM `bigquery-public-data.samples.shakespeare` AS BQ_CONNECTOR_QUERY_ALIAS ) AS SUBQUERY_0 WHERE ( ( SUBQUERY_0.WORD_COUNT > 0 ) AND NOT ( CONTAINS_SUBSTR ( SUBQUERY_0.WORD , '\'' ) ) ) ) AS SUBQUERY_1 ) AS SUBQUERY_2 GROUP BY SUBQUERY_2.SUBQUERY_2_COL_0 ) AS SUBQUERY_3 ORDER BY ( SUBQUERY_3.SUBQUERY_3_COL_1 ) DESC
```

<img width="2535" alt="Screen Shot 2022-09-09 at 2 50 06 PM" src="https://user-images.githubusercontent.com/7350529/189450798-6bf56fca-29cc-48fe-83c8-7508dfe388c3.png">
