### PR TITLE
fixing nightly build failures

### DIFF
--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/acceptance/AcceptanceTestConstants.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/acceptance/AcceptanceTestConstants.java
@@ -50,4 +50,6 @@ public class AcceptanceTestConstants {
           + "    cast(\""
           + MAX_BIG_NUMERIC
           + "\" as bignumeric) as max";
+
+  protected static final long SERVERLESS_BATCH_TIMEOUT_IN_SECONDS = 600;
 }

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/acceptance/AcceptanceTestUtils.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/acceptance/AcceptanceTestUtils.java
@@ -146,7 +146,9 @@ public class AcceptanceTestUtils {
                 false)
             .map(Blob::getBlobId)
             .toArray(BlobId[]::new);
-    storage.delete(blobIds);
+    if (blobIds.length > 1) {
+      storage.delete(blobIds);
+    }
   }
 
   public static void createBqDataset(String dataset) {

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/acceptance/BigNumericDataprocServerlessAcceptanceTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/acceptance/BigNumericDataprocServerlessAcceptanceTestBase.java
@@ -63,8 +63,7 @@ public class BigNumericDataprocServerlessAcceptanceTestBase
             testName,
             "big_numeric.py",
             zipFileUri,
-            Arrays.asList(tableName, context.getResultsDirUri(testName)),
-            480);
+            Arrays.asList(tableName, context.getResultsDirUri(testName)));
     assertThat(operationSnapshot.isDone()).isTrue();
     assertThat(operationSnapshot.getErrorMessage()).isEmpty();
     String output = AcceptanceTestUtils.getCsv(context.getResultsDirUri(testName));

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/acceptance/DataprocServerlessAcceptanceTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/acceptance/DataprocServerlessAcceptanceTestBase.java
@@ -85,8 +85,7 @@ public class DataprocServerlessAcceptanceTestBase {
       String testName,
       String pythonFile,
       String pythonZipUri,
-      List<String> args,
-      long durationInSeconds)
+      List<String> args)
       throws Exception {
     AcceptanceTestUtils.uploadToGcs(
         DataprocServerlessAcceptanceTestBase.class.getResourceAsStream("/acceptance/" + pythonFile),
@@ -115,7 +114,10 @@ public class DataprocServerlessAcceptanceTestBase {
                 .setBatchId(context.clusterId)
                 .setBatch(batch)
                 .build());
-    return batchAsync.getPollingFuture().get(durationInSeconds, TimeUnit.SECONDS);
+
+    return batchAsync
+        .getPollingFuture()
+        .get(AcceptanceTestConstants.SERVERLESS_BATCH_TIMEOUT_IN_SECONDS, TimeUnit.SECONDS);
   }
 
   protected PySparkBatch.Builder createPySparkBatchBuilder(

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/acceptance/ReadSheakspeareDataprocServerlessAcceptanceTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/acceptance/ReadSheakspeareDataprocServerlessAcceptanceTestBase.java
@@ -38,8 +38,7 @@ public class ReadSheakspeareDataprocServerlessAcceptanceTestBase
             testName,
             "read_shakespeare.py",
             null,
-            Arrays.asList(context.getResultsDirUri(testName)),
-            480);
+            Arrays.asList(context.getResultsDirUri(testName)));
     assertThat(operationSnapshot.isDone()).isTrue();
     assertThat(operationSnapshot.getErrorMessage()).isEmpty();
     String output = AcceptanceTestUtils.getCsv(context.getResultsDirUri(testName));

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/acceptance/WriteStreamDataprocServerlessAcceptanceTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/acceptance/WriteStreamDataprocServerlessAcceptanceTestBase.java
@@ -52,8 +52,7 @@ public class WriteStreamDataprocServerlessAcceptanceTestBase
                 context.testBaseGcsDir + "/" + testName + "/json/",
                 context.bqDataset,
                 context.bqStreamTable,
-                AcceptanceTestUtils.BUCKET),
-            480);
+                AcceptanceTestUtils.BUCKET));
     assertThat(operationSnapshot.isDone()).isTrue();
     assertThat(operationSnapshot.getErrorMessage()).isEmpty();
 

--- a/spark-bigquery-dsv1/spark-bigquery-with-dependencies_2.12/src/test/java/com/google/cloud/spark/bigquery/acceptance/Scala212DataprocImage21AcceptanceTest.java
+++ b/spark-bigquery-dsv1/spark-bigquery-with-dependencies_2.12/src/test/java/com/google/cloud/spark/bigquery/acceptance/Scala212DataprocImage21AcceptanceTest.java
@@ -30,8 +30,7 @@ public class Scala212DataprocImage21AcceptanceTest extends DataprocAcceptanceTes
   @BeforeClass
   public static void setup() throws Exception {
     context =
-        DataprocAcceptanceTestBase.setup(
-            "preview-debian11", "spark-bigquery", Collections.emptyList());
+        DataprocAcceptanceTestBase.setup("2.1-debian11", "spark-bigquery", Collections.emptyList());
   }
 
   @AfterClass

--- a/spark-bigquery-dsv1/spark-bigquery-with-dependencies_2.12/src/test/java/com/google/cloud/spark/bigquery/acceptance/Scala212DataprocImage21DisableConscryptAcceptanceTest.java
+++ b/spark-bigquery-dsv1/spark-bigquery-with-dependencies_2.12/src/test/java/com/google/cloud/spark/bigquery/acceptance/Scala212DataprocImage21DisableConscryptAcceptanceTest.java
@@ -30,8 +30,7 @@ public class Scala212DataprocImage21DisableConscryptAcceptanceTest
   @BeforeClass
   public static void setup() throws Exception {
     context =
-        DataprocAcceptanceTestBase.setup(
-            "preview-debian11", "spark-bigquery", DISABLE_CONSCRYPT_LIST);
+        DataprocAcceptanceTestBase.setup("2.1-debian11", "spark-bigquery", DISABLE_CONSCRYPT_LIST);
   }
 
   @AfterClass


### PR DESCRIPTION
The PR has fix for the following build failures
```
Step #1 - "maven-build": [ERROR] com.google.cloud.spark.bigquery.acceptance.Scala212DataprocImage20DisableConscryptAcceptanceTest  Time elapsed: 104.765 s  <<< ERROR!
Step #1 - "maven-build": java.lang.IllegalStateException: Batch is empty
Step #1 - "maven-build": 	at com.google.common.base.Preconditions.checkState(Preconditions.java:502)
Step #1 - "maven-build": 	at com.google.api.client.util.Preconditions.checkState(Preconditions.java:92)
Step #1 - "maven-build": 	at com.google.api.client.googleapis.batch.BatchRequest.execute(BatchRequest.java:231)
Step #1 - "maven-build": 	at com.google.cloud.storage.spi.v1.HttpStorageRpc$DefaultRpcBatch.submit(HttpStorageRpc.java:263)
Step #1 - "maven-build": 	at com.google.cloud.storage.StorageBatch.submit(StorageBatch.java:151)
Step #1 - "maven-build": 	at com.google.cloud.storage.StorageImpl.delete(StorageImpl.java:1125)
Step #1 - "maven-build": 	at com.google.cloud.storage.StorageImpl.delete(StorageImpl.java:1102)
Step #1 - "maven-build": 	at com.google.cloud.spark.bigquery.acceptance.AcceptanceTestUtils.deleteGcsDir(AcceptanceTestUtils.java:149)
Step #1 - "maven-build": 	at com.google.cloud.spark.bigquery.acceptance.DataprocAcceptanceTestBase.tearDown(DataprocAcceptanceTestBase.java:103)
Step #1 - "maven-build": 	at com.google.cloud.spark.bigquery.acceptance.Scala212DataprocImage20DisableConscryptAcceptanceTest.tearDown(Scala212DataprocImage20DisableConscryptAcceptanceTest.java:38)
...
```

```
[ERROR] com.google.cloud.spark.bigquery.acceptance.Scala213Spark33ReadSheakspeareDataprocServerlessAcceptanceTest.testBatch  Time elapsed: 276.78 s  <<< ERROR!
Step #1 - "maven-build": java.util.concurrent.CancellationException: Task was cancelled.
Step #1 - "maven-build": 	at com.google.common.util.concurrent.AbstractFuture.cancellationExceptionWithCause(AbstractFuture.java:1543)
Step #1 - "maven-build": 	at com.google.common.util.concurrent.AbstractFuture.getDoneValue(AbstractFuture.java:586)
Step #1 - "maven-build": 	at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:463)
Step #1 - "maven-build": 	at com.google.cloud.spark.bigquery.acceptance.DataprocServerlessAcceptanceTestBase.createAndRunPythonBatch(DataprocServerlessAcceptanceTestBase.java:118)
Step #1 - "maven-build": 	at com.google.cloud.spark.bigquery.acceptance.ReadSheakspeareDataprocServerlessAcceptanceTestBase.testBatch(ReadSheakspeareDataprocServerlessAcceptanceTestBase.java:36)
...
```

```
[ERROR]   Scala212DataprocImage21DisableConscryptAcceptanceTest.setup:33->DataprocAcceptanceTestBase.setup:93->DataprocAcceptanceTestBase.createClusterIfNeeded:115->DataprocAcceptanceTestBase.cluster:134->DataprocAcceptanceTestBase.lambda$createClusterIfNeeded$0:122 Â» Execution com.google.api.gax.rpc.InvalidArgumentException: io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Failed to resolve image version 'preview-debian11'. Accepted image versions: [2.0-centos, 1.5-debian10, 2.1-ubuntu, 1.5-centos8, 2.0-ubuntu18, 1.5-ubuntu18, 2.0-rocky8, 2.1-debian, 2.1-rocky8, 2.0-debian, 2.0-rocky, 2.0-debian10, 1.5-rocky, 1.5-centos, 2.1-ubuntu20, 1.4-ubuntu18, 1.5-ubuntu, 1.4-debian10, 1.3-ubuntu, 1.4-ubuntu, 2.0, 2.1, 2.1-rocky, 1.3, 1.3-debian10, 2.1-debian11, 1.4, 2.0-ubuntu, 1.5, 1.4-debian, 1.5-debian, 1.3-debian, 1.3-ubuntu18, 1.5-rocky8, 2.0-centos8]. See https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-versions for additional information on image versioning.
```
