### PR TITLE
Issue #908: setting the preferred min parallelism to be not more than max parallelism

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@
 * GAX has been upgraded to version 2.23.0
 * gRPC has been upgraded to version 1.53.0
 * Netty has been upgraded to version 4.1.89.Final
-* PR #915: Fixing the Issue #908
+* Issue #908: Fixing the `preferred_min_stream_count` must be less than or equal to `max_stream_count`
 
 ## 0.28.1 - 2023-02-27
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@
 * GAX has been upgraded to version 2.23.0
 * gRPC has been upgraded to version 1.53.0
 * Netty has been upgraded to version 4.1.89.Final
-* Issue #908: Fixing the `preferred_min_stream_count` must be less than or equal to `max_stream_count`
+* Issue #908: Making sure that `preferred_min_stream_count` must be less than or equal to `max_stream_count`
 
 ## 0.28.1 - 2023-02-27
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 * GAX has been upgraded to version 2.23.0
 * gRPC has been upgraded to version 1.53.0
 * Netty has been upgraded to version 4.1.89.Final
+* PR #915: Fixing the Issue #908
 
 ## 0.28.1 - 2023-02-27
 

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreator.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreator.java
@@ -133,7 +133,7 @@ public class ReadSessionCreator {
     int minStreamCount = preferredMinStreamCount;
     if (minStreamCount > maxStreamCount) {
       minStreamCount = maxStreamCount;
-      log.debug(
+      log.warn(
           "preferred min parallelism is larger than the max parallelism, therefore setting it to max parallelism [{}]",
           minStreamCount);
     }

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreator.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreator.java
@@ -130,6 +130,13 @@ public class ReadSessionCreator {
                   log.debug("using default max parallelism [{}]", defaultMaxStreamCount);
                   return defaultMaxStreamCount;
                 });
+    int minStreamCount = preferredMinStreamCount;
+    if (minStreamCount > maxStreamCount) {
+      minStreamCount = maxStreamCount;
+      log.debug(
+          "preferred min parallelism is larger than the max parallelism, therefore setting it to max parallelism [{}]",
+          minStreamCount);
+    }
     Instant sessionPrepEndTime = Instant.now();
 
     ReadSession readSession =
@@ -144,7 +151,7 @@ public class ReadSessionCreator {
                         .setTable(tablePath)
                         .build())
                 .setMaxStreamCount(maxStreamCount)
-                .setPreferredMinStreamCount(Math.min(preferredMinStreamCount, maxStreamCount))
+                .setPreferredMinStreamCount(minStreamCount)
                 .build());
 
     if (readSession != null) {

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreator.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreator.java
@@ -144,7 +144,7 @@ public class ReadSessionCreator {
                         .setTable(tablePath)
                         .build())
                 .setMaxStreamCount(maxStreamCount)
-                .setPreferredMinStreamCount(preferredMinStreamCount)
+                .setPreferredMinStreamCount(Math.min(preferredMinStreamCount, maxStreamCount))
                 .build());
 
     if (readSession != null) {


### PR DESCRIPTION
https://github.com/GoogleCloudDataproc/spark-bigquery-connector/issues/908