### PR TITLE
Switch off V1_BATCH_WRITE for dsv2

### DIFF
--- a/spark-bigquery-dsv2/spark-3.1-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark31BigQueryTable.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark31BigQueryTable.java
@@ -41,7 +41,7 @@ public class Spark31BigQueryTable implements Table, SupportsRead, SupportsWrite 
 
   public static final ImmutableSet<TableCapability> TABLE_CAPABILITIES =
       ImmutableSet.of(
-          TableCapability.BATCH_READ, TableCapability.V1_BATCH_WRITE, TableCapability.TRUNCATE);
+          TableCapability.BATCH_READ, TableCapability.BATCH_WRITE, TableCapability.TRUNCATE);
 
   protected Injector injector;
   protected TableId tableId;


### PR DESCRIPTION
Since there is no support of V1Write in dsv2, should set the Table.Capabilities to v2 BATCH_WRITE