### PR TITLE
Rename BigQueryDirectDataWriterHelper.commit() to finalizeStream()

### DIFF
--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryDirectDataWriterHelper.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryDirectDataWriterHelper.java
@@ -230,14 +230,14 @@ public class BigQueryDirectDataWriterHelper {
   /**
    * Appends any data that remains in the protoRows, waits for 500 milliseconds, and finalizes the
    * write-stream. This also closes the internal StreamWriter, so that the helper instance is not
-   * usable after calling <code>commit()</code>.
+   * usable after calling <code>finalizeStream()</code>.
    *
    * @return The finalized row-count of the write-stream.
    * @throws IOException If the row-count returned by the FinalizeWriteStreamResponse does not match
    *     the expected offset (which is equal to the number of rows appended thus far).
    * @see this#writeStreamRowCount
    */
-  public long commit() throws IOException {
+  public long finalizeStream() throws IOException {
     if (this.protoRows.getSerializedRowsCount() != 0) {
       sendAppendRowsRequest();
     }

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataWriterContext.java
@@ -88,9 +88,9 @@ public class BigQueryDirectDataWriterContext implements DataWriterContext<Intern
 
   @Override
   public WriterCommitMessageContext commit() throws IOException {
-    logger.debug("Data Writer {} commit()", partitionId);
+    logger.debug("Data Writer {} finalizeStream()", partitionId);
 
-    long rowCount = writerHelper.commit();
+    long rowCount = writerHelper.finalizeStream();
     String writeStreamName = writerHelper.getWriteStreamName();
 
     logger.debug(


### PR DESCRIPTION
This is to reflect more accurately what the function does. Note: We can't use just "finalize()" for the name as it's a reserved Java keyword.