### PR TITLE
spark-bigquery-with-dependencies missing checkmark for spark 3.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ below.
 | spark-3.1-bigquery                    |         |                     |                     |         | &check; | &check; | &check; |
 | spark-2.4-bigquery                    |         | &check;             | &check;             |         |         |         |         |
 | spark-bigquery-with-dependencies_2.13 |         |                     |                     |         |         | &check; | &check; |
-| spark-bigquery-with-dependencies_2.12 |         |                     | &check;             | &check; | &check; | &check; |         |
+| spark-bigquery-with-dependencies_2.12 |         |                     | &check;             | &check; | &check; | &check; | &check; |
 | spark-bigquery-with-dependencies_2.11 | &check; | &check;             |                     |         |         |         |         |
 
 ### Connector to Dataproc Image Compatibility Matrix


### PR DESCRIPTION
I tested the spark-bigquery-with-dependencies 0.28 works for spark 3.3.1. but its probably missing the check mark on the readme, so just wanted to correct it, as I was almost thought i will have to move to scala 2_13 :) which is not required as it works fine.