### PR TITLE
Adding gcloud CLI to nightly image

### DIFF
--- a/cloudbuild/Dockerfile
+++ b/cloudbuild/Dockerfile
@@ -1,3 +1,10 @@
 # This Dockerfile creates an image for running presubmit tests.
 FROM openjdk:8
 
+RUN \
+  echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
+  tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+  apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
+  apt-get update -y && \
+  apt-get install google-cloud-cli -y


### PR DESCRIPTION
Taken from https://cloud.google.com/sdk/docs/install (the "Docker Tip")