### PR TITLE
additional scan perf tuning.

### DIFF
--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryConfig.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryConfig.java
@@ -41,6 +41,7 @@ public class BigQueryClientFactoryConfig implements BigQueryConfig {
   private final int cacheExpirationTimeInMinutes;
   private final ImmutableMap<String, String> bigQueryJobLabels;
   private final Optional<Long> createReadSessionTimeoutInSeconds;
+  private final Optional<Integer> flowControlWindowBytes;
 
   BigQueryClientFactoryConfig(BigQueryConfig bigQueryConfig) {
     this.accessTokenProviderFQCN = bigQueryConfig.getAccessTokenProviderFQCN();
@@ -63,6 +64,7 @@ public class BigQueryClientFactoryConfig implements BigQueryConfig {
     this.cacheExpirationTimeInMinutes = bigQueryConfig.getCacheExpirationTimeInMinutes();
     this.bigQueryJobLabels = bigQueryConfig.getBigQueryJobLabels();
     this.createReadSessionTimeoutInSeconds = bigQueryConfig.getCreateReadSessionTimeoutInSeconds();
+    this.flowControlWindowBytes = bigQueryConfig.getFlowControlWindowBytes();
   }
 
   @Override
@@ -161,6 +163,11 @@ public class BigQueryClientFactoryConfig implements BigQueryConfig {
   }
 
   @Override
+  public Optional<Integer> getFlowControlWindowBytes() {
+    return flowControlWindowBytes;
+  }
+
+  @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
@@ -185,7 +192,8 @@ public class BigQueryClientFactoryConfig implements BigQueryConfig {
         && Objects.equal(bigQueryStorageGrpcEndpoint, that.bigQueryStorageGrpcEndpoint)
         && Objects.equal(bigQueryHttpEndpoint, that.bigQueryHttpEndpoint)
         && Objects.equal(cacheExpirationTimeInMinutes, that.cacheExpirationTimeInMinutes)
-        && Objects.equal(createReadSessionTimeoutInSeconds, that.createReadSessionTimeoutInSeconds);
+        && Objects.equal(createReadSessionTimeoutInSeconds, that.createReadSessionTimeoutInSeconds)
+        && Objects.equal(flowControlWindowBytes, that.flowControlWindowBytes);
   }
 
   @Override
@@ -205,6 +213,7 @@ public class BigQueryClientFactoryConfig implements BigQueryConfig {
         bigQueryProxyConfig,
         bigQueryStorageGrpcEndpoint,
         bigQueryHttpEndpoint,
-        cacheExpirationTimeInMinutes);
+        cacheExpirationTimeInMinutes,
+        flowControlWindowBytes);
   }
 }

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfig.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfig.java
@@ -58,4 +58,8 @@ public interface BigQueryConfig {
   ImmutableMap<String, String> getBigQueryJobLabels();
 
   Optional<Long> getCreateReadSessionTimeoutInSeconds();
+
+  // Get a static flow control window per RPC. When not set
+  // auto flow control is determined by Bandwidth Delay Product.
+  Optional<Integer> getFlowControlWindowBytes();
 }

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryTest.java
@@ -436,6 +436,11 @@ public class BigQueryClientFactoryTest {
     }
 
     @Override
+    public Optional<Integer> getFlowControlWindowBytes() {
+      return Optional.of(2 << 20);
+    }
+
+    @Override
     public boolean equals(Object o) {
       if (this == o) {
         return true;

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -175,6 +175,8 @@ public class SparkBigQueryConfig
   private int numBackgroundThreadsPerStream = 0;
   private int numPrebufferReadRowsResponses = MIN_BUFFERED_RESPONSES_PER_STREAM;
   private int numStreamsPerPartition = MIN_STREAMS_PER_PARTITION;
+  private com.google.common.base.Optional<Integer> flowControlWindowBytes =
+      com.google.common.base.Optional.absent();
   private SparkBigQueryProxyAndHttpConfig sparkBigQueryProxyAndHttpConfig;
   private CompressionCodec arrowCompressionCodec = DEFAULT_ARROW_COMPRESSION_CODEC;
   private WriteMethod writeMethod = DEFAULT_WRITE_METHOD;
@@ -403,6 +405,10 @@ public class SparkBigQueryConfig
         getAnyOption(globalOptions, options, "bqPrebufferResponsesPerStream")
             .transform(Integer::parseInt)
             .or(MIN_BUFFERED_RESPONSES_PER_STREAM);
+    config.flowControlWindowBytes =
+        getAnyOption(globalOptions, options, "bqFlowControlWindowBytes")
+            .transform(Integer::parseInt);
+
     config.numStreamsPerPartition =
         getAnyOption(globalOptions, options, "bqNumStreamsPerPartition")
             .transform(Integer::parseInt)
@@ -778,6 +784,11 @@ public class SparkBigQueryConfig
 
   public ZoneId getDatetimeZoneId() {
     return datetimeZoneId;
+  }
+
+  @Override
+  public Optional<Integer> getFlowControlWindowBytes() {
+    return flowControlWindowBytes.toJavaUtil();
   }
 
   @Override

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -905,6 +905,22 @@ public class SparkBigQueryConfigTest {
   }
 
   @Test
+  public void testBqFlowControWindow() {
+    SparkBigQueryConfig config =
+        SparkBigQueryConfig.from(
+            asDataSourceOptionsMap(withParameter("bqFlowControlWindowBytes", "12345")),
+            emptyMap, // allConf
+            new Configuration(),
+            emptyMap, // customDefaults
+            1,
+            new SQLConf(),
+            sparkVersion,
+            /* schema */ Optional.empty(),
+            /* tableIsMandatory */ true);
+    assertThat(config.getFlowControlWindowBytes()).isEqualTo(Optional.of(12345));
+  }
+
+  @Test
   public void testBadCredentials() {
     SparkBigQueryConfig config =
         SparkBigQueryConfig.from(
@@ -937,7 +953,7 @@ public class SparkBigQueryConfigTest {
   }
 
   @Test
-  public void testEnableListInterfaceWithDefaultIntermediateFormat() {
+  public void testEnableListInferenceWithDefaultIntermediateFormat() {
     SparkBigQueryConfig config =
         SparkBigQueryConfig.from(
             asDataSourceOptionsMap(withParameter("enableListInference", "true")),


### PR DESCRIPTION
- Add configuration to control netty flow control window size
- Add backpressure to StreamCombining iterator

Together these appear to improve over baseline performance when using parameters below by 10-15% over basic line items aggregation (on my cluster 330 seconds to 300 seconds or slightly less).  When trying to understand the impact of each change, it appears flow control + buffering responses accounts for 7-10%, the backpression accounts for 3-5% but seems to reduce overall variance across runs.

Also the backpressure potentially indicates we can additionally tune Netty/gRPC thread pools to potentially avoid contention. I think in general they use number of cores on the box for sizing which makes less sense if Spark splits executors across multiple JVMs on the same box (I don't have any plans to investigate this further).

Parameters that see improved performance:
spark.datasource.bigquery.bqFlowControlWindowBytes=64435456 spark.datasource.bigquery.bqPrebufferResponsesPerStream=100