### PR TITLE
Add support for passing configuration to custom AccessTokenProvider

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -1187,7 +1187,9 @@ spark.read.format("bigquery").option("credentials", "<SERVICE_ACCOUNT_JSON_IN_BA
   [com.google.cloud.bigquery.connector.common.AccessTokenProvider](https://github.com/GoogleCloudDataproc/spark-bigquery-connector/tree/master/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/AccessTokenProvider.java)
   interface. The fully qualified class name of the implementation should be provided in the `gcpAccessTokenProvider`
   option. `AccessTokenProvider` must be implemented in Java or other JVM language such as Scala or Kotlin. It must
-  have a no-arg constructor. The jar containing the implementation should be on the cluster's classpath.
+  either have a no-arg constructor or a constructor accepting a single `java.util.String` argument. This configuration
+  parameter can be supplied using the `gcpAccessTokenProviderConfig` option. If this is not provided then the no-arg
+  constructor wil be called. The jar containing the implementation should be on the cluster's classpath.
 ```
 // Globally
 spark.conf.set("gcpAccessTokenProvider", "com.example.ExampleAccessTokenProvider")
@@ -1205,8 +1207,7 @@ spark.read.format("bigquery").option("gcpAccessToken", "<acccess-token>")
 ```
 
 **Important:** The `CredentialsProvider` and  `AccessTokenProvider` need to be implemented in Java or
-other JVM language such as Scala or Kotlin. It must have a no-arg constructor. The jar containing
-the implementation should be on the cluster's classpath.
+other JVM language such as Scala or Kotlin. The jar containing the implementation should be on the cluster's classpath.
 
 **Notice:** Only one of the above options should be provided.
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,15 @@ The latest version of the connector is publicly available in the following links
 
 | version    | Link                                                                                                                                                                                                                   |
 |------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Spark 3.1  | `gs://spark-lib/bigquery/spark-3.1-bigquery-0.28.0-preview.jar`([HTTP link](https://storage.googleapis.com/spark-lib/bigquery/spark-3.1-bigquery-0.28.0-preview.jar))                        |
-| Spark 2.4  | `gs://spark-lib/bigquery/spark-2.4-bigquery-0.28.0-preview.jar`([HTTP link](https://storage.googleapis.com/spark-lib/bigquery/spark-2.4-bigquery-0.28.0-preview.jar))                        |
-| Scala 2.13 | `gs://spark-lib/bigquery/spark-bigquery-with-dependencies_2.13-0.28.0.jar` ([HTTP link](https://storage.googleapis.com/spark-lib/bigquery/spark-bigquery-with-dependencies_2.13-0.28.0.jar)) |
-| Scala 2.12 | `gs://spark-lib/bigquery/spark-bigquery-with-dependencies_2.12-0.28.0.jar` ([HTTP link](https://storage.googleapis.com/spark-lib/bigquery/spark-bigquery-with-dependencies_2.12-0.28.0.jar)) |
-| Scala 2.11 | `gs://spark-lib/bigquery/spark-bigquery-with-dependencies_2.11-0.28.0.jar` ([HTTP link](https://storage.googleapis.com/spark-lib/bigquery/spark-bigquery-with-dependencies_2.11-0.28.0.jar)) |
+| Spark 3.3  | `gs://spark-lib/bigquery/spark-3.3-bigquery-0.29.0-preview.jar`([HTTP link](https://storage.googleapis.com/spark-lib/bigquery/spark-3.3-bigquery-0.29.0-preview.jar))                        |
+| Spark 3.2  | `gs://spark-lib/bigquery/spark-3.2-bigquery-0.29.0-preview.jar`([HTTP link](https://storage.googleapis.com/spark-lib/bigquery/spark-3.2-bigquery-0.29.0-preview.jar))                        |
+| Spark 3.1  | `gs://spark-lib/bigquery/spark-3.1-bigquery-0.29.0-preview.jar`([HTTP link](https://storage.googleapis.com/spark-lib/bigquery/spark-3.1-bigquery-0.29.0-preview.jar))                        |
+| Spark 2.4  | `gs://spark-lib/bigquery/spark-2.4-bigquery-0.29.0-preview.jar`([HTTP link](https://storage.googleapis.com/spark-lib/bigquery/spark-2.4-bigquery-0.29.0-preview.jar))                        |
+| Scala 2.13 | `gs://spark-lib/bigquery/spark-bigquery-with-dependencies_2.13-0.29.0.jar` ([HTTP link](https://storage.googleapis.com/spark-lib/bigquery/spark-bigquery-with-dependencies_2.13-0.29.0.jar)) |
+| Scala 2.12 | `gs://spark-lib/bigquery/spark-bigquery-with-dependencies_2.12-0.29.0.jar` ([HTTP link](https://storage.googleapis.com/spark-lib/bigquery/spark-bigquery-with-dependencies_2.12-0.29.0.jar)) |
+| Scala 2.11 | `gs://spark-lib/bigquery/spark-bigquery-with-dependencies_2.11-0.29.0.jar` ([HTTP link](https://storage.googleapis.com/spark-lib/bigquery/spark-bigquery-with-dependencies_2.11-0.29.0.jar)) |
 
-The first two versions are Java based connectors targeting Spark 2.4/Spark 3.1 of all Scala versions built on the new
+The first four versions are Java based connectors targeting Spark 2.4/3.1/3.2/3.3 of all Scala versions built on the new
 Data Source APIs (Data Source API v2) of Spark. They are still in preview mode.
 
 The final two connectors are Scala based connectors, please use the jar relevant to your Spark installation as outlined
@@ -72,20 +74,24 @@ below.
 ### Connector to Spark Compatibility Matrix
 | Connector \ Spark                     | 2.3     | 2.4<br>(Scala 2.11) | 2.4<br>(Scala 2.12) | 3.0     | 3.1     | 3.2     | 3.3     |
 |---------------------------------------|---------|---------------------|---------------------|---------|---------|---------|---------|
+| spark-3.3-bigquery                    |         |                     |                     |         |         |         | &check; |
+| spark-3.2-bigquery                    |         |                     |                     |         |         | &check; | &check; |
 | spark-3.1-bigquery                    |         |                     |                     |         | &check; | &check; | &check; |
 | spark-2.4-bigquery                    |         | &check;             | &check;             |         |         |         |         |
 | spark-bigquery-with-dependencies_2.13 |         |                     |                     |         |         | &check; | &check; |
-| spark-bigquery-with-dependencies_2.12 |         |                     | &check;             | &check; | &check; | &check; | &check; |
+| spark-bigquery-with-dependencies_2.12 |         |                     | &check;             | &check; | &check; | &check; |         |
 | spark-bigquery-with-dependencies_2.11 | &check; | &check;             |                     |         |         |         |         |
 
 ### Connector to Dataproc Image Compatibility Matrix
-| Connector \ Dataproc Image            | 1.3     | 1.4     | 1.5     | 2.0     | Serverless<br>Image 1.0 | Serverless<br>Image 2.0 |
-|---------------------------------------|---------|---------|---------|---------|-------------------------|-------------------------|
-| spark-3.1-bigquery                    |         |         |         | &check; | &check;                 | &check;                 |
-| spark-2.4-bigquery                    |         | &check; | &check; |         |                         |                         |
-| spark-bigquery-with-dependencies_2.13 |         |         |         |         |                         | &check;                 |
-| spark-bigquery-with-dependencies_2.12 |         |         | &check; | &check; | &check;                 |                         |
-| spark-bigquery-with-dependencies_2.11 | &check; | &check; |         |         |                         |                         |
+| Connector \ Dataproc Image            | 1.3     | 1.4     | 1.5     | 2.0     | 2.1     | Serverless<br>Image 1.0 | Serverless<br>Image 2.0 |
+|---------------------------------------|---------|---------|---------|---------|---------|-------------------------|-------------------------|
+| spark-3.3-bigquery                    |         |         |         |         | &check; | &check;                 | &check;                 |
+| spark-3.2-bigquery                    |         |         |         |         | &check; | &check;                 | &check;                 |
+| spark-3.1-bigquery                    |         |         |         | &check; | &check; | &check;                 | &check;                 |
+| spark-2.4-bigquery                    |         | &check; | &check; |         |         |                         |                         |
+| spark-bigquery-with-dependencies_2.13 |         |         |         |         |         |                         | &check;                 |
+| spark-bigquery-with-dependencies_2.12 |         |         | &check; | &check; | &check; | &check;                 |                         |
+| spark-bigquery-with-dependencies_2.11 | &check; | &check; |         |         |         |                         |                         |
 
 ### Maven / Ivy Package Usage
 The connector is also available from the
@@ -95,11 +101,13 @@ repository. It can be used using the `--packages` option or the
 
 | version    | Connector Artifact                                                                 |
 |------------|------------------------------------------------------------------------------------|
-| Spark 3.1  | `com.google.cloud.spark:spark-3.1-bigquery:0.28.0-preview`            |
-| Spark 2.4  | `com.google.cloud.spark:spark-2.4-bigquery:0.28.0-preview`            |
-| Scala 2.13 | `com.google.cloud.spark:spark-bigquery-with-dependencies_2.13:0.28.0` |
-| Scala 2.12 | `com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:0.28.0` |
-| Scala 2.11 | `com.google.cloud.spark:spark-bigquery-with-dependencies_2.11:0.28.0` |
+| Spark 3.3  | `com.google.cloud.spark:spark-3.3-bigquery:0.29.0-preview`            |
+| Spark 3.2  | `com.google.cloud.spark:spark-3.2-bigquery:0.29.0-preview`            |
+| Spark 3.1  | `com.google.cloud.spark:spark-3.1-bigquery:0.29.0-preview`            |
+| Spark 2.4  | `com.google.cloud.spark:spark-2.4-bigquery:0.29.0-preview`            |
+| Scala 2.13 | `com.google.cloud.spark:spark-bigquery-with-dependencies_2.13:0.29.0` |
+| Scala 2.12 | `com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:0.29.0` |
+| Scala 2.11 | `com.google.cloud.spark:spark-bigquery-with-dependencies_2.11:0.29.0` |
 
 ## Hello World Example
 
@@ -109,7 +117,7 @@ You can run a simple PySpark wordcount against the API without compilation by ru
 
 ```
 gcloud dataproc jobs submit pyspark --cluster "$MY_CLUSTER" \
-  --jars gs://spark-lib/bigquery/spark-bigquery-with-dependencies_2.12-0.28.0.jar \
+  --jars gs://spark-lib/bigquery/spark-bigquery-with-dependencies_2.12-0.29.0.jar \
   examples/python/shakespeare.py
 ```
 
@@ -117,7 +125,7 @@ gcloud dataproc jobs submit pyspark --cluster "$MY_CLUSTER" \
 
 ```
 gcloud dataproc jobs submit pyspark --cluster "$MY_CLUSTER" \
-  --jars gs://spark-lib/bigquery/spark-bigquery-with-dependencies_2.11-0.28.0.jar \
+  --jars gs://spark-lib/bigquery/spark-bigquery-with-dependencies_2.11-0.29.0.jar \
   examples/python/shakespeare.py
 ```
 
@@ -942,9 +950,9 @@ creating the job or added during runtime. See examples below:
 1) Adding python files while launching pyspark
 ```
 # use appropriate version for jar depending on the scala version
-pyspark --jars gs://spark-lib/bigquery/spark-bigquery-with-dependencies_2.11-0.28.0.jar
-  --py-files gs://spark-lib/bigquery/spark-bigquery-support-0.28.0.zip
-  --files gs://spark-lib/bigquery/spark-bigquery-support-0.28.0.zip
+pyspark --jars gs://spark-lib/bigquery/spark-bigquery-with-dependencies_2.11-0.29.0.jar
+  --py-files gs://spark-lib/bigquery/spark-bigquery-support-0.29.0.zip
+  --files gs://spark-lib/bigquery/spark-bigquery-support-0.29.0.zip
 ```
 
 2) Adding python files in Jupyter Notebook
@@ -954,14 +962,14 @@ from pyspark import SparkFiles
 # use appropriate version for jar depending on the scala version
 spark = SparkSession.builder\
   .appName('BigNumeric')\
-  .config('spark.jars', 'gs://spark-lib/bigquery/spark-bigquery-with-dependencies_2.11-0.28.0.jar')\
-  .config('spark.submit.pyFiles', 'gs://spark-lib/bigquery/spark-bigquery-support-0.28.0.zip')\
-  .config('spark.files', 'gs://spark-lib/bigquery/spark-bigquery-support-0.28.0.zip')\
+  .config('spark.jars', 'gs://spark-lib/bigquery/spark-bigquery-with-dependencies_2.11-0.29.0.jar')\
+  .config('spark.submit.pyFiles', 'gs://spark-lib/bigquery/spark-bigquery-support-0.29.0.zip')\
+  .config('spark.files', 'gs://spark-lib/bigquery/spark-bigquery-support-0.29.0.zip')\
   .getOrCreate()
 
 # extract the spark-bigquery-support zip file
 import zipfile
-with zipfile.ZipFile(SparkFiles.get("spark-bigquery-support-0.28.0.zip")) as zf:
+with zipfile.ZipFile(SparkFiles.get("spark-bigquery-support-0.29.0.zip")) as zf:
   zf.extractall()
 ```
 
@@ -970,10 +978,10 @@ with zipfile.ZipFile(SparkFiles.get("spark-bigquery-support-0.28.0.zip")) as zf:
 # use appropriate version for jar depending on the scala version
 spark = SparkSession.builder\
   .appName('BigNumeric')\
-  .config('spark.jars', 'gs://spark-lib/bigquery/spark-bigquery-with-dependencies_2.11-0.28.0.jar')\
+  .config('spark.jars', 'gs://spark-lib/bigquery/spark-bigquery-with-dependencies_2.11-0.29.0.jar')\
   .getOrCreate()
 
-spark.sparkContext.addPyFile("gs://spark-lib/bigquery/spark-bigquery-support-0.28.0.zip")
+spark.sparkContext.addPyFile("gs://spark-lib/bigquery/spark-bigquery-support-0.29.0.zip")
 ```
 
 Usage Example:
@@ -1081,7 +1089,7 @@ using the following code:
 ```python
 from pyspark.sql import SparkSession
 spark = SparkSession.builder
-  .config("spark.jars.packages", "com.google.cloud.spark:spark-bigquery-with-dependencies_2.11:0.28.0")
+  .config("spark.jars.packages", "com.google.cloud.spark:spark-bigquery-with-dependencies_2.11:0.29.0")
   .getOrCreate()
 df = spark.read.format("bigquery")
   .load("dataset.table")
@@ -1090,7 +1098,7 @@ df = spark.read.format("bigquery")
 **Scala:**
 ```python
 val spark = SparkSession.builder
-.config("spark.jars.packages", "com.google.cloud.spark:spark-bigquery-with-dependencies_2.11:0.28.0")
+.config("spark.jars.packages", "com.google.cloud.spark:spark-bigquery-with-dependencies_2.11:0.29.0")
 .getOrCreate()
 val df = spark.read.format("bigquery")
 .load("dataset.table")
@@ -1098,7 +1106,7 @@ val df = spark.read.format("bigquery")
 
 In case Spark cluster is using Scala 2.12 (it's optional for Spark 2.4.x,
 mandatory in 3.0.x), then the relevant package is
-com.google.cloud.spark:spark-bigquery-with-dependencies_**2.12**:0.28.0. In
+com.google.cloud.spark:spark-bigquery-with-dependencies_**2.12**:0.29.0. In
 order to know which Scala version is used, please run the following code:
 
 **Python:**
@@ -1122,14 +1130,14 @@ To include the connector in your project:
 <dependency>
   <groupId>com.google.cloud.spark</groupId>
   <artifactId>spark-bigquery-with-dependencies_${scala.version}</artifactId>
-  <version>0.28.0</version>
+  <version>0.29.0</version>
 </dependency>
 ```
 
 ### SBT
 
 ```sbt
-libraryDependencies += "com.google.cloud.spark" %% "spark-bigquery-with-dependencies" % "0.28.0"
+libraryDependencies += "com.google.cloud.spark" %% "spark-bigquery-with-dependencies" % "0.29.0"
 ```
 
 ## FAQ
@@ -1173,9 +1181,7 @@ spark.read.format("bigquery").option("credentials", "<SERVICE_ACCOUNT_JSON_IN_BA
   [com.google.cloud.bigquery.connector.common.AccessTokenProvider](https://github.com/GoogleCloudDataproc/spark-bigquery-connector/tree/master/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/AccessTokenProvider.java)
   interface. The fully qualified class name of the implementation should be provided in the `gcpAccessTokenProvider`
   option. `AccessTokenProvider` must be implemented in Java or other JVM language such as Scala or Kotlin. It must
-  either have a no-arg constructor or a constructor accepting a single `java.util.String` argument. This configuration
-  parameter can be supplied using the `gcpAccessTokenProviderConfig` option. If this is not provided then the no-arg
-  constructor wil be called. The jar containing the implementation should be on the cluster's classpath.
+  have a no-arg constructor. The jar containing the implementation should be on the cluster's classpath.
 ```
 // Globally
 spark.conf.set("gcpAccessTokenProvider", "com.example.ExampleAccessTokenProvider")
@@ -1191,6 +1197,10 @@ spark.conf.set("gcpAccessToken", "<access-token>")
 // Per read/Write
 spark.read.format("bigquery").option("gcpAccessToken", "<acccess-token>")
 ```
+
+**Important:** The `CredentialsProvider` and  `AccessTokenProvider` need to be implemented in Java or
+other JVM language such as Scala or Kotlin. It must have a no-arg constructor. The jar containing
+the implementation should be on the cluster's classpath.
 
 **Notice:** Only one of the above options should be provided.
 

--- a/README.md
+++ b/README.md
@@ -1173,7 +1173,9 @@ spark.read.format("bigquery").option("credentials", "<SERVICE_ACCOUNT_JSON_IN_BA
   [com.google.cloud.bigquery.connector.common.AccessTokenProvider](https://github.com/GoogleCloudDataproc/spark-bigquery-connector/tree/master/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/AccessTokenProvider.java)
   interface. The fully qualified class name of the implementation should be provided in the `gcpAccessTokenProvider`
   option. `AccessTokenProvider` must be implemented in Java or other JVM language such as Scala or Kotlin. It must
-  have a no-arg constructor. The jar containing the implementation should be on the cluster's classpath.
+  either have a no-arg constructor or a constructor accepting a single `java.util.String` argument. This configuration
+  parameter can be supplied using the `gcpAccessTokenProviderConfig` option. If this is not provided then the no-arg
+  constructor wil be called. The jar containing the implementation should be on the cluster's classpath.
 ```
 // Globally
 spark.conf.set("gcpAccessTokenProvider", "com.example.ExampleAccessTokenProvider")
@@ -1189,10 +1191,6 @@ spark.conf.set("gcpAccessToken", "<access-token>")
 // Per read/Write
 spark.read.format("bigquery").option("gcpAccessToken", "<acccess-token>")
 ```
-
-**Important:** The `CredentialsProvider` and  `AccessTokenProvider` need to be implemented in Java or
-other JVM language such as Scala or Kotlin. It must have a no-arg constructor. The jar containing
-the implementation should be on the cluster's classpath.
 
 **Notice:** Only one of the above options should be provided.
 

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryConfig.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryConfig.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 public class BigQueryClientFactoryConfig implements BigQueryConfig {
 
   private final Optional<String> accessTokenProviderFQCN;
+  private final Optional<String> accessTokenProviderConfig;
   private final Optional<String> credentialsKey;
   private final Optional<String> credentialsFile;
   private final Optional<String> accessToken;
@@ -43,6 +44,7 @@ public class BigQueryClientFactoryConfig implements BigQueryConfig {
 
   BigQueryClientFactoryConfig(BigQueryConfig bigQueryConfig) {
     this.accessTokenProviderFQCN = bigQueryConfig.getAccessTokenProviderFQCN();
+    this.accessTokenProviderConfig = bigQueryConfig.getAccessTokenProviderConfig();
     this.credentialsKey = bigQueryConfig.getCredentialsKey();
     this.credentialsFile = bigQueryConfig.getCredentialsFile();
     this.accessToken = bigQueryConfig.getAccessToken();
@@ -66,6 +68,11 @@ public class BigQueryClientFactoryConfig implements BigQueryConfig {
   @Override
   public Optional<String> getAccessTokenProviderFQCN() {
     return accessTokenProviderFQCN;
+  }
+
+  @Override
+  public Optional<String> getAccessTokenProviderConfig() {
+    return accessTokenProviderConfig;
   }
 
   @Override

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientModule.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientModule.java
@@ -59,6 +59,7 @@ public class BigQueryClientModule implements com.google.inject.Module {
     BigQueryProxyConfig proxyConfig = config.getBigQueryProxyConfig();
     return new BigQueryCredentialsSupplier(
         config.getAccessTokenProviderFQCN(),
+        config.getAccessTokenProviderConfig(),
         config.getAccessToken(),
         config.getCredentialsKey(),
         config.getCredentialsFile(),

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfig.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfig.java
@@ -23,6 +23,8 @@ public interface BigQueryConfig {
 
   Optional<String> getAccessTokenProviderFQCN();
 
+  Optional<String> getAccessTokenProviderConfig();
+
   Optional<String> getCredentialsKey();
 
   Optional<String> getCredentialsFile();

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryCredentialsSupplier.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryCredentialsSupplier.java
@@ -35,6 +35,7 @@ public class BigQueryCredentialsSupplier {
 
   public BigQueryCredentialsSupplier(
       Optional<String> accessTokenProviderFQCN,
+      Optional<String> accessTokenProviderConfig,
       Optional<String> accessToken,
       Optional<String> credentialsKey,
       Optional<String> credentialsFile,
@@ -43,7 +44,15 @@ public class BigQueryCredentialsSupplier {
       Optional<String> proxyPassword) {
     if (accessTokenProviderFQCN.isPresent()) {
       AccessTokenProvider accessTokenProvider =
-          createVerifiedInstance(accessTokenProviderFQCN.get(), AccessTokenProvider.class);
+          accessTokenProviderConfig
+              .map(
+                  config ->
+                      createVerifiedInstance(
+                          accessTokenProviderFQCN.get(), AccessTokenProvider.class, config))
+              .orElseGet(
+                  () ->
+                      createVerifiedInstance(
+                          accessTokenProviderFQCN.get(), AccessTokenProvider.class));
       this.credentials =
           new AccessTokenProviderCredentials(verifySerialization(accessTokenProvider));
     } else if (accessToken.isPresent()) {

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
@@ -57,6 +57,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.IntFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -362,10 +363,16 @@ public class BigQueryUtil {
    * class
    */
   public static <T> T createVerifiedInstance(
-      String fullyQualifiedClassName, Class<T> requiredClass) {
+      String fullyQualifiedClassName, Class<T> requiredClass, Object... constructorArgs) {
     try {
       Class<?> clazz = Class.forName(fullyQualifiedClassName);
-      Object result = clazz.getDeclaredConstructor().newInstance();
+      Object result =
+          clazz
+              .getDeclaredConstructor(
+                  Arrays.stream(constructorArgs)
+                      .map(Object::getClass)
+                      .toArray((IntFunction<Class<?>[]>) Class[]::new))
+              .newInstance(constructorArgs);
       if (!requiredClass.isInstance(result)) {
         throw new IllegalArgumentException(
             String.format(

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryTest.java
@@ -346,6 +346,11 @@ public class BigQueryClientFactoryTest {
     }
 
     @Override
+    public Optional<String> getAccessTokenProviderConfig() {
+      return Optional.empty();
+    }
+
+    @Override
     public Optional<String> getCredentialsKey() {
       return Optional.empty();
     }

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryCredentialsSupplierTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryCredentialsSupplierTest.java
@@ -71,6 +71,7 @@ public class BigQueryCredentialsSupplierTest {
     Credentials nonProxyCredentials =
         new BigQueryCredentialsSupplier(
                 Optional.empty(),
+                Optional.empty(),
                 Optional.of(ACCESS_TOKEN),
                 Optional.empty(),
                 Optional.empty(),
@@ -81,6 +82,7 @@ public class BigQueryCredentialsSupplierTest {
 
     Credentials proxyCredentials =
         new BigQueryCredentialsSupplier(
+                Optional.empty(),
                 Optional.empty(),
                 Optional.of(ACCESS_TOKEN),
                 Optional.empty(),
@@ -111,6 +113,7 @@ public class BigQueryCredentialsSupplierTest {
         new BigQueryCredentialsSupplier(
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.of(credentialsKey),
                 Optional.empty(),
                 Optional.empty(),
@@ -120,6 +123,7 @@ public class BigQueryCredentialsSupplierTest {
 
     Credentials proxyCredentials =
         new BigQueryCredentialsSupplier(
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(credentialsKey),
@@ -156,6 +160,7 @@ public class BigQueryCredentialsSupplierTest {
                 new BigQueryCredentialsSupplier(
                         Optional.empty(),
                         Optional.empty(),
+                        Optional.empty(),
                         Optional.of(credentialsKey),
                         Optional.empty(),
                         optionalProxyURI,
@@ -168,6 +173,7 @@ public class BigQueryCredentialsSupplierTest {
             IllegalArgumentException.class,
             () ->
                 new BigQueryCredentialsSupplier(
+                        Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.of(credentialsKey),
@@ -199,6 +205,7 @@ public class BigQueryCredentialsSupplierTest {
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.of(credentialsFile.getAbsolutePath()),
                 Optional.empty(),
                 Optional.empty(),
@@ -207,6 +214,7 @@ public class BigQueryCredentialsSupplierTest {
 
     Credentials proxyCredentials =
         new BigQueryCredentialsSupplier(
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
@@ -245,6 +253,7 @@ public class BigQueryCredentialsSupplierTest {
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
+                        Optional.empty(),
                         Optional.of(credentialsFile.getAbsolutePath()),
                         optionalProxyURI,
                         Optional.empty(),
@@ -256,6 +265,7 @@ public class BigQueryCredentialsSupplierTest {
             IllegalArgumentException.class,
             () ->
                 new BigQueryCredentialsSupplier(
+                        Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
@@ -298,6 +308,7 @@ public class BigQueryCredentialsSupplierTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
     Credentials credentials = supplier.getCredentials();
     assertThat(credentials).isEqualTo(GoogleCredentials.getApplicationDefault());
@@ -310,6 +321,7 @@ public class BigQueryCredentialsSupplierTest {
             UncheckedIOException.class,
             () -> {
               new BigQueryCredentialsSupplier(
+                  Optional.empty(),
                   Optional.empty(),
                   Optional.empty(),
                   Optional.empty(),
@@ -329,6 +341,7 @@ public class BigQueryCredentialsSupplierTest {
             UncheckedIOException.class,
             () -> {
               new BigQueryCredentialsSupplier(
+                  Optional.empty(),
                   Optional.empty(),
                   Optional.empty(),
                   Optional.of("bm8ga2V5IGhlcmU="), // "no key here"

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryUtilTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryUtilTest.java
@@ -326,6 +326,14 @@ public class BigQueryUtilTest {
   }
 
   @Test
+  public void testCreateVerifiedInstanceWithArg() {
+    String result =
+        BigQueryUtil.createVerifiedInstance("java.lang.String", String.class, "test");
+    assertThat(result).isNotNull();
+    assertThat(result).isEqualTo("test");
+  }
+
+  @Test
   public void testVerifySerialization() {
     int[] source = new int[] {1, 2, 3};
     int[] copy = BigQueryUtil.verifySerialization(source);

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryUtilTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryUtilTest.java
@@ -327,8 +327,7 @@ public class BigQueryUtilTest {
 
   @Test
   public void testCreateVerifiedInstanceWithArg() {
-    String result =
-        BigQueryUtil.createVerifiedInstance("java.lang.String", String.class, "test");
+    String result = BigQueryUtil.createVerifiedInstance("java.lang.String", String.class, "test");
     assertThat(result).isNotNull();
     assertThat(result).isEqualTo("test");
   }

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/integration/CustomCredentialsIntegrationTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/integration/CustomCredentialsIntegrationTest.java
@@ -87,6 +87,10 @@ public class CustomCredentialsIntegrationTest {
     // first call
     Table table = bigQuery.getTable(TABLE_ID);
     assertThat(table).isNotNull();
-    assertThat(accessTokenProvider.getCallCount()).isEqualTo(0);
+    assertThat(accessTokenProvider.getCallCount()).isEqualTo(1);
+    // second call
+    table = bigQuery.getTable(TABLE_ID);
+    assertThat(table).isNotNull();
+    assertThat(accessTokenProvider.getCallCount()).isEqualTo(2);
   }
 }

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/integration/CustomCredentialsIntegrationTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/integration/CustomCredentialsIntegrationTest.java
@@ -24,7 +24,6 @@ import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.connector.common.AccessTokenProviderCredentials;
 import com.google.cloud.bigquery.connector.common.BigQueryCredentialsSupplier;
-import java.io.IOException;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -64,11 +63,11 @@ public class CustomCredentialsIntegrationTest {
   }
 
   @Test
-  public void testAccessTokenProvider_withConfig() throws IOException {
+  public void testAccessTokenProvider_withConfig() {
     BigQueryCredentialsSupplier credentialsSupplier =
         new BigQueryCredentialsSupplier(
             Optional.of(DefaultCredentialsDelegateAccessTokenProvider.class.getCanonicalName()),
-            Optional.of("some-static-token"),
+            Optional.of("some-configuration"),
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
@@ -81,7 +80,7 @@ public class CustomCredentialsIntegrationTest {
         (DefaultCredentialsDelegateAccessTokenProvider)
             ((AccessTokenProviderCredentials) credentials).getAccessTokenProvider();
     assertThat(accessTokenProvider.getCallCount()).isEqualTo(0);
-    assertThat(accessTokenProvider.getAccessToken().getTokenValue()).isEqualTo("some-static-token");
+    assertThat(accessTokenProvider.getConfig()).isEqualTo("some-configuration");
 
     BigQueryOptions options = BigQueryOptions.newBuilder().setCredentials(credentials).build();
     BigQuery bigQuery = options.getService();

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/integration/DefaultCredentialsDelegateAccessTokenProvider.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/integration/DefaultCredentialsDelegateAccessTokenProvider.java
@@ -15,8 +15,6 @@
  */
 package com.google.cloud.bigquery.connector.common.integration;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.bigquery.connector.common.AccessToken;
 import com.google.cloud.bigquery.connector.common.AccessTokenProvider;
@@ -32,11 +30,16 @@ import java.util.Date;
  */
 public class DefaultCredentialsDelegateAccessTokenProvider implements AccessTokenProvider {
 
+  private String config;
   private GoogleCredentials delegate;
-  private String token;
   private int callCount = 0;
 
   public DefaultCredentialsDelegateAccessTokenProvider() {
+    this(null);
+  }
+
+  public DefaultCredentialsDelegateAccessTokenProvider(String config) {
+    this.config = config;
     try {
       this.delegate = GoogleCredentials.getApplicationDefault();
     } catch (IOException e) {
@@ -44,24 +47,19 @@ public class DefaultCredentialsDelegateAccessTokenProvider implements AccessToke
     }
   }
 
-  public DefaultCredentialsDelegateAccessTokenProvider(String token) {
-    this.token = token;
-  }
-
   @Override
   public AccessToken getAccessToken() throws IOException {
-    checkState(delegate != null || token != null);
-    if (token != null) {
-      return new AccessToken(token, new Date(System.currentTimeMillis() + 2000));
-    } else {
-      com.google.auth.oauth2.AccessToken accessToken = delegate.refreshAccessToken();
-      callCount++;
-      return new AccessToken(
-          accessToken.getTokenValue(), new Date(System.currentTimeMillis() + 2000));
-    }
+    com.google.auth.oauth2.AccessToken accessToken = delegate.refreshAccessToken();
+    callCount++;
+    return new AccessToken(
+        accessToken.getTokenValue(), new Date(System.currentTimeMillis() + 2000));
   }
 
   int getCallCount() {
     return callCount;
+  }
+
+  String getConfig() {
+    return config;
   }
 }

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -134,6 +134,7 @@ public class SparkBigQueryConfig
   String parentProjectId;
   boolean useParentProjectForMetadataOperations;
   com.google.common.base.Optional<String> accessTokenProviderFQCN;
+  com.google.common.base.Optional<String> accessTokenProviderConfig;
   com.google.common.base.Optional<String> credentialsKey;
   com.google.common.base.Optional<String> credentialsFile;
   com.google.common.base.Optional<String> accessToken;
@@ -283,6 +284,8 @@ public class SparkBigQueryConfig
     config.useParentProjectForMetadataOperations =
         getAnyBooleanOption(globalOptions, options, "useParentProjectForMetadataOperations", false);
     config.accessTokenProviderFQCN = getAnyOption(globalOptions, options, "gcpAccessTokenProvider");
+    config.accessTokenProviderConfig =
+        getAnyOption(globalOptions, options, "gcpAccessTokenProviderConfig");
     config.accessToken = getAnyOption(globalOptions, options, "gcpAccessToken");
     config.credentialsKey = getAnyOption(globalOptions, options, "credentials");
     config.credentialsFile =
@@ -530,6 +533,7 @@ public class SparkBigQueryConfig
 
     return new BigQueryCredentialsSupplier(
             accessTokenProviderFQCN.toJavaUtil(),
+            accessTokenProviderConfig.toJavaUtil(),
             accessToken.toJavaUtil(),
             credentialsKey.toJavaUtil(),
             credentialsFile.toJavaUtil(),
@@ -573,6 +577,11 @@ public class SparkBigQueryConfig
   @Override
   public Optional<String> getAccessTokenProviderFQCN() {
     return accessTokenProviderFQCN.toJavaUtil();
+  }
+
+  @Override
+  public Optional<String> getAccessTokenProviderConfig() {
+    return accessTokenProviderConfig.toJavaUtil();
   }
 
   @Override


### PR DESCRIPTION
A replacement for https://github.com/GoogleCloudDataproc/spark-bigquery-connector/pull/811. The goal here is to let a custom `AccessTokenProvider` be passed optional configuration via read options. 