### PR TITLE
Increase number of partitions to 138 for natality table

### DIFF
--- a/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/ReadByFormatIntegrationTestBase.java
+++ b/spark-bigquery-tests/src/main/java/com/google/cloud/spark/bigquery/integration/ReadByFormatIntegrationTestBase.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 
 public class ReadByFormatIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
 
-  private static final int LARGE_TABLE_NUMBER_OF_PARTITIONS = 69;
+  private static final int LARGE_TABLE_NUMBER_OF_PARTITIONS = 138;
   protected final String dataFormat;
   protected final boolean userProvidedSchemaAllowed;
 


### PR DESCRIPTION
Not sure why but the number of partitions for this table has doubled which was causing integration test failures