### PR TITLE
Change UnaryOperationExtractor and BinaryOperationExtractor to take LogicalPlan instead of UnaryNode/BinaryNode

### DIFF
--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/BinaryOperationExtractor.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/BinaryOperationExtractor.scala
@@ -1,12 +1,13 @@
 package com.google.cloud.spark.bigquery.pushdowns
 
-import org.apache.spark.sql.catalyst.plans.logical.{BinaryNode, Join, LogicalPlan}
+import org.apache.spark.sql.catalyst.plans.logical.{Join, LogicalPlan}
 
-/** Extractor for supported binary operations. */
+/** Extractor for supported binary operations. Returns the node itself if the
+ * operation is supported **/
 object BinaryOperationExtractor {
-  def unapply(node: BinaryNode): Option[(LogicalPlan, LogicalPlan)] =
+  def unapply(node: LogicalPlan): Option[LogicalPlan] =
     Option(node match {
-      case _: Join => (node.left, node.right)
+      case _: Join => node
       case _ => null
     })
 }

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/SparkExpressionConverter.scala
@@ -97,9 +97,9 @@ abstract class SparkExpressionConverter {
             ConstantString("COALESCE") + blockStatement( ConstantString("CAST") + blockStatement(convertStatement(right, fields) + ConstantString("AS STRING") ) + "," + ConstantString("\"\"") )
         )
 
-      case b: BinaryOperator =>
+      case b@BinaryOperator(left, right) =>
         blockStatement(
-          convertStatement(b.left, fields) + b.symbol + convertStatement(b.right, fields)
+          convertStatement(left, fields) + b.symbol + convertStatement(right, fields)
         )
       case l: Literal =>
         l.dataType match {

--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/UnaryOperationExtractor.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/UnaryOperationExtractor.scala
@@ -2,14 +2,15 @@ package com.google.cloud.spark.bigquery.pushdowns
 
 import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, Filter, GlobalLimit, LocalLimit, LogicalPlan, Project, ReturnAnswer, Sort, UnaryNode, Window}
 
-/** Extractor for supported unary operations. */
+/** Extractor for supported unary operations. Returns the node itself if the
+ * operation is supported **/
 object UnaryOperationExtractor {
 
-  def unapply(node: UnaryNode): Option[LogicalPlan] =
+  def unapply(node: LogicalPlan): Option[LogicalPlan] =
     node match {
       case _: Filter | _: Project | _: GlobalLimit | _: LocalLimit |
            _: Aggregate | _: Sort | _: ReturnAnswer | _: Window =>
-        Some(node.child)
+        Some(node)
 
       case _ => None
     }

--- a/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/UnaryOperationExtractorSuite.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/test/scala/com/google/cloud/spark/bigquery/pushdowns/UnaryOperationExtractorSuite.scala
@@ -15,49 +15,49 @@ class UnaryOperationExtractorSuite extends AnyFunSuite {
     val filterExpression = EqualTo.apply(schoolIdAttributeReference, Literal(1234L))
     val filterPlan = Filter(filterExpression, childPlan)
     val plan = UnaryOperationExtractor.unapply(filterPlan)
-    assertReturnedPlan(plan)
+    assertReturnedPlan(plan, filterPlan)
   }
 
   test("Project") {
     val projectPlan = Project(Seq(), childPlan)
     val plan = UnaryOperationExtractor.unapply(projectPlan)
-    assertReturnedPlan(plan)
+    assertReturnedPlan(plan, projectPlan)
   }
 
   test("GlobalLimit") {
     val globalLimitPlan = GlobalLimit(Literal(21), childPlan)
     val plan = UnaryOperationExtractor.unapply(globalLimitPlan)
-    assertReturnedPlan(plan)
+    assertReturnedPlan(plan, globalLimitPlan)
   }
 
   test("LocalLimit") {
     val localLimitPlan = LocalLimit(Literal(21), childPlan)
     val plan = UnaryOperationExtractor.unapply(localLimitPlan)
-    assertReturnedPlan(plan)
+    assertReturnedPlan(plan, localLimitPlan)
   }
 
   test("Aggregate") {
     val aggregatePlan = Aggregate(Seq(), Seq() , childPlan)
     val plan = UnaryOperationExtractor.unapply(aggregatePlan)
-    assertReturnedPlan(plan)
+    assertReturnedPlan(plan, aggregatePlan)
   }
 
   test("Sort") {
     val sortPlan = Sort(Seq(), global = false, childPlan)
     val plan = UnaryOperationExtractor.unapply(sortPlan)
-    assertReturnedPlan(plan)
+    assertReturnedPlan(plan, sortPlan)
   }
 
   test("ReturnAnswer") {
     val returnAnswerPlan = ReturnAnswer(childPlan)
     val plan = UnaryOperationExtractor.unapply(returnAnswerPlan)
-    assertReturnedPlan(plan)
+    assertReturnedPlan(plan, returnAnswerPlan)
   }
 
   test("Window") {
     val windowPlan = Window(Seq(), Seq(), Seq(), childPlan)
     val plan = UnaryOperationExtractor.unapply(windowPlan)
-    assertReturnedPlan(plan)
+    assertReturnedPlan(plan, windowPlan)
   }
 
   test("non supported unary node") {
@@ -66,10 +66,11 @@ class UnaryOperationExtractorSuite extends AnyFunSuite {
     assert(plan.isEmpty)
   }
 
-  def assertReturnedPlan(plan: Option[LogicalPlan]): Unit = {
+  def assertReturnedPlan(plan: Option[LogicalPlan], originalPlan: LogicalPlan): Unit = {
     assert(plan.isDefined)
-    assert(plan.get.isInstanceOf[Range])
-    assert(plan.get == childPlan)
+    assert(plan.get == originalPlan)
+    assert(plan.get.children.head.isInstanceOf[Range])
+    assert(plan.get.children.head == childPlan)
   }
 
 }

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11/src/test/scala/com/google/cloud/spark/bigquery/pushdowns/BinaryOperationExtractorSuite.scala
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11/src/test/scala/com/google/cloud/spark/bigquery/pushdowns/BinaryOperationExtractorSuite.scala
@@ -30,8 +30,8 @@ class BinaryOperationExtractorSuite extends AnyFunSuite  {
     val joinPlan = Join(leftChildPlan, rightChildPlan, JoinType.apply("inner"), None)
     val plan = BinaryOperationExtractor.unapply(joinPlan)
     assert(plan.isDefined)
-    assert(plan.get._1 == leftChildPlan)
-    assert(plan.get._2 == rightChildPlan)
+    assert(plan.get.children.head == leftChildPlan)
+    assert(plan.get.children(1) == rightChildPlan)
   }
 
   test("non supported binary node") {

--- a/spark-bigquery-pushdown/spark-3.1-bigquery-pushdown_2.12/src/test/scala/com/google/cloud/spark/bigquery/pushdowns/BinaryOperationExtractorSuite.scala
+++ b/spark-bigquery-pushdown/spark-3.1-bigquery-pushdown_2.12/src/test/scala/com/google/cloud/spark/bigquery/pushdowns/BinaryOperationExtractorSuite.scala
@@ -30,8 +30,8 @@ class BinaryOperationExtractorSuite extends AnyFunSuite  {
     val joinPlan = Join(leftChildPlan, rightChildPlan, JoinType.apply("inner"), None, JoinHint.NONE)
     val plan = BinaryOperationExtractor.unapply(joinPlan)
     assert(plan.isDefined)
-    assert(plan.get._1 == leftChildPlan)
-    assert(plan.get._2 == rightChildPlan)
+    assert(plan.get.children.head == leftChildPlan)
+    assert(plan.get.children(1) == rightChildPlan)
   }
 
   test("non supported binary node") {

--- a/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.13/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark33BigQueryPushdown.scala
+++ b/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.13/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark33BigQueryPushdown.scala
@@ -19,7 +19,7 @@ package com.google.cloud.spark.bigquery.pushdowns
 class Spark33BigQueryPushdown extends BaseSparkBigQueryPushdown {
 
   override def supportsSparkVersion(sparkVersion: String): Boolean = {
-    sparkVersion.startsWith("3.3s")
+    sparkVersion.startsWith("3.3")
   }
 
   override def createSparkExpressionConverter(expressionFactory: SparkExpressionFactory, sparkPlanFactory: SparkPlanFactory): SparkExpressionConverter = {


### PR DESCRIPTION
From Spark 3.2 onwards, UnaryNode and BinaryNode have been changed to interfaces. In earlier Spark version they were classes.

So, this PR changes UnaryOperationExtractor and BinaryOperationExtractor to take LogicalPlan as input instead of UnaryNode/BinaryNode which preserves the compatibility between all the different Spark versions