### PR TITLE
Changes to add a ProjectNode on top of existing ProjectNode

### DIFF
--- a/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/BigQuerySQLQuery.scala
+++ b/spark-bigquery-pushdown/pushdown_common_src/main/scala/com/google/cloud/spark/bigquery/pushdowns/BigQuerySQLQuery.scala
@@ -129,8 +129,9 @@ abstract class BigQuerySQLQuery(
    * @return SQL statement for this query.
    */
   def getStatement(useAlias: Boolean = false): BigQuerySQLStatement = {
+    val selectedColumns = if(columns.isEmpty || columns.get.isEmpty) ConstantString("*").toStatement else columns.get
     val statement =
-      ConstantString("SELECT") + columns.getOrElse(ConstantString("*").toStatement) + "FROM" +
+      ConstantString("SELECT") + selectedColumns + "FROM" +
         sourceStatement + suffixStatement
 
     if (useAlias) {


### PR DESCRIPTION
Changes to add a ProjectNode on top of existing ProjectNode when show() is called and if there is no limit applied on the query during pushdown.