### PR TITLE
[EXE-1239] AIQ building + downgrade libs + fix Spark version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1240,6 +1240,7 @@ option("key", "value") > spark.conf > hadoop configuration
 only care about building `spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12`.
 
 # Prereqs
+???
 
 # Version
 Bump `revision` in `spark-bigquery-parent/pom.xml` to the next `-aiq#` version

--- a/README.md
+++ b/README.md
@@ -1234,3 +1234,47 @@ You can set the following in the hadoop configuration as well.
 If the same parameter is set at multiple places the order of priority is as follows:
 
 option("key", "value") > spark.conf > hadoop configuration
+
+## AIQ DEV
+# Prereqs
+
+# Version
+Bump to the next `-aiq#` version
+```
+mvnw versions:set -DgenerateBackupPoms=false
+```
+
+# Build
+This places artifacts in `~/.m2/repository/org/apache/hadoop/`
+```
+mvn clean install -DskipTests
+```
+
+# Tests
+Full tests are expensive to run and flaky
+```
+mvn verify -DtestsThreadCount=1
+```
+
+So you can run individual tests on the projects affected
+```
+cd hadoop-tools/hadoop-aws
+mvn verify -DtestsThreadCount=1
+```
+
+# Deploy
+To deploy to S3 at our bucket `s3://s3.amazonaws.com/aiq-artifacts`
+```
+mvn deploy -DskipTests
+```
+
+Based off of https://nuvalence.io/blog/using-a-s3-bucket-as-a-maven-repository
+Note we put the user/password in ~/.m2/settings.xml so it's not checked in
+
+As of 03/2022 these are places that reference Hadoop which you'll likely need to
+change when building new hadoop jars
+
+https://github.com/ActionIQ/aiq/blob/e27ff5acadcd94a9d4fe8197962e38f6ae2358a2/deploy/ansible/group_vars/all/globals.yaml#L61
+https://github.com/ActionIQ/flame/blob/2.4/pom.xml#L2908
+https://github.com/ActionIQ-OSS/aws-glue-data-catalog-client-for-apache-hive-metastore/blob/4f81546817c3340a50151de73708ae764ed21385/pom.xml#L31
+https://github.com/ActionIQ-OSS/hive/blob/release-1.2.1-spark2/pom.xml#L137

--- a/README.md
+++ b/README.md
@@ -1236,11 +1236,9 @@ If the same parameter is set at multiple places the order of priority is as foll
 option("key", "value") > spark.conf > hadoop configuration
 
 ## AIQ DEV
-`spark-bigquery-parent` is the main parent project, but we really
-only care about building `spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12`.
 
 # Prereqs
-???
+The user/password for S3 should come from ~/.m2/settings.xml, which was created by the AIQ laptop script.
 
 # Version
 Bump `revision` in `spark-bigquery-parent/pom.xml` to the next `-aiq#` version
@@ -1264,5 +1262,3 @@ To deploy to S3 at our bucket `s3://s3.amazonaws.com/aiq-artifacts`
 ```
 ./mvnw deploy -DskipTests
 ```
-
-The user/password for S3 should come from ~/.m2/settings.xml, which was created by the AIQ laptop script.

--- a/README.md
+++ b/README.md
@@ -1241,13 +1241,13 @@ option("key", "value") > spark.conf > hadoop configuration
 # Version
 Bump to the next `-aiq#` version
 ```
-mvnw versions:set -DgenerateBackupPoms=false
+./mvnw versions:set -DgenerateBackupPoms=false
 ```
 
 # Build
 This places artifacts in `~/.m2/repository/org/apache/hadoop/`
 ```
-mvn clean install -DskipTests
+./mvn clean install -DskipTests
 ```
 
 # Tests
@@ -1270,11 +1270,3 @@ mvn deploy -DskipTests
 
 Based off of https://nuvalence.io/blog/using-a-s3-bucket-as-a-maven-repository
 Note we put the user/password in ~/.m2/settings.xml so it's not checked in
-
-As of 03/2022 these are places that reference Hadoop which you'll likely need to
-change when building new hadoop jars
-
-https://github.com/ActionIQ/aiq/blob/e27ff5acadcd94a9d4fe8197962e38f6ae2358a2/deploy/ansible/group_vars/all/globals.yaml#L61
-https://github.com/ActionIQ/flame/blob/2.4/pom.xml#L2908
-https://github.com/ActionIQ-OSS/aws-glue-data-catalog-client-for-apache-hive-metastore/blob/4f81546817c3340a50151de73708ae764ed21385/pom.xml#L31
-https://github.com/ActionIQ-OSS/hive/blob/release-1.2.1-spark2/pom.xml#L137

--- a/README.md
+++ b/README.md
@@ -1236,37 +1236,31 @@ If the same parameter is set at multiple places the order of priority is as foll
 option("key", "value") > spark.conf > hadoop configuration
 
 ## AIQ DEV
+`spark-bigquery-parent` is the main parent project, but we really
+only care about building `spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12`.
+
 # Prereqs
 
 # Version
-Bump to the next `-aiq#` version
-```
-./mvnw versions:set -DgenerateBackupPoms=false
-```
+Bump `revision` in `spark-bigquery-parent` to the next `-aiq#` version
 
 # Build
-This places artifacts in `~/.m2/repository/org/apache/hadoop/`
+This places artifacts in `~/.m2/repository/`
 ```
-./mvn clean install -DskipTests
+./mvnw clean install -DskipTests
 ```
 
 # Tests
-Full tests are expensive to run and flaky
+Full tests are flaky, some require configuring GCP settings, so just make sure projects
+we care about are passing.
 ```
-mvn verify -DtestsThreadCount=1
-```
-
-So you can run individual tests on the projects affected
-```
-cd hadoop-tools/hadoop-aws
-mvn verify -DtestsThreadCount=1
+./mvnw verify -DtestsThreadCount=1
 ```
 
 # Deploy
 To deploy to S3 at our bucket `s3://s3.amazonaws.com/aiq-artifacts`
 ```
-mvn deploy -DskipTests
+./mvnw deploy -DskipTests
 ```
 
-Based off of https://nuvalence.io/blog/using-a-s3-bucket-as-a-maven-repository
-Note we put the user/password in ~/.m2/settings.xml so it's not checked in
+Note the user/password for S3 should come from ~/.m2/settings.xml, which was setup by the AIQ laptop script.

--- a/README.md
+++ b/README.md
@@ -1242,7 +1242,7 @@ only care about building `spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.
 # Prereqs
 
 # Version
-Bump `revision` in `spark-bigquery-parent` to the next `-aiq#` version
+Bump `revision` in `spark-bigquery-parent/pom.xml` to the next `-aiq#` version
 
 # Build
 This places artifacts in `~/.m2/repository/`
@@ -1251,10 +1251,11 @@ This places artifacts in `~/.m2/repository/`
 ```
 
 # Tests
-Full tests are flaky, some require configuring GCP settings, so just make sure projects
-we care about are passing.
+Full tests dont work, they require configuring GCP settings, so just make sure projects
+we care about are passing. Or if you are making a change, confirm the same tests fail with
+and without the change.
 ```
-./mvnw verify -DtestsThreadCount=1
+./mvnw test -fn
 ```
 
 # Deploy
@@ -1263,4 +1264,4 @@ To deploy to S3 at our bucket `s3://s3.amazonaws.com/aiq-artifacts`
 ./mvnw deploy -DskipTests
 ```
 
-Note the user/password for S3 should come from ~/.m2/settings.xml, which was setup by the AIQ laptop script.
+The user/password for S3 should come from ~/.m2/settings.xml, which was created by the AIQ laptop script.

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
@@ -302,7 +302,7 @@ public class BigQueryClient {
     Iterable<Table> allTables = bigQuery.listTables(datasetId).iterateAll();
     return StreamSupport.stream(allTables.spliterator(), false)
         .filter(table -> allowedTypes.contains(table.getDefinition().getType()))
-        .collect(ImmutableList.toImmutableList());
+        .collect(Collectors.toList());
   }
 
   TableId createDestinationTable(

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfigurationUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfigurationUtil.java
@@ -36,13 +36,26 @@ public class BigQueryConfigurationUtil {
 
   private BigQueryConfigurationUtil() {}
 
+  public static <T> java.util.Optional<T> googOptionToJava(
+      com.google.common.base.Optional<T> googOpt) {
+    return java.util.Optional.ofNullable(googOpt.orNull());
+  }
+
+  public static <T> com.google.common.base.Optional<T> javaOptionToGoog(
+      java.util.Optional<T> javaOpt) {
+    if (javaOpt == null) {
+      return null;
+    } else {
+      return com.google.common.base.Optional.fromNullable(javaOpt.orElse((T) null));
+    }
+  }
+
   public static com.google.common.base.Supplier<String> defaultBilledProject() {
     return () -> BigQueryOptions.getDefaultInstance().getProjectId();
   }
 
   public static String getRequiredOption(Map<String, String> options, String name) {
-    return getOption(options, name, DEFAULT_FALLBACK)
-        .toJavaUtil()
+    return googOptionToJava(getOption(options, name, DEFAULT_FALLBACK))
         .orElseThrow(() -> new IllegalArgumentException(format("Option %s required.", name)));
   }
 
@@ -58,10 +71,10 @@ public class BigQueryConfigurationUtil {
 
   public static com.google.common.base.Optional<String> getOption(
       Map<String, String> options, String name, Supplier<Optional<String>> fallback) {
-    return fromJavaUtil(
+    return javaOptionToGoog(
         firstPresent(
             java.util.Optional.ofNullable(options.get(name.toLowerCase())),
-            fallback.get().toJavaUtil()));
+            googOptionToJava(fallback.get())));
   }
 
   public static com.google.common.base.Optional<String> getOptionFromMultipleParams(
@@ -107,7 +120,7 @@ public class BigQueryConfigurationUtil {
   }
 
   public static com.google.common.base.Optional fromJavaUtil(java.util.Optional o) {
-    return com.google.common.base.Optional.fromJavaUtil(o);
+    return javaOptionToGoog(o);
   }
 
   /** TableId that does not include partition decorator */
@@ -122,8 +135,8 @@ public class BigQueryConfigurationUtil {
     Optional<String> projectParam = getOption(options, "project").or(fallbackProject);
     return parseTableId(
         tableParam,
-        datasetParam.toJavaUtil(),
-        projectParam.toJavaUtil(), /* datePartition */
+        googOptionToJava(datasetParam),
+        googOptionToJava(projectParam), /* datePartition */
         java.util.Optional.empty());
   }
 
@@ -132,7 +145,7 @@ public class BigQueryConfigurationUtil {
       java.util.Optional<String> fallbackProject,
       java.util.Optional<String> fallbackDataset) {
     return parseSimpleTableId(
-        options, Optional.fromJavaUtil(fallbackProject), Optional.fromJavaUtil(fallbackDataset));
+        options, javaOptionToGoog(fallbackProject), javaOptionToGoog(fallbackDataset));
   }
 
   public static TableId parseSimpleTableId(

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,21 @@
         <version>1.3.3</version>
       </extension>
     </extensions>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 
   <distributionManagement>
@@ -78,22 +93,6 @@
       <url>scpexe://people.apache.org/www/hadoop.apache.org/docs/r${project.version}</url>
     </site>
   </distributionManagement>
-
-  <plugins>
-    <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-source-plugin</artifactId>
-      <version>3.2.0</version>
-      <executions>
-        <execution>
-          <id>attach-sources</id>
-          <goals>
-            <goal>jar</goal>
-          </goals>
-        </execution>
-      </executions>
-    </plugin>
-  </plugins>
 
   <profiles>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -54,46 +54,6 @@
     <module>spark-bigquery-python-lib</module>
   </modules>
 
-  <build>
-    <extensions>
-      <extension>
-        <groupId>com.github.seahen</groupId>
-        <artifactId>maven-s3-wagon</artifactId>
-        <version>1.3.3</version>
-      </extension>
-    </extensions>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.0</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
-
-  <distributionManagement>
-    <repository>
-      <id>aws-releases</id>
-      <url>s3://aiq-artifacts/releases</url>
-    </repository>
-    <snapshotRepository>
-      <id>aws-snapshots</id>
-      <url>s3://aiq-artifacts/snapshots</url>
-    </snapshotRepository>
-    <site>
-      <id>apache.website</id>
-      <url>scpexe://people.apache.org/www/hadoop.apache.org/docs/r${project.version}</url>
-    </site>
-  </distributionManagement>
-
   <profiles>
     <profile>
       <id>all</id>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <profile>
       <id>all</id>
       <activation>
-        <activeByDefault>false</activeByDefault>
+        <activeByDefault>true</activeByDefault>
       </activation>
       <modules>
         <module>spark-bigquery-dsv1</module>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <profile>
       <id>all</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <activeByDefault>false</activeByDefault>
       </activation>
       <modules>
         <module>spark-bigquery-dsv1</module>
@@ -165,7 +165,7 @@
     <profile>
       <id>dsv2_2.4</id>
       <activation>
-        <activeByDefault>false</activeByDefault>
+        <activeByDefault>true</activeByDefault>
       </activation>
       <modules>
         <module>spark-bigquery-dsv2/spark-bigquery-dsv2-common</module>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,47 @@
     <module>spark-bigquery-python-lib</module>
   </modules>
 
+  <build>
+    <extensions>
+      <extension>
+        <groupId>com.github.seahen</groupId>
+        <artifactId>maven-s3-wagon</artifactId>
+        <version>1.3.3</version>
+      </extension>
+    </extensions>
+  </build>
+
+  <distributionManagement>
+    <repository>
+      <id>aws-releases</id>
+      <url>s3://aiq-artifacts/releases</url>
+    </repository>
+    <snapshotRepository>
+      <id>aws-snapshots</id>
+      <url>s3://aiq-artifacts/snapshots</url>
+    </snapshotRepository>
+    <site>
+      <id>apache.website</id>
+      <url>scpexe://people.apache.org/www/hadoop.apache.org/docs/r${project.version}</url>
+    </site>
+  </distributionManagement>
+
+  <plugins>
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-source-plugin</artifactId>
+      <version>3.2.0</version>
+      <executions>
+        <execution>
+          <id>attach-sources</id>
+          <goals>
+            <goal>jar</goal>
+          </goals>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+
   <profiles>
     <profile>
       <id>all</id>

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/ReadRowsResponseToInternalRowIteratorConverter.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/ReadRowsResponseToInternalRowIteratorConverter.java
@@ -15,7 +15,8 @@
  */
 package com.google.cloud.spark.bigquery;
 
-import static com.google.common.base.Optional.fromJavaUtil;
+import static com.google.cloud.bigquery.connector.common.BigQueryConfigurationUtil.javaOptionToGoog;
+import static com.google.cloud.bigquery.connector.common.BigQueryConfigurationUtil.googOptionToJava;
 
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.connector.common.BigQueryStorageReadRowsTracer;
@@ -34,6 +35,7 @@ public interface ReadRowsResponseToInternalRowIteratorConverter {
       final com.google.cloud.bigquery.Schema bqSchema,
       final List<String> columnsInOrder,
       final String rawAvroSchema,
+<<<<<<< HEAD
       final Optional<StructType> userProvidedSchema,
       final Optional<BigQueryStorageReadRowsTracer> bigQueryStorageReadRowsTracer) {
     return new Avro(
@@ -42,11 +44,16 @@ public interface ReadRowsResponseToInternalRowIteratorConverter {
         rawAvroSchema,
         fromJavaUtil(userProvidedSchema),
         fromJavaUtil(bigQueryStorageReadRowsTracer));
+=======
+      final Optional<StructType> userProvidedSchema) {
+    return new Avro(bqSchema, columnsInOrder, rawAvroSchema, javaOptionToGoog(userProvidedSchema));
+>>>>>>> 6fa7b4d (Fix)
   }
 
   static ReadRowsResponseToInternalRowIteratorConverter arrow(
       final List<String> columnsInOrder,
       final ByteString arrowSchema,
+<<<<<<< HEAD
       final Optional<StructType> userProvidedSchema,
       final Optional<BigQueryStorageReadRowsTracer> bigQueryStorageReadRowsTracer) {
     return new Arrow(
@@ -54,6 +61,10 @@ public interface ReadRowsResponseToInternalRowIteratorConverter {
         arrowSchema,
         fromJavaUtil(userProvidedSchema),
         fromJavaUtil(bigQueryStorageReadRowsTracer));
+=======
+      final Optional<StructType> userProvidedSchema) {
+    return new Arrow(columnsInOrder, arrowSchema, javaOptionToGoog(userProvidedSchema));
+>>>>>>> 6fa7b4d (Fix)
   }
 
   Iterator<InternalRow> convert(ReadRowsResponse response);
@@ -90,6 +101,7 @@ public interface ReadRowsResponseToInternalRowIteratorConverter {
           columnsInOrder,
           new org.apache.avro.Schema.Parser().parse(rawAvroSchema),
           response.getAvroRows().getSerializedBinaryRows(),
+<<<<<<< HEAD
           userProvidedSchema.toJavaUtil(),
           bigQueryStorageReadRowsTracer.toJavaUtil());
     }
@@ -97,6 +109,9 @@ public interface ReadRowsResponseToInternalRowIteratorConverter {
     @Override
     public int getBatchSizeInBytes(ReadRowsResponse response) {
       return response.getAvroRows().getSerializedBinaryRows().size();
+=======
+          googOptionToJava(userProvidedSchema));
+>>>>>>> 6fa7b4d (Fix)
     }
   }
 
@@ -126,6 +141,7 @@ public interface ReadRowsResponseToInternalRowIteratorConverter {
           columnsInOrder,
           arrowSchema,
           response.getArrowRecordBatch().getSerializedRecordBatch(),
+<<<<<<< HEAD
           userProvidedSchema.toJavaUtil(),
           bigQueryStorageReadRowsTracer.toJavaUtil());
     }
@@ -133,6 +149,9 @@ public interface ReadRowsResponseToInternalRowIteratorConverter {
     @Override
     public int getBatchSizeInBytes(ReadRowsResponse response) {
       return response.getArrowRecordBatch().getSerializedRecordBatch().size();
+=======
+          googOptionToJava(userProvidedSchema));
+>>>>>>> 6fa7b4d (Fix)
     }
   }
 }

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -18,12 +18,13 @@ package com.google.cloud.spark.bigquery;
 import static com.google.cloud.bigquery.connector.common.BigQueryConfigurationUtil.DEFAULT_FALLBACK;
 import static com.google.cloud.bigquery.connector.common.BigQueryConfigurationUtil.defaultBilledProject;
 import static com.google.cloud.bigquery.connector.common.BigQueryConfigurationUtil.empty;
-import static com.google.cloud.bigquery.connector.common.BigQueryConfigurationUtil.fromJavaUtil;
 import static com.google.cloud.bigquery.connector.common.BigQueryConfigurationUtil.getAnyBooleanOption;
 import static com.google.cloud.bigquery.connector.common.BigQueryConfigurationUtil.getAnyOption;
 import static com.google.cloud.bigquery.connector.common.BigQueryConfigurationUtil.getOption;
 import static com.google.cloud.bigquery.connector.common.BigQueryConfigurationUtil.getOptionFromMultipleParams;
 import static com.google.cloud.bigquery.connector.common.BigQueryConfigurationUtil.getRequiredOption;
+import static com.google.cloud.bigquery.connector.common.BigQueryConfigurationUtil.javaOptionToGoog;
+import static com.google.cloud.bigquery.connector.common.BigQueryConfigurationUtil.googOptionToJava;
 import static com.google.cloud.bigquery.connector.common.BigQueryUtil.firstPresent;
 import static com.google.cloud.bigquery.connector.common.BigQueryUtil.parseTableId;
 import static com.google.cloud.spark.bigquery.SparkBigQueryUtil.scalaMapToJavaMap;
@@ -241,19 +242,20 @@ public class SparkBigQueryConfig
         materializationConfiguration.getMaterializationExpirationTimeInMinutes();
     // get the table details
     com.google.common.base.Optional<String> fallbackDataset = config.materializationDataset;
-    Optional<String> fallbackProject =
+    Optional<String> fallbackProject = googOptionToJava(
         com.google.common.base.Optional.fromNullable(
-                hadoopConfiguration.get(GCS_CONFIG_PROJECT_ID_PROPERTY))
-            .toJavaUtil();
-    Optional<String> tableParam =
+            hadoopConfiguration.get(GCS_CONFIG_PROJECT_ID_PROPERTY))
+    );
+    Optional<String> tableParam = googOptionToJava(
         getOptionFromMultipleParams(options, ImmutableList.of("table", "path"), DEFAULT_FALLBACK)
-            .toJavaUtil();
-    Optional<String> datasetParam = getOption(options, "dataset").or(fallbackDataset).toJavaUtil();
+    );
+    Optional<String> datasetParam = googOptionToJava(
+        getOption(options, "dataset").or(fallbackDataset));
     Optional<String> projectParam =
-        firstPresent(getOption(options, "project").toJavaUtil(), fallbackProject);
+        firstPresent(googOptionToJava(getOption(options, "project")), fallbackProject);
     config.partitionType =
         getOption(options, "partitionType").transform(TimePartitioning.Type::valueOf);
-    Optional<String> datePartitionParam = getOption(options, DATE_PARTITION_PARAM).toJavaUtil();
+    Optional<String> datePartitionParam = googOptionToJava(getOption(options, DATE_PARTITION_PARAM));
     datePartitionParam.ifPresent(
         date -> validateDateFormat(date, config.getPartitionTypeOrDefault(), DATE_PARTITION_PARAM));
     // checking for query
@@ -286,15 +288,17 @@ public class SparkBigQueryConfig
     config.accessToken = getAnyOption(globalOptions, options, "gcpAccessToken");
     config.credentialsKey = getAnyOption(globalOptions, options, "credentials");
     config.credentialsFile =
-        fromJavaUtil(
+        javaOptionToGoog(
             firstPresent(
-                getAnyOption(globalOptions, options, "credentialsFile").toJavaUtil(),
-                com.google.common.base.Optional.fromNullable(
-                        hadoopConfiguration.get(GCS_CONFIG_CREDENTIALS_FILE_PROPERTY))
-                    .toJavaUtil()));
+                googOptionToJava(getAnyOption(globalOptions, options, "credentialsFile")),
+                googOptionToJava(com.google.common.base.Optional.fromNullable(
+                  hadoopConfiguration.get(GCS_CONFIG_CREDENTIALS_FILE_PROPERTY)
+                ))
+            )
+        );
     config.accessToken = getAnyOption(globalOptions, options, "gcpAccessToken");
     config.filter = getOption(options, "filter");
-    config.schema = fromJavaUtil(schema);
+    config.schema = javaOptionToGoog(schema);
     config.maxParallelism =
         getOptionFromMultipleParams(
                 options, ImmutableList.of("maxParallelism", "parallelism"), DEFAULT_FALLBACK)
@@ -529,10 +533,16 @@ public class SparkBigQueryConfig
   public Credentials createCredentials() {
 
     return new BigQueryCredentialsSupplier(
+<<<<<<< HEAD
             accessTokenProviderFQCN.toJavaUtil(),
             accessToken.toJavaUtil(),
             credentialsKey.toJavaUtil(),
             credentialsFile.toJavaUtil(),
+=======
+            googOptionToJava(accessToken),
+            googOptionToJava(credentialsKey),
+            googOptionToJava(credentialsFile),
+>>>>>>> 6fa7b4d (Fix)
             sparkBigQueryProxyAndHttpConfig.getProxyUri(),
             sparkBigQueryProxyAndHttpConfig.getProxyUsername(),
             sparkBigQueryProxyAndHttpConfig.getProxyPassword())
@@ -557,7 +567,7 @@ public class SparkBigQueryConfig
   }
 
   public Optional<String> getQuery() {
-    return query.toJavaUtil();
+    return googOptionToJava(query);
   }
 
   @Override
@@ -577,25 +587,25 @@ public class SparkBigQueryConfig
 
   @Override
   public Optional<String> getCredentialsKey() {
-    return credentialsKey.toJavaUtil();
+    return googOptionToJava(credentialsKey);
   }
 
   @Override
   public Optional<String> getCredentialsFile() {
-    return credentialsFile.toJavaUtil();
+    return googOptionToJava(credentialsFile);
   }
 
   @Override
   public Optional<String> getAccessToken() {
-    return accessToken.toJavaUtil();
+    return googOptionToJava(accessToken);
   }
 
   public Optional<String> getFilter() {
-    return filter.toJavaUtil();
+    return googOptionToJava(filter);
   }
 
   public Optional<StructType> getSchema() {
-    return schema.toJavaUtil();
+    return googOptionToJava(schema);
   }
 
   public OptionalInt getMaxParallelism() {
@@ -613,15 +623,15 @@ public class SparkBigQueryConfig
   }
 
   public Optional<String> getTemporaryGcsBucket() {
-    return temporaryGcsBucket.toJavaUtil();
+    return googOptionToJava(temporaryGcsBucket);
   }
 
   public Optional<String> getPersistentGcsBucket() {
-    return persistentGcsBucket.toJavaUtil();
+    return googOptionToJava(persistentGcsBucket);
   }
 
   public Optional<String> getPersistentGcsPath() {
-    return persistentGcsPath.toJavaUtil();
+    return googOptionToJava(persistentGcsPath);
   }
 
   public IntermediateFormat getIntermediateFormat() {
@@ -655,16 +665,16 @@ public class SparkBigQueryConfig
 
   @Override
   public Optional<String> getMaterializationProject() {
-    return materializationProject.toJavaUtil();
+    return googOptionToJava(materializationProject);
   }
 
   @Override
   public Optional<String> getMaterializationDataset() {
-    return materializationDataset.toJavaUtil();
+    return googOptionToJava(materializationDataset);
   }
 
   public Optional<String> getPartitionField() {
-    return partitionField.toJavaUtil();
+    return googOptionToJava(partitionField);
   }
 
   public OptionalLong getPartitionExpirationMs() {
@@ -674,11 +684,11 @@ public class SparkBigQueryConfig
   }
 
   public Optional<Boolean> getPartitionRequireFilter() {
-    return partitionRequireFilter.toJavaUtil();
+    return googOptionToJava(partitionRequireFilter);
   }
 
   public Optional<TimePartitioning.Type> getPartitionType() {
-    return partitionType.toJavaUtil();
+    return googOptionToJava(partitionType);
   }
 
   public TimePartitioning.Type getPartitionTypeOrDefault() {
@@ -686,11 +696,11 @@ public class SparkBigQueryConfig
   }
 
   public Optional<ImmutableList<String>> getClusteredFields() {
-    return clusteredFields.transform(fields -> ImmutableList.copyOf(fields)).toJavaUtil();
+    return googOptionToJava(clusteredFields.transform(fields -> ImmutableList.copyOf(fields)));
   }
 
   public Optional<JobInfo.CreateDisposition> getCreateDisposition() {
-    return createDisposition.toJavaUtil();
+    return googOptionToJava(createDisposition);
   }
 
   public boolean isOptimizedEmptyProjection() {
@@ -740,6 +750,7 @@ public class SparkBigQueryConfig
   }
 
   @Override
+<<<<<<< HEAD
   public Optional<String> getBigQueryStorageGrpcEndpoint() {
     return bigQueryStorageGrpcEndpoint.toJavaUtil();
   }
@@ -747,6 +758,10 @@ public class SparkBigQueryConfig
   @Override
   public Optional<String> getBigQueryHttpEndpoint() {
     return bigQueryHttpEndpoint.toJavaUtil();
+=======
+  public Optional<String> getEndpoint() {
+    return googOptionToJava(storageReadEndpoint);
+>>>>>>> 6fa7b4d (Fix)
   }
 
   @Override
@@ -785,7 +800,7 @@ public class SparkBigQueryConfig
   }
 
   public Optional<String> getTraceId() {
-    return traceId.toJavaUtil();
+    return googOptionToJava(traceId);
   }
 
   @Override
@@ -800,24 +815,29 @@ public class SparkBigQueryConfig
   public ReadSessionCreatorConfig toReadSessionCreatorConfig() {
     return new ReadSessionCreatorConfigBuilder()
         .setViewsEnabled(viewsEnabled)
-        .setMaterializationProject(materializationProject.toJavaUtil())
-        .setMaterializationDataset(materializationDataset.toJavaUtil())
+        .setMaterializationProject(googOptionToJava(materializationProject))
+        .setMaterializationDataset(googOptionToJava(materializationDataset))
         .setMaterializationExpirationTimeInMinutes(materializationExpirationTimeInMinutes)
         .setReadDataFormat(readDataFormat)
         .setMaxReadRowsRetries(maxReadRowsRetries)
         .setViewEnabledParamName(VIEWS_ENABLED_OPTION)
         .setDefaultParallelism(defaultParallelism)
         .setMaxParallelism(getMaxParallelism())
+<<<<<<< HEAD
         .setPreferredMinParallelism(getPreferredMinParallelism())
         .setRequestEncodedBase(encodedCreateReadSessionRequest.toJavaUtil())
         .setBigQueryStorageGrpcEndpoint(bigQueryStorageGrpcEndpoint.toJavaUtil())
         .setBigQueryHttpEndpoint(bigQueryHttpEndpoint.toJavaUtil())
+=======
+        .setRequestEncodedBase(googOptionToJava(encodedCreateReadSessionRequest))
+        .setEndpoint(googOptionToJava(storageReadEndpoint))
+>>>>>>> 6fa7b4d (Fix)
         .setBackgroundParsingThreads(numBackgroundThreadsPerStream)
         .setPushAllFilters(pushAllFilters)
         .setPrebufferReadRowsResponses(numPrebufferReadRowsResponses)
         .setStreamsPerPartition(numStreamsPerPartition)
         .setArrowCompressionCodec(arrowCompressionCodec)
-        .setTraceId(traceId.toJavaUtil())
+        .setTraceId(googOptionToJava(traceId))
         .build();
   }
 

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryProxyAndHttpConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryProxyAndHttpConfig.java
@@ -16,7 +16,8 @@
 package com.google.cloud.spark.bigquery;
 
 import static com.google.cloud.bigquery.connector.common.BigQueryUtil.firstPresent;
-import static com.google.common.base.Optional.fromJavaUtil;
+import static com.google.cloud.bigquery.connector.common.BigQueryConfigurationUtil.javaOptionToGoog;
+import static com.google.cloud.bigquery.connector.common.BigQueryConfigurationUtil.googOptionToJava;
 import static com.google.common.base.Optional.fromNullable;
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -154,10 +155,10 @@ public class SparkBigQueryProxyAndHttpConfig implements BigQueryProxyConfig, Ser
       Configuration hadoopConfiguration,
       String bqOption,
       String gcsProperty) {
-    return fromJavaUtil(
+    return javaOptionToGoog(
         firstPresent(
-            getFirstOrSecondOption(options, globalOptions, bqOption).toJavaUtil(),
-            fromNullable(hadoopConfiguration.get(gcsProperty)).toJavaUtil()));
+            googOptionToJava(getFirstOrSecondOption(options, globalOptions, bqOption)),
+            googOptionToJava(fromNullable(hadoopConfiguration.get(gcsProperty)))));
   }
 
   private static com.google.common.base.Optional<String> getFirstOrSecondOption(
@@ -196,27 +197,27 @@ public class SparkBigQueryProxyAndHttpConfig implements BigQueryProxyConfig, Ser
   }
 
   public Optional<URI> getProxyUri() {
-    return proxyUri.toJavaUtil();
+    return googOptionToJava(proxyUri);
   }
 
   public Optional<String> getProxyUsername() {
-    return proxyUsername.toJavaUtil();
+    return googOptionToJava(proxyUsername);
   }
 
   public Optional<String> getProxyPassword() {
-    return proxyPassword.toJavaUtil();
+    return googOptionToJava(proxyPassword);
   }
 
   Optional<Integer> getHttpMaxRetry() {
-    return httpMaxRetry.toJavaUtil();
+    return googOptionToJava(httpMaxRetry);
   }
 
   Optional<Integer> getHttpConnectTimeout() {
-    return httpConnectTimeout.toJavaUtil();
+    return googOptionToJava(httpConnectTimeout);
   }
 
   Optional<Integer> getHttpReadTimeout() {
-    return httpReadTimeout.toJavaUtil();
+    return googOptionToJava(httpReadTimeout);
   }
 
   @Override

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/BigQueryWriteHelper.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/BigQueryWriteHelper.java
@@ -113,13 +113,17 @@ public class BigQueryWriteHelper {
     }
   }
 
+  private static <T> Stream<T> guavaStreamFromIter(java.util.Iterator<T> iterator) {
+    return java.util.stream.StreamSupport.stream(java.util.Spliterators.spliteratorUnknownSize(iterator, 0), false);
+  }
+
   void loadDataToBigQuery() throws IOException {
     FileSystem fs = gcsPath.getFileSystem(conf);
     FormatOptions formatOptions = config.getIntermediateFormat().getFormatOptions();
     String suffix = "." + formatOptions.getType().toLowerCase();
     List<String> sourceUris =
         SparkBigQueryUtil.optimizeLoadUriListForSpark(
-            Streams.stream(HdfsUtils.toJavaUtilIterator(fs.listFiles(gcsPath, false)))
+            guavaStreamFromIter(HdfsUtils.toJavaUtilIterator(fs.listFiles(gcsPath, false)))
                 .map(file -> file.getPath().toString())
                 .filter(path -> path.toLowerCase().endsWith(suffix))
                 .collect(Collectors.toList()));

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDataSourceWriterModule.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDataSourceWriterModule.java
@@ -15,6 +15,9 @@
  */
 package com.google.cloud.spark.bigquery.write.context;
 
+import static com.google.cloud.bigquery.connector.common.BigQueryConfigurationUtil.javaOptionToGoog;
+import static com.google.cloud.bigquery.connector.common.BigQueryConfigurationUtil.googOptionToJava;
+
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.connector.common.BigQueryClient;
@@ -68,9 +71,14 @@ public class BigQueryDataSourceWriterModule implements Module {
         mode,
         sparkSchema,
         bigqueryDataWriteHelperRetrySettings,
+<<<<<<< HEAD
         com.google.common.base.Optional.fromJavaUtil(tableConfig.getTraceId()),
         tableConfig.getEnableModeCheckForSchemaFields(),
         tableConfig.getBigQueryTableLabels()); // needs to be serializable
+=======
+        javaOptionToGoog(tableConfig.getTraceId()),
+        tableConfig.getEnableModeCheckForSchemaFields()); // needs to be serializable
+>>>>>>> 6fa7b4d (Fix)
   }
 
   @Singleton

--- a/spark-bigquery-dsv2/spark-2.4-bigquery/pom.xml
+++ b/spark-bigquery-dsv2/spark-2.4-bigquery/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>spark-2.4-bigquery</artifactId>
-    <version>${revision}-preview</version>
+    <version>${revision}</version>
     <name>BigQuery DataSource v2 for Spark 2.4</name>
     <properties>
         <spark.version>2.4.0</spark.version>

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/pom.xml
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>spark-3.1-bigquery</artifactId>
-  <version>${revision}-preview</version>
+  <version>${revision}</version>
   <name>BigQuery DataSource v2 for Spark 3.1</name>
   <properties>
     <spark.version>3.1.0</spark.version>

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/ArrowInputPartitionContext.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/ArrowInputPartitionContext.java
@@ -15,7 +15,8 @@
  */
 package com.google.cloud.spark.bigquery.v2.context;
 
-import static com.google.common.base.Optional.fromJavaUtil;
+import static com.google.cloud.bigquery.connector.common.BigQueryConfigurationUtil.javaOptionToGoog;
+import static com.google.cloud.bigquery.connector.common.BigQueryConfigurationUtil.googOptionToJava;
 
 import com.google.cloud.bigquery.connector.common.BigQueryClientFactory;
 import com.google.cloud.bigquery.connector.common.BigQueryStorageReadRowsTracer;
@@ -59,7 +60,7 @@ public class ArrowInputPartitionContext implements InputPartitionContext<Columna
     this.serializedArrowSchema =
         readSessionResponse.getReadSession().getArrowSchema().getSerializedSchema();
     this.tracerFactory = tracerFactory;
-    this.userProvidedSchema = fromJavaUtil(userProvidedSchema);
+    this.userProvidedSchema = javaOptionToGoog(userProvidedSchema);
   }
 
   public InputPartitionReaderContext<ColumnarBatch> createPartitionReaderContext() {
@@ -80,7 +81,7 @@ public class ArrowInputPartitionContext implements InputPartitionContext<Columna
         readRowsHelper,
         selectedFields,
         tracer,
-        userProvidedSchema.toJavaUtil(),
+        googOptionToJava(userProvidedSchema),
         options.numBackgroundThreads());
   }
 

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -37,19 +37,23 @@
     </scm>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>aws-releases</id>
+            <url>s3://aiq-artifacts/releases</url>
         </repository>
+        <snapshotRepository>
+            <id>aws-snapshots</id>
+            <url>s3://aiq-artifacts/snapshots</url>
+        </snapshotRepository>
+        <site>
+            <id>apache.website</id>
+            <url>scpexe://people.apache.org/www/hadoop.apache.org/docs/r${project.version}</url>
+        </site>
     </distributionManagement>
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.0.1-SNAPSHOT</revision>
+        <revision>0.26.0-aiq1</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>10.0.1</arrow.version>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -53,7 +53,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.26.0-aiq2</revision>
+        <revision>0.28.0-aiq1</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>10.0.1</arrow.version>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -64,13 +64,16 @@
         <google-cloud-storage.version>2.16.0</google-cloud-storage.version>
         <google-truth.version>1.1.3</google-truth.version>
         <grpc.version>1.51.1</grpc.version>
-        <guava.version>31.1-jre</guava.version>
-        <jackson.version>2.14.1</jackson.version>
+        <!-- TODO: once AIQ is upgraded, set this back to 31.1-jre -->
+        <guava.version>20.0</guava.version>
+        <!-- TODO: once AIQ is upgraded, set this back to 2.14.1 -->
+        <jackson.version>2.9.10</jackson.version>
+        <!-- TODO: keep in sync? -->
         <netty.version>4.1.86.Final</netty.version>
         <paranamer.version>2.8</paranamer.version>
         <protobuf.version>3.21.12</protobuf.version>
         <zstd.version>1.4.9-1</zstd.version>
-        <deploy.skip>true</deploy.skip>
+        <deploy.skip>false</deploy.skip>
         <nexus.remote.skip>false</nexus.remote.skip>
         <shade.skip>true</shade.skip>
         <!-- checkstyle
@@ -301,6 +304,13 @@
         </dependency>
     </dependencies>
     <build>
+        <extensions>
+            <extension>
+                <groupId>com.github.seahen</groupId>
+                <artifactId>maven-s3-wagon</artifactId>
+                <version>1.3.3</version>
+            </extension>
+        </extensions>
         <pluginManagement>
             <plugins>
                 <plugin>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -53,7 +53,7 @@
 
     <properties>
         <gpg.skip>true</gpg.skip>
-        <revision>0.26.0-aiq1</revision>
+        <revision>0.26.0-aiq2</revision>
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>10.0.1</arrow.version>

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryPushdown.scala
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryPushdown.scala
@@ -19,7 +19,7 @@ package com.google.cloud.spark.bigquery.pushdowns
 class Spark24BigQueryPushdown extends BaseSparkBigQueryPushdown {
 
   override def supportsSparkVersion(sparkVersion: String): Boolean = {
-    sparkVersion.startsWith("2.4")
+    sparkVersion.startsWith("2.4") || sparkVersion.startsWith("2-4")
   }
 
   override def createSparkExpressionConverter(expressionFactory: SparkExpressionFactory, sparkPlanFactory: SparkPlanFactory): SparkExpressionConverter = {

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryPushdown.scala
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/src/main/scala/com/google/cloud/spark/bigquery/pushdowns/Spark24BigQueryPushdown.scala
@@ -19,7 +19,7 @@ package com.google.cloud.spark.bigquery.pushdowns
 class Spark24BigQueryPushdown extends BaseSparkBigQueryPushdown {
 
   override def supportsSparkVersion(sparkVersion: String): Boolean = {
-    sparkVersion.startsWith("2.4")
+    sparkVersion.startsWith("2.4") || sparkVersion.startsWith("2-4")
   }
 
   override def createSparkExpressionConverter(expressionFactory: SparkExpressionFactory, sparkPlanFactory: SparkPlanFactory): SparkExpressionConverter = {


### PR DESCRIPTION
- Set base branch to 0.28.0 tag
- Updated the versioning to `-aiqXYZ` and removed the `-preview` suffix 
- Added readme notes
- Updated deploy to point to our S3 bucket
- Downgrading to Guava 20 and Jackson 2.9 libraries to match what AIQ uses, which means I needed to change a bunch of the util methods to use the old ones. Still fixing it 😬 
- Fixing small bug with our Spark version starting with `2-4` vs `2.4`

## Test and Deploy
See readme notes