### PR TITLE
Avoiding DuplicateProjectException when using the dsv1 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,15 @@
       </activation>
       <modules>
         <module>spark-bigquery-dsv1</module>
-        <module>spark-bigquery-pushdown</module>
+        <module>spark-bigquery-pushdown/spark-bigquery-pushdown-parent</module>
+        <module>spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.11</module>
+        <module>spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.12</module>
+        <module>spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.13</module>
+        <module>spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11</module>
+        <module>spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12</module>
+        <module>spark-bigquery-pushdown/spark-3.1-bigquery-pushdown_2.12</module>
+        <module>spark-bigquery-pushdown/spark-3.2-bigquery-pushdown_2.13</module>
+        <module>spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.13</module>
       </modules>
     </profile>
     <profile>


### PR DESCRIPTION
The error is 
```
[ERROR] Project 'com.google.cloud.spark:spark-bigquery-pushdown-parent:0.27.0' is duplicated in the reactor -> [Help 1]
org.apache.maven.project.DuplicateProjectException: Project 'com.google.cloud.spark:spark-bigquery-pushdown-parent:0.27.0' is duplicated in the reactor
```