### PR TITLE
Allow maxParallelism to be specified via spark properties

### DIFF
--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -299,8 +299,7 @@ public class SparkBigQueryConfig
     config.filter = getOption(options, "filter");
     config.schema = fromJavaUtil(schema);
     config.maxParallelism =
-        getOptionFromMultipleParams(
-                options, ImmutableList.of("maxParallelism", "parallelism"), DEFAULT_FALLBACK)
+        getAnyOption(globalOptions, options, ImmutableList.of("maxParallelism", "parallelism"))
             .transform(Integer::valueOf)
             .orNull();
     config.preferredMinParallelism =


### PR DESCRIPTION
This would allow users to specify the maxParallelism as `spark.datasource.bigquery.maxParallelism`