### PR TITLE
Remove one level of indirection in ArrowSchemaConverter.

### DIFF
--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/ArrowBinaryIterator.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/ArrowBinaryIterator.java
@@ -103,7 +103,8 @@ public class ArrowBinaryIterator implements Iterator<InternalRow> {
             .map(name -> root.getVector(name))
             .map(
                 vector ->
-                    new ArrowSchemaConverter(vector, userProvidedFieldMap.get(vector.getName())))
+                    ArrowSchemaConverter.newArrowSchemaConverter(
+                        vector, userProvidedFieldMap.get(vector.getName())))
             .collect(Collectors.toList())
             .toArray(new ColumnVector[0]);
 

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/ArrowColumnBatchPartitionReaderContext.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/ArrowColumnBatchPartitionReaderContext.java
@@ -259,7 +259,7 @@ public class ArrowColumnBatchPartitionReaderContext
               .map(root::getVector)
               .map(
                   vector ->
-                      new ArrowSchemaConverter(vector, userProvidedFieldMap.get(vector.getName())))
+                      ArrowSchemaConverter.newArrowSchemaConverter(vector, userProvidedFieldMap.get(vector.getName())))
               .toArray(ColumnVector[]::new);
 
       currentBatch = new ColumnarBatch(columns);

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/ArrowColumnBatchPartitionReaderContext.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/ArrowColumnBatchPartitionReaderContext.java
@@ -259,7 +259,8 @@ public class ArrowColumnBatchPartitionReaderContext
               .map(root::getVector)
               .map(
                   vector ->
-                      ArrowSchemaConverter.newArrowSchemaConverter(vector, userProvidedFieldMap.get(vector.getName())))
+                      ArrowSchemaConverter.newArrowSchemaConverter(
+                          vector, userProvidedFieldMap.get(vector.getName())))
               .toArray(ColumnVector[]::new);
 
       currentBatch = new ColumnarBatch(columns);


### PR DESCRIPTION
- Make ArrowSchemaConverter Generic
- Changes all accessors to now extend ArrowSchemaConverter
- Instantiates new classes via static factory method instead of direct constructor.
- Moves null checks to each concrete implementation.  While I believe JVM should be able to optimize based on the parent method, I'm not 100% sure and this way JVM should be able to avoid megamorphic dispatch for sure (also eliminate old work around from a [bug in Arrow 0.9](https://github.com/apache/spark/commit/e50a37a587fd7db48b59e37f234f8c74bd6707f7) for checks.
- Move child fields to StructAccessor (hopefully keeps more common classes smaller).