### PR TITLE
Accept config for access token provider

### DIFF
--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryConfig.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryConfig.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 public class BigQueryClientFactoryConfig implements BigQueryConfig {
 
   private final Optional<String> accessTokenProviderFQCN;
+  private final Optional<String> accessTokenProviderConfig;
   private final Optional<String> credentialsKey;
   private final Optional<String> credentialsFile;
   private final Optional<String> accessToken;
@@ -43,6 +44,7 @@ public class BigQueryClientFactoryConfig implements BigQueryConfig {
 
   BigQueryClientFactoryConfig(BigQueryConfig bigQueryConfig) {
     this.accessTokenProviderFQCN = bigQueryConfig.getAccessTokenProviderFQCN();
+    this.accessTokenProviderConfig = bigQueryConfig.getAccessTokenProviderConfig();
     this.credentialsKey = bigQueryConfig.getCredentialsKey();
     this.credentialsFile = bigQueryConfig.getCredentialsFile();
     this.accessToken = bigQueryConfig.getAccessToken();
@@ -66,6 +68,11 @@ public class BigQueryClientFactoryConfig implements BigQueryConfig {
   @Override
   public Optional<String> getAccessTokenProviderFQCN() {
     return accessTokenProviderFQCN;
+  }
+
+  @Override
+  public Optional<String> getAccessTokenProviderConfig() {
+    return accessTokenProviderConfig;
   }
 
   @Override

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientModule.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientModule.java
@@ -59,6 +59,7 @@ public class BigQueryClientModule implements com.google.inject.Module {
     BigQueryProxyConfig proxyConfig = config.getBigQueryProxyConfig();
     return new BigQueryCredentialsSupplier(
         config.getAccessTokenProviderFQCN(),
+        config.getAccessTokenProviderConfig(),
         config.getAccessToken(),
         config.getCredentialsKey(),
         config.getCredentialsFile(),

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfig.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfig.java
@@ -23,6 +23,8 @@ public interface BigQueryConfig {
 
   Optional<String> getAccessTokenProviderFQCN();
 
+  Optional<String> getAccessTokenProviderConfig();
+
   Optional<String> getCredentialsKey();
 
   Optional<String> getCredentialsFile();

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryCredentialsSupplier.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryCredentialsSupplier.java
@@ -35,6 +35,7 @@ public class BigQueryCredentialsSupplier {
 
   public BigQueryCredentialsSupplier(
       Optional<String> accessTokenProviderFQCN,
+      Optional<String> accessTokenProviderConfig,
       Optional<String> accessToken,
       Optional<String> credentialsKey,
       Optional<String> credentialsFile,
@@ -43,7 +44,8 @@ public class BigQueryCredentialsSupplier {
       Optional<String> proxyPassword) {
     if (accessTokenProviderFQCN.isPresent()) {
       AccessTokenProvider accessTokenProvider =
-          createVerifiedInstance(accessTokenProviderFQCN.get(), AccessTokenProvider.class);
+              accessTokenProviderConfig.map(providerConfig -> createVerifiedInstance(accessTokenProviderFQCN.get(), AccessTokenProvider.class, providerConfig))
+                      .orElseGet(() -> createVerifiedInstance(accessTokenProviderFQCN.get(), AccessTokenProvider.class));
       this.credentials =
           new AccessTokenProviderCredentials(verifySerialization(accessTokenProvider));
     } else if (accessToken.isPresent()) {

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryCredentialsSupplier.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryCredentialsSupplier.java
@@ -44,8 +44,15 @@ public class BigQueryCredentialsSupplier {
       Optional<String> proxyPassword) {
     if (accessTokenProviderFQCN.isPresent()) {
       AccessTokenProvider accessTokenProvider =
-              accessTokenProviderConfig.map(providerConfig -> createVerifiedInstance(accessTokenProviderFQCN.get(), AccessTokenProvider.class, providerConfig))
-                      .orElseGet(() -> createVerifiedInstance(accessTokenProviderFQCN.get(), AccessTokenProvider.class));
+          accessTokenProviderConfig
+              .map(
+                  providerConfig ->
+                      createVerifiedInstance(
+                          accessTokenProviderFQCN.get(), AccessTokenProvider.class, providerConfig))
+              .orElseGet(
+                  () ->
+                      createVerifiedInstance(
+                          accessTokenProviderFQCN.get(), AccessTokenProvider.class));
       this.credentials =
           new AccessTokenProviderCredentials(verifySerialization(accessTokenProvider));
     } else if (accessToken.isPresent()) {

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
@@ -310,8 +310,10 @@ public class BigQueryUtil {
       String fullyQualifiedClassName, Class<T> requiredClass, Object... constructorArgs) {
     try {
       Class<?> clazz = Class.forName(fullyQualifiedClassName);
-      Object result = clazz.getDeclaredConstructor(
-              Arrays.stream(constructorArgs)
+      Object result =
+          clazz
+              .getDeclaredConstructor(
+                  Arrays.stream(constructorArgs)
                       .map(Object::getClass)
                       .toArray((IntFunction<Class<?>[]>) Class[]::new))
               .newInstance(constructorArgs);

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.IntFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -306,10 +307,15 @@ public class BigQueryUtil {
    * class
    */
   public static <T> T createVerifiedInstance(
-      String fullyQualifiedClassName, Class<T> requiredClass) {
+      String fullyQualifiedClassName, Class<T> requiredClass, Object... constructorArgs) {
     try {
       Class<?> clazz = Class.forName(fullyQualifiedClassName);
-      Object result = clazz.getDeclaredConstructor().newInstance();
+      Object result = clazz.getDeclaredConstructor(
+              Arrays.stream(constructorArgs)
+                      .map(Object::getClass)
+                      .toArray((IntFunction<Class<?>[]>) Class[]::new))
+              .newInstance(constructorArgs);
+
       if (!requiredClass.isInstance(result)) {
         throw new IllegalArgumentException(
             String.format(

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryTest.java
@@ -346,6 +346,11 @@ public class BigQueryClientFactoryTest {
     }
 
     @Override
+    public Optional<String> getAccessTokenProviderConfig() {
+      return Optional.empty();
+    }
+
+    @Override
     public Optional<String> getCredentialsKey() {
       return Optional.empty();
     }

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryCredentialsSupplierTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryCredentialsSupplierTest.java
@@ -71,6 +71,7 @@ public class BigQueryCredentialsSupplierTest {
     Credentials nonProxyCredentials =
         new BigQueryCredentialsSupplier(
                 Optional.empty(),
+                Optional.empty(),
                 Optional.of(ACCESS_TOKEN),
                 Optional.empty(),
                 Optional.empty(),
@@ -81,6 +82,7 @@ public class BigQueryCredentialsSupplierTest {
 
     Credentials proxyCredentials =
         new BigQueryCredentialsSupplier(
+                Optional.empty(),
                 Optional.empty(),
                 Optional.of(ACCESS_TOKEN),
                 Optional.empty(),
@@ -111,6 +113,7 @@ public class BigQueryCredentialsSupplierTest {
         new BigQueryCredentialsSupplier(
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.of(credentialsKey),
                 Optional.empty(),
                 Optional.empty(),
@@ -120,6 +123,7 @@ public class BigQueryCredentialsSupplierTest {
 
     Credentials proxyCredentials =
         new BigQueryCredentialsSupplier(
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(credentialsKey),
@@ -156,6 +160,7 @@ public class BigQueryCredentialsSupplierTest {
                 new BigQueryCredentialsSupplier(
                         Optional.empty(),
                         Optional.empty(),
+                        Optional.empty(),
                         Optional.of(credentialsKey),
                         Optional.empty(),
                         optionalProxyURI,
@@ -168,6 +173,7 @@ public class BigQueryCredentialsSupplierTest {
             IllegalArgumentException.class,
             () ->
                 new BigQueryCredentialsSupplier(
+                        Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.of(credentialsKey),
@@ -199,6 +205,7 @@ public class BigQueryCredentialsSupplierTest {
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.of(credentialsFile.getAbsolutePath()),
                 Optional.empty(),
                 Optional.empty(),
@@ -207,6 +214,7 @@ public class BigQueryCredentialsSupplierTest {
 
     Credentials proxyCredentials =
         new BigQueryCredentialsSupplier(
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
@@ -245,6 +253,7 @@ public class BigQueryCredentialsSupplierTest {
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
+                        Optional.empty(),
                         Optional.of(credentialsFile.getAbsolutePath()),
                         optionalProxyURI,
                         Optional.empty(),
@@ -256,6 +265,7 @@ public class BigQueryCredentialsSupplierTest {
             IllegalArgumentException.class,
             () ->
                 new BigQueryCredentialsSupplier(
+                        Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
@@ -298,6 +308,7 @@ public class BigQueryCredentialsSupplierTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
     Credentials credentials = supplier.getCredentials();
     assertThat(credentials).isEqualTo(GoogleCredentials.getApplicationDefault());
@@ -310,6 +321,7 @@ public class BigQueryCredentialsSupplierTest {
             UncheckedIOException.class,
             () -> {
               new BigQueryCredentialsSupplier(
+                  Optional.empty(),
                   Optional.empty(),
                   Optional.empty(),
                   Optional.empty(),
@@ -329,6 +341,7 @@ public class BigQueryCredentialsSupplierTest {
             UncheckedIOException.class,
             () -> {
               new BigQueryCredentialsSupplier(
+                  Optional.empty(),
                   Optional.empty(),
                   Optional.empty(),
                   Optional.of("bm8ga2V5IGhlcmU="), // "no key here"

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/integration/ConfiguredAccessTokenProvider.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/integration/ConfiguredAccessTokenProvider.java
@@ -5,14 +5,14 @@ import com.google.cloud.bigquery.connector.common.AccessTokenProvider;
 import java.io.IOException;
 
 public final class ConfiguredAccessTokenProvider implements AccessTokenProvider {
-    private final String config;
+  private final String config;
 
-    public ConfiguredAccessTokenProvider(String config) {
-        this.config = config;
-    }
+  public ConfiguredAccessTokenProvider(String config) {
+    this.config = config;
+  }
 
-    @Override
-    public AccessToken getAccessToken() throws IOException {
-        return new AccessToken(config, null);
-    }
+  @Override
+  public AccessToken getAccessToken() throws IOException {
+    return new AccessToken(config, null);
+  }
 }

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/integration/ConfiguredAccessTokenProvider.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/integration/ConfiguredAccessTokenProvider.java
@@ -1,0 +1,18 @@
+package com.google.cloud.bigquery.connector.common.integration;
+
+import com.google.cloud.bigquery.connector.common.AccessToken;
+import com.google.cloud.bigquery.connector.common.AccessTokenProvider;
+import java.io.IOException;
+
+public final class ConfiguredAccessTokenProvider implements AccessTokenProvider {
+    private final String config;
+
+    public ConfiguredAccessTokenProvider(String config) {
+        this.config = config;
+    }
+
+    @Override
+    public AccessToken getAccessToken() throws IOException {
+        return new AccessToken(config, null);
+    }
+}

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/integration/CustomCredentialsIntegrationTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/integration/CustomCredentialsIntegrationTest.java
@@ -22,11 +22,8 @@ import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableId;
-import com.google.cloud.bigquery.connector.common.AccessToken;
-import com.google.cloud.bigquery.connector.common.AccessTokenProvider;
 import com.google.cloud.bigquery.connector.common.AccessTokenProviderCredentials;
 import com.google.cloud.bigquery.connector.common.BigQueryCredentialsSupplier;
-import java.io.IOException;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -65,26 +62,24 @@ public class CustomCredentialsIntegrationTest {
     assertThat(accessTokenProvider.getCallCount()).isEqualTo(2);
   }
 
-
   @Test
   public void testAccessTokenProviderWithConfig() throws Exception {
     BigQueryCredentialsSupplier credentialsSupplier =
-            new BigQueryCredentialsSupplier(
-                    Optional.of(ConfiguredAccessTokenProvider.class.getCanonicalName()),
-                    Optional.of("some-config"),
-                    Optional.empty(),
-                    Optional.empty(),
-                    Optional.empty(),
-                    Optional.empty(),
-                    Optional.empty(),
-                    Optional.empty());
+        new BigQueryCredentialsSupplier(
+            Optional.of(ConfiguredAccessTokenProvider.class.getCanonicalName()),
+            Optional.of("some-config"),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty());
     Credentials credentials = credentialsSupplier.getCredentials();
     assertThat(credentials).isInstanceOf(AccessTokenProviderCredentials.class);
     ConfiguredAccessTokenProvider accessTokenProvider =
-            (ConfiguredAccessTokenProvider)
-                    ((AccessTokenProviderCredentials) credentials).getAccessTokenProvider();
+        (ConfiguredAccessTokenProvider)
+            ((AccessTokenProviderCredentials) credentials).getAccessTokenProvider();
 
     assertThat(accessTokenProvider.getAccessToken().getTokenValue()).isEqualTo("some-config");
   }
-
 }

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/integration/CustomCredentialsIntegrationTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/integration/CustomCredentialsIntegrationTest.java
@@ -22,8 +22,11 @@ import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.connector.common.AccessToken;
+import com.google.cloud.bigquery.connector.common.AccessTokenProvider;
 import com.google.cloud.bigquery.connector.common.AccessTokenProviderCredentials;
 import com.google.cloud.bigquery.connector.common.BigQueryCredentialsSupplier;
+import java.io.IOException;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -37,6 +40,7 @@ public class CustomCredentialsIntegrationTest {
     BigQueryCredentialsSupplier credentialsSupplier =
         new BigQueryCredentialsSupplier(
             Optional.of(DefaultCredentialsDelegateAccessTokenProvider.class.getCanonicalName()),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
@@ -60,4 +64,27 @@ public class CustomCredentialsIntegrationTest {
     assertThat(table).isNotNull();
     assertThat(accessTokenProvider.getCallCount()).isEqualTo(2);
   }
+
+
+  @Test
+  public void testAccessTokenProviderWithConfig() throws Exception {
+    BigQueryCredentialsSupplier credentialsSupplier =
+            new BigQueryCredentialsSupplier(
+                    Optional.of(ConfiguredAccessTokenProvider.class.getCanonicalName()),
+                    Optional.of("some-config"),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty());
+    Credentials credentials = credentialsSupplier.getCredentials();
+    assertThat(credentials).isInstanceOf(AccessTokenProviderCredentials.class);
+    ConfiguredAccessTokenProvider accessTokenProvider =
+            (ConfiguredAccessTokenProvider)
+                    ((AccessTokenProviderCredentials) credentials).getAccessTokenProvider();
+
+    assertThat(accessTokenProvider.getAccessToken().getTokenValue()).isEqualTo("some-config");
+  }
+
 }

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -283,6 +283,7 @@ public class SparkBigQueryConfig
     config.useParentProjectForMetadataOperations =
         getAnyBooleanOption(globalOptions, options, "useParentProjectForMetadataOperations", false);
     config.accessTokenProviderFQCN = getAnyOption(globalOptions, options, "gcpAccessTokenProvider");
+    config.accessTokenProviderConfig = getAnyOption(globalOptions, options, "gcpAccessTokenProviderConfig");
     config.accessToken = getAnyOption(globalOptions, options, "gcpAccessToken");
     config.credentialsKey = getAnyOption(globalOptions, options, "credentials");
     config.credentialsFile =

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -283,7 +283,8 @@ public class SparkBigQueryConfig
     config.useParentProjectForMetadataOperations =
         getAnyBooleanOption(globalOptions, options, "useParentProjectForMetadataOperations", false);
     config.accessTokenProviderFQCN = getAnyOption(globalOptions, options, "gcpAccessTokenProvider");
-    config.accessTokenProviderConfig = getAnyOption(globalOptions, options, "gcpAccessTokenProviderConfig");
+    config.accessTokenProviderConfig =
+        getAnyOption(globalOptions, options, "gcpAccessTokenProviderConfig");
     config.accessToken = getAnyOption(globalOptions, options, "gcpAccessToken");
     config.credentialsKey = getAnyOption(globalOptions, options, "credentials");
     config.credentialsFile =

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -134,6 +134,7 @@ public class SparkBigQueryConfig
   String parentProjectId;
   boolean useParentProjectForMetadataOperations;
   com.google.common.base.Optional<String> accessTokenProviderFQCN;
+  com.google.common.base.Optional<String> accessTokenProviderConfig;
   com.google.common.base.Optional<String> credentialsKey;
   com.google.common.base.Optional<String> credentialsFile;
   com.google.common.base.Optional<String> accessToken;
@@ -525,6 +526,7 @@ public class SparkBigQueryConfig
 
     return new BigQueryCredentialsSupplier(
             accessTokenProviderFQCN.toJavaUtil(),
+            accessTokenProviderConfig.toJavaUtil(),
             accessToken.toJavaUtil(),
             credentialsKey.toJavaUtil(),
             credentialsFile.toJavaUtil(),
@@ -568,6 +570,11 @@ public class SparkBigQueryConfig
   @Override
   public Optional<String> getAccessTokenProviderFQCN() {
     return accessTokenProviderFQCN.toJavaUtil();
+  }
+
+  @Override
+  public Optional<String> getAccessTokenProviderConfig() {
+    return accessTokenProviderConfig.toJavaUtil();
   }
 
   @Override


### PR DESCRIPTION
I'd like to use a custom AccessTokenProvider but my use-case requires a little bit of configuration that differs for each BQ table that I read. As such, I'd like to be able to pass configuration into the provider via the Spark dataset reader API, e.g. 

```
sparkSession
    .read()
    .format("bigquery")
    .option("gcpAccessTokenProvider", "com.my.token.Provider")
    .option("gcpAccessTokenProviderConfig", "datasetId=foo&tableId=bar")
    .load("foo.bar")
```