### PR TITLE
Add support for service account impersonation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * Issue #945: Fixing unable to add new column even with option `allowFieldAddition`
 * PR #951: Adding support to create BigQueryReadClient with UnboundedScheduledExecutorService
 * PR #965: Fix to reuse the same BigQueryClient for the same BigQueryConfig, rather than creating a new one.
+* PR #950: Added support for service account impersonation
 
 ## 0.30.0 - 2023-04-11
 

--- a/README-template.md
+++ b/README-template.md
@@ -1239,6 +1239,28 @@ spark.conf.set("gcpAccessTokenProvider", "com.example.ExampleAccessTokenProvider
 // Per read/Write
 spark.read.format("bigquery").option("gcpAccessTokenProvider", "com.example.ExampleAccessTokenProvider")
 ```
+* Service account impersonation can be configured for a specific username and a group name, or
+  for all users by default using below properties:
+
+  - `gcpImpersonationServiceAccountForUser_<USER_NAME>` (not set by default)
+
+    The service account impersonation for a specific user.
+
+  - `gcpImpersonationServiceAccountForGroup_<GROUP_NAME>` (not set by default)
+
+    The service account impersonation for a specific group.
+
+  - `gcpImpersonationServiceAccount` (not set by default)
+
+    Default service account impersonation for all users.
+
+  If any of the above properties are set then the service account specified will be impersonated by
+  generating a short-lived credentials when accessing BigQuery.
+
+  If more than one property is set then the service account associated with the username will take
+  precedence over the service account associated with the group name for a matching user and group,
+  which in turn will take precedence over default service account impersonation.
+
 * For a simpler application, where access token refresh is not required, another alternative is to pass the access token
   as the `gcpAccessToken` configuration option. You can get the access token by running
   `gcloud auth application-default print-access-token`.

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryConfig.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryConfig.java
@@ -20,7 +20,9 @@ import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.QueryJobConfiguration.Priority;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public class BigQueryClientFactoryConfig implements BigQueryConfig {
 
@@ -29,6 +31,11 @@ public class BigQueryClientFactoryConfig implements BigQueryConfig {
   private final Optional<String> credentialsKey;
   private final Optional<String> credentialsFile;
   private final Optional<String> accessToken;
+  private final String loggedInUserName;
+  private final Set<String> loggedInUserGroups;
+  private final Optional<String> impersonationServiceAccount;
+  private final Optional<Map<String, String>> impersonationServiceAccountsForUsers;
+  private final Optional<Map<String, String>> impersonationServiceAccountsForGroups;
   private final String parentProjectId;
   private final boolean useParentProjectForMetadataOperations;
   private final boolean viewsEnabled;
@@ -52,6 +59,13 @@ public class BigQueryClientFactoryConfig implements BigQueryConfig {
     this.credentialsKey = bigQueryConfig.getCredentialsKey();
     this.credentialsFile = bigQueryConfig.getCredentialsFile();
     this.accessToken = bigQueryConfig.getAccessToken();
+    this.loggedInUserName = bigQueryConfig.getLoggedInUserName();
+    this.loggedInUserGroups = bigQueryConfig.getLoggedInUserGroups();
+    this.impersonationServiceAccountsForUsers =
+        bigQueryConfig.getImpersonationServiceAccountsForUsers();
+    this.impersonationServiceAccountsForGroups =
+        bigQueryConfig.getImpersonationServiceAccountsForGroups();
+    this.impersonationServiceAccount = bigQueryConfig.getImpersonationServiceAccount();
     this.parentProjectId = bigQueryConfig.getParentProjectId();
     this.useParentProjectForMetadataOperations =
         bigQueryConfig.useParentProjectForMetadataOperations();
@@ -94,6 +108,31 @@ public class BigQueryClientFactoryConfig implements BigQueryConfig {
   @Override
   public Optional<String> getAccessToken() {
     return accessToken;
+  }
+
+  @Override
+  public String getLoggedInUserName() {
+    return loggedInUserName;
+  }
+
+  @Override
+  public Set<String> getLoggedInUserGroups() {
+    return loggedInUserGroups;
+  }
+
+  @Override
+  public Optional<Map<String, String>> getImpersonationServiceAccountsForUsers() {
+    return impersonationServiceAccountsForUsers;
+  }
+
+  @Override
+  public Optional<Map<String, String>> getImpersonationServiceAccountsForGroups() {
+    return impersonationServiceAccountsForGroups;
+  }
+
+  @Override
+  public Optional<String> getImpersonationServiceAccount() {
+    return impersonationServiceAccount;
   }
 
   @Override

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientModule.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientModule.java
@@ -63,6 +63,11 @@ public class BigQueryClientModule implements com.google.inject.Module {
         config.getAccessToken(),
         config.getCredentialsKey(),
         config.getCredentialsFile(),
+        config.getLoggedInUserName(),
+        config.getLoggedInUserGroups(),
+        config.getImpersonationServiceAccountsForUsers(),
+        config.getImpersonationServiceAccountsForGroups(),
+        config.getImpersonationServiceAccount(),
         proxyConfig.getProxyUri(),
         proxyConfig.getProxyUsername(),
         proxyConfig.getProxyPassword());

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfig.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfig.java
@@ -19,7 +19,9 @@ import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.bigquery.QueryJobConfiguration.Priority;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public interface BigQueryConfig {
 
@@ -32,6 +34,16 @@ public interface BigQueryConfig {
   Optional<String> getCredentialsFile();
 
   Optional<String> getAccessToken();
+
+  String getLoggedInUserName();
+
+  Set<String> getLoggedInUserGroups();
+
+  Optional<Map<String, String>> getImpersonationServiceAccountsForUsers();
+
+  Optional<Map<String, String>> getImpersonationServiceAccountsForGroups();
+
+  Optional<String> getImpersonationServiceAccount();
 
   String getParentProjectId();
 

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfigurationUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfigurationUtil.java
@@ -25,6 +25,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -73,6 +74,39 @@ public class BigQueryConfigurationUtil {
         .filter(com.google.common.base.Optional::isPresent)
         .findFirst()
         .orElseGet(fallback);
+  }
+
+  public static Map<String, String> getMapEntriesWithPrefix(
+      Map<String, String> map, String prefix) {
+    Map<String, String> result = new HashMap();
+    for (Map.Entry<String, String> entry : map.entrySet()) {
+      if (entry.getKey().startsWith(prefix)) {
+        result.put(entry.getKey(), entry.getValue());
+      }
+    }
+    return result;
+  }
+
+  public static com.google.common.base.Optional<Map<String, String>> removePrefixFromMapKeys(
+      com.google.common.base.Optional<Map<String, String>> map, String prefix) {
+    Map<String, String> modifiedMap = new HashMap<>();
+    if (map.isPresent()) {
+      for (Map.Entry<String, String> entry : map.get().entrySet()) {
+        String originalKey = entry.getKey();
+        String modifiedKey =
+            originalKey.startsWith(prefix) ? originalKey.substring(prefix.length()) : originalKey;
+        modifiedMap.put(modifiedKey, entry.getValue());
+      }
+    }
+    return com.google.common.base.Optional.of(modifiedMap);
+  }
+
+  public static com.google.common.base.Optional<Map<String, String>> getAnyOptionsWithPrefix(
+      ImmutableMap<String, String> globalOptions, Map<String, String> options, String prefix) {
+    Map<String, String> result = getMapEntriesWithPrefix(globalOptions, prefix);
+    Map<String, String> prefixOptions = getMapEntriesWithPrefix(options, prefix);
+    result.putAll(prefixOptions);
+    return com.google.common.base.Optional.of(result);
   }
 
   public static com.google.common.base.Optional<String> getAnyOption(

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryTest.java
@@ -34,7 +34,9 @@ import java.net.URI;
 import java.security.PrivateKey;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.Test;
 
 public class BigQueryClientFactoryTest {
@@ -460,6 +462,31 @@ public class BigQueryClientFactoryTest {
 
     @Override
     public Optional<String> getCredentialsFile() {
+      return Optional.empty();
+    }
+
+    @Override
+    public String getLoggedInUserName() {
+      return null;
+    }
+
+    @Override
+    public Set<String> getLoggedInUserGroups() {
+      return null;
+    }
+
+    @Override
+    public Optional<Map<String, String>> getImpersonationServiceAccountsForUsers() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<Map<String, String>> getImpersonationServiceAccountsForGroups() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> getImpersonationServiceAccount() {
       return Optional.empty();
     }
 

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/integration/CustomCredentialsIntegrationTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/integration/CustomCredentialsIntegrationTest.java
@@ -41,6 +41,11 @@ public class CustomCredentialsIntegrationTest {
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),
+            null,
+            null,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty(),
             Optional.empty());
@@ -68,6 +73,11 @@ public class CustomCredentialsIntegrationTest {
         new BigQueryCredentialsSupplier(
             Optional.of(DefaultCredentialsDelegateAccessTokenProvider.class.getCanonicalName()),
             Optional.of("some-configuration"),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            null,
+            null,
             Optional.empty(),
             Optional.empty(),
             Optional.empty(),


### PR DESCRIPTION
This is modeled after the GCS connector's implementation (https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/master/gcs/CONFIGURATION.md#service-account-impersonation).