### PR TITLE
Cache ReadSession response

### DIFF
--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreator.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreator.java
@@ -100,10 +100,10 @@ public class ReadSessionCreator {
     ReadSession.Builder requestedSession = request.getReadSession().toBuilder();
     config.getTraceId().ifPresent(traceId -> requestedSession.setTraceId(traceId));
 
-    if (isInputTableAView(tableDetails)) {
-      filter = Optional.empty();
-    }
     TableReadOptions.Builder readOptions = requestedSession.getReadOptionsBuilder();
+    if (!isInputTableAView(tableDetails)) {
+      filter.ifPresent(readOptions::setRowRestriction);
+    }
     filter.ifPresent(readOptions::setRowRestriction);
     readOptions.addAllSelectedFields(selectedFields);
     readOptions.setArrowSerializationOptions(

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreator.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreator.java
@@ -104,7 +104,6 @@ public class ReadSessionCreator {
     if (!isInputTableAView(tableDetails)) {
       filter.ifPresent(readOptions::setRowRestriction);
     }
-    filter.ifPresent(readOptions::setRowRestriction);
     readOptions.addAllSelectedFields(selectedFields);
     readOptions.setArrowSerializationOptions(
         ArrowSerializationOptions.newBuilder()

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfig.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfig.java
@@ -40,6 +40,7 @@ public class ReadSessionCreatorConfig {
   private final int streamsPerPartition;
   private final CompressionCodec arrowCompressionCodec;
   private final Optional<String> traceId;
+  private final boolean enableReadSessionCaching;
 
   ReadSessionCreatorConfig(
       boolean viewsEnabled,
@@ -60,7 +61,8 @@ public class ReadSessionCreatorConfig {
       int prebufferResponses,
       int streamsPerPartition,
       CompressionCodec arrowCompressionCodec,
-      Optional<String> traceId) {
+      Optional<String> traceId,
+      boolean enableReadSessionCaching) {
     this.viewsEnabled = viewsEnabled;
     this.materializationProject = materializationProject;
     this.materializationDataset = materializationDataset;
@@ -80,6 +82,7 @@ public class ReadSessionCreatorConfig {
     this.streamsPerPartition = streamsPerPartition;
     this.arrowCompressionCodec = arrowCompressionCodec;
     this.traceId = traceId;
+    this.enableReadSessionCaching = enableReadSessionCaching;
   }
 
   public boolean isViewsEnabled() {
@@ -164,5 +167,9 @@ public class ReadSessionCreatorConfig {
 
   public OptionalInt getPreferredMinParallelism() {
     return preferredMinParallelism;
+  }
+
+  public boolean isReadSessionCachingEnabled() {
+    return enableReadSessionCaching;
   }
 }

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfigBuilder.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfigBuilder.java
@@ -42,6 +42,7 @@ public class ReadSessionCreatorConfigBuilder {
   int streamsPerPartition = 1;
   private CompressionCodec arrowCompressionCodec = CompressionCodec.COMPRESSION_UNSPECIFIED;
   private Optional<String> traceId = Optional.empty();
+  private boolean enableReadSessionCaching = false;
 
   @CanIgnoreReturnValue
   public ReadSessionCreatorConfigBuilder setViewsEnabled(boolean viewsEnabled) {
@@ -165,6 +166,12 @@ public class ReadSessionCreatorConfigBuilder {
     return this;
   }
 
+  public ReadSessionCreatorConfigBuilder setEnableReadSessionCaching(
+      boolean enableReadSessionCaching) {
+    this.enableReadSessionCaching = enableReadSessionCaching;
+    return this;
+  }
+
   public ReadSessionCreatorConfig build() {
     return new ReadSessionCreatorConfig(
         viewsEnabled,
@@ -185,6 +192,7 @@ public class ReadSessionCreatorConfigBuilder {
         prebufferResponses,
         streamsPerPartition,
         arrowCompressionCodec,
-        traceId);
+        traceId,
+        enableReadSessionCaching);
   }
 }

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -177,6 +177,7 @@ public class SparkBigQueryConfig
   private int numStreamsPerPartition = MIN_STREAMS_PER_PARTITION;
   private com.google.common.base.Optional<Integer> flowControlWindowBytes =
       com.google.common.base.Optional.absent();
+  private boolean enableReadSessionCaching = false;
   private SparkBigQueryProxyAndHttpConfig sparkBigQueryProxyAndHttpConfig;
   private CompressionCodec arrowCompressionCodec = DEFAULT_ARROW_COMPRESSION_CODEC;
   private WriteMethod writeMethod = DEFAULT_WRITE_METHOD;
@@ -413,6 +414,8 @@ public class SparkBigQueryConfig
         getAnyOption(globalOptions, options, "bqNumStreamsPerPartition")
             .transform(Integer::parseInt)
             .or(MIN_STREAMS_PER_PARTITION);
+    config.enableReadSessionCaching =
+        getAnyBooleanOption(globalOptions, options, "enableReadSessionCaching", false);
 
     String arrowCompressionCodecParam =
         getAnyOption(globalOptions, options, ARROW_COMPRESSION_CODEC_OPTION)
@@ -850,6 +853,7 @@ public class SparkBigQueryConfig
         .setStreamsPerPartition(numStreamsPerPartition)
         .setArrowCompressionCodec(arrowCompressionCodec)
         .setTraceId(traceId.toJavaUtil())
+        .setEnableReadSessionCaching(enableReadSessionCaching)
         .build();
   }
 


### PR DESCRIPTION
ReadSession creation is a huge bottleneck for performance. Caching the ReadSession response allows queries to reuse the existing ReadSession when we encounter the same table, filters, columns combination. 