### PR TITLE
Add support for writing BigNumeric

### DIFF
--- a/README.md
+++ b/README.md
@@ -923,7 +923,7 @@ The BigNumeric data can be accessed via BigNumericUDT DataType which internally 
 to hold the BigNumeric data. The data can be read in either AVRO or ARROW formats.
 
 In order to write BigNumericUDT to BigQuery, use either ORC or PARQUET intermediate formats (currently we do not support
-AVRO). Notice that the data gets written to BigQuery as String.
+AVRO).
 
 Code examples:
 

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/ProtobufUtils.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/ProtobufUtils.java
@@ -106,7 +106,7 @@ public class ProtobufUtils {
                   LegacySQLTypeName.NUMERIC, DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING)
               .put(
                   LegacySQLTypeName.BIGNUMERIC,
-                  DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING)
+                  DescriptorProtos.FieldDescriptorProto.Type.TYPE_BYTES)
               .put(LegacySQLTypeName.STRING, DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING)
               .put(LegacySQLTypeName.JSON, DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING)
               .put(
@@ -145,7 +145,7 @@ public class ProtobufUtils {
                   NUMERIC_SPARK_TYPE.json(), DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING)
               .put(
                   BigQueryDataTypes.BigNumericType.json(),
-                  DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING)
+                  DescriptorProtos.FieldDescriptorProto.Type.TYPE_BYTES)
               .put(
                   DataTypes.StringType.json(),
                   DescriptorProtos.FieldDescriptorProto.Type.TYPE_STRING)

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/ProtobufUtils.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/ProtobufUtils.java
@@ -424,7 +424,7 @@ public class ProtobufUtils {
     }
 
     if (sparkType instanceof BigNumericUDT) {
-      return sparkValue.toString();
+      return sparkValue;
     }
 
     if (sparkType instanceof BooleanType) {

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SchemaConverters.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SchemaConverters.java
@@ -180,9 +180,7 @@ public class SchemaConverters {
     }
 
     if (LegacySQLTypeName.BIGNUMERIC.equals(bqField.getType())) {
-      byte[] bytes = getBytes((ByteBuffer) value);
-      BigDecimal bigDecimal = new BigDecimal(new BigInteger(bytes), BQ_BIG_NUMERIC_SCALE);
-      return UTF8String.fromString(bigDecimal.toString());
+      return getBytes((ByteBuffer) value);
     }
 
     if (LegacySQLTypeName.RECORD.equals(bqField.getType())) {

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/AvroSchemaConverterTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/AvroSchemaConverterTest.java
@@ -82,8 +82,8 @@ public class AvroSchemaConverterTest {
                 null,
                 false,
                 ImmutableList.of(
-                    new Schema.Field("min", nullable(Schema.Type.STRING), null, (Object) null),
-                    new Schema.Field("max", nullable(Schema.Type.STRING), null, (Object) null)))));
+                    new Schema.Field("min", nullable(Schema.Type.BYTES), null, (Object) null),
+                    new Schema.Field("max", nullable(Schema.Type.BYTES), null, (Object) null)))));
 
     checkField(fields[12], "int_arr", nullable(Schema.createArray(nullable(Schema.Type.LONG))));
     checkField(

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/ProtobufUtilsTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/ProtobufUtilsTest.java
@@ -93,7 +93,7 @@ public class ProtobufUtilsTest {
                                 .addField(
                                     PROTO_STRING_FIELD.clone().setName("Numeric").setNumber(9))
                                 .addField(
-                                    PROTO_STRING_FIELD.clone().setName("BigNumeric").setNumber(10))
+                                    PROTO_BYTES_FIELD.clone().setName("BigNumeric").setNumber(10))
                                 .addField(
                                     PROTO_INTEGER_FIELD.clone().setName("TimeStamp").setNumber(11))
                                 .setName("Schema")
@@ -142,8 +142,7 @@ public class ProtobufUtilsTest {
                             new MathContext(BQ_NUMERIC_PRECISION)),
                         BQ_NUMERIC_PRECISION,
                         BQ_NUMERIC_SCALE),
-                    UTF8String.fromString(
-                        "-578960446186580977117854925043439539266.34992332820282019728792003956564819968")
+                    new byte[] {11, 0x7F}
                   })
             });
 
@@ -254,7 +253,7 @@ public class ProtobufUtilsTest {
       Field.newBuilder("Numeric", LegacySQLTypeName.NUMERIC).setMode(Field.Mode.REQUIRED).build();
   public final Field BIGQUERY_BIGNUMERIC_FIELD =
       Field.newBuilder("BigNumeric", LegacySQLTypeName.BIGNUMERIC)
-          .setMode(Field.Mode.REQUIRED)
+          .setMode(Field.Mode.NULLABLE)
           .build();
 
   public final Schema BIG_BIGQUERY_SCHEMA =
@@ -391,9 +390,7 @@ public class ProtobufUtilsTest {
                   .setField(
                       BIG_SCHEMA_ROW_DESCRIPTOR.findFieldByNumber(10),
                       "-99999999999999999999999999999.999999999")
-                  .setField(
-                      BIG_SCHEMA_ROW_DESCRIPTOR.findFieldByNumber(11),
-                      "-578960446186580977117854925043439539266.34992332820282019728792003956564819968")
+                  .setField(BIG_SCHEMA_ROW_DESCRIPTOR.findFieldByNumber(11), new byte[] {11, 0x7F})
                   .build()
                   .toByteString())
           .build();


### PR DESCRIPTION
Current version on Spark BigQuery Connector is not supporting for wring BigNumeric to BigQuery.
According to [BigQuery Storage API Doc](https://cloud.google.com/bigquery/docs/write-api#data_type_conversions), storage API supports writing BigNumeric with ByteString protobuf. To support writing BigNumeric,
1. I changed protobuf from String to ByteString
2. I changed BigNumericUDT to use BigDecimalByteStringEncoder for encoding/decoding BigDecimal