### PR TITLE
changing the hash from BigQueryConfig to BigQueryClientFactoryConfig

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * Issue #945: Fixing unable to add new column even with option `allowFieldAddition`
 * PR #951: Adding support to create BigQueryReadClient with UnboundedScheduledExecutorService
+* PR #965: Fix to reuse the same BigQueryClient for the same BigQueryConfig, rather than creating a new one.
 
 ## 0.30.0 - 2023-04-11
 

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactory.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactory.java
@@ -113,10 +113,10 @@ public class BigQueryClientFactory implements Serializable {
       return Objects.hashCode(
           BigQueryUtil.getCredentialsByteArray(credentials),
           headerProvider,
-          new BigQueryClientFactoryConfig(bqConfig));
+          bqConfig.clientCreationHashCode());
     }
 
-    return Objects.hashCode(credentials, headerProvider, new BigQueryClientFactoryConfig(bqConfig));
+    return Objects.hashCode(credentials, headerProvider, bqConfig.clientCreationHashCode());
   }
 
   @Override
@@ -131,9 +131,7 @@ public class BigQueryClientFactory implements Serializable {
     BigQueryClientFactory that = (BigQueryClientFactory) o;
 
     if (Objects.equal(headerProvider, that.headerProvider)
-        && Objects.equal(
-            new BigQueryClientFactoryConfig(bqConfig),
-            new BigQueryClientFactoryConfig(that.bqConfig))) {
+        && bqConfig.clientCreationEquals(that.bqConfig)) {
       // Here, credentials and that.credentials are instances of GoogleCredentials which can be one
       // of GoogleCredentials, UserCredentials, ServiceAccountCredentials,
       // ExternalAccountCredentials or ImpersonatedCredentials (See the class

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactory.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactory.java
@@ -113,10 +113,10 @@ public class BigQueryClientFactory implements Serializable {
       return Objects.hashCode(
           BigQueryUtil.getCredentialsByteArray(credentials),
           headerProvider,
-          bqConfig.clientCreationHashCode());
+          bqConfig.getClientCreationHashCode());
     }
 
-    return Objects.hashCode(credentials, headerProvider, bqConfig.clientCreationHashCode());
+    return Objects.hashCode(credentials, headerProvider, bqConfig.getClientCreationHashCode());
   }
 
   @Override
@@ -131,7 +131,7 @@ public class BigQueryClientFactory implements Serializable {
     BigQueryClientFactory that = (BigQueryClientFactory) o;
 
     if (Objects.equal(headerProvider, that.headerProvider)
-        && bqConfig.clientCreationEquals(that.bqConfig)) {
+        && bqConfig.areClientCreationConfigsEqual(that.bqConfig)) {
       // Here, credentials and that.credentials are instances of GoogleCredentials which can be one
       // of GoogleCredentials, UserCredentials, ServiceAccountCredentials,
       // ExternalAccountCredentials or ImpersonatedCredentials (See the class

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactory.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactory.java
@@ -111,7 +111,9 @@ public class BigQueryClientFactory implements Serializable {
     // ExternalAccountCredentials first and then compare their hashCodes.
     if (credentials instanceof ExternalAccountCredentials) {
       return Objects.hashCode(
-          BigQueryUtil.getCredentialsByteArray(credentials), headerProvider, new BigQueryClientFactoryConfig(bqConfig));
+          BigQueryUtil.getCredentialsByteArray(credentials),
+          headerProvider,
+          new BigQueryClientFactoryConfig(bqConfig));
     }
 
     return Objects.hashCode(credentials, headerProvider, new BigQueryClientFactoryConfig(bqConfig));

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactory.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactory.java
@@ -111,10 +111,10 @@ public class BigQueryClientFactory implements Serializable {
     // ExternalAccountCredentials first and then compare their hashCodes.
     if (credentials instanceof ExternalAccountCredentials) {
       return Objects.hashCode(
-          BigQueryUtil.getCredentialsByteArray(credentials), headerProvider, bqConfig);
+          BigQueryUtil.getCredentialsByteArray(credentials), headerProvider, new BigQueryClientFactoryConfig(bqConfig));
     }
 
-    return Objects.hashCode(credentials, headerProvider, bqConfig);
+    return Objects.hashCode(credentials, headerProvider, new BigQueryClientFactoryConfig(bqConfig));
   }
 
   @Override

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfig.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfig.java
@@ -67,7 +67,7 @@ public interface BigQueryConfig {
 
   Priority getQueryJobPriority();
 
-  default int clientCreationHashCode() {
+  default int getClientCreationHashCode() {
     return Objects.hashCode(
         getAccessTokenProviderFQCN(),
         getAccessTokenProviderConfig(),
@@ -83,7 +83,7 @@ public interface BigQueryConfig {
         useParentProjectForMetadataOperations());
   }
 
-  default boolean clientCreationEquals(BigQueryConfig b) {
+  default boolean areClientCreationConfigsEqual(BigQueryConfig b) {
     if (this == b) {
       return true;
     }

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfig.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfig.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigquery.connector.common;
 
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.cloud.bigquery.QueryJobConfiguration.Priority;
+import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
 import java.util.Optional;
 
@@ -65,4 +66,40 @@ public interface BigQueryConfig {
   Optional<Integer> getFlowControlWindowBytes();
 
   Priority getQueryJobPriority();
+
+  default int clientCreationHashCode() {
+    return Objects.hashCode(
+        getAccessTokenProviderFQCN(),
+        getAccessTokenProviderConfig(),
+        getCredentialsKey(),
+        getAccessToken(),
+        getCredentialsFile(),
+        getBigQueryHttpEndpoint(),
+        getFlowControlWindowBytes(),
+        getBigQueryStorageGrpcEndpoint(),
+        getCreateReadSessionTimeoutInSeconds(),
+        getBigQueryProxyConfig(),
+        getParentProjectId(),
+        useParentProjectForMetadataOperations());
+  }
+
+  default boolean clientCreationEquals(BigQueryConfig b) {
+    if (this == b) {
+      return true;
+    }
+    return Objects.equal(getAccessTokenProviderFQCN(), b.getAccessTokenProviderFQCN())
+        && Objects.equal(getAccessTokenProviderConfig(), b.getAccessTokenProviderConfig())
+        && Objects.equal(getCredentialsKey(), b.getCredentialsKey())
+        && Objects.equal(getAccessToken(), b.getAccessToken())
+        && Objects.equal(getCredentialsFile(), b.getCredentialsFile())
+        && Objects.equal(getBigQueryHttpEndpoint(), b.getBigQueryHttpEndpoint())
+        && Objects.equal(getFlowControlWindowBytes(), b.getFlowControlWindowBytes())
+        && Objects.equal(getBigQueryStorageGrpcEndpoint(), b.getBigQueryStorageGrpcEndpoint())
+        && Objects.equal(
+            getCreateReadSessionTimeoutInSeconds(), b.getCreateReadSessionTimeoutInSeconds())
+        && Objects.equal(getBigQueryProxyConfig(), b.getBigQueryProxyConfig())
+        && Objects.equal(getParentProjectId(), b.getParentProjectId())
+        && Objects.equal(
+            useParentProjectForMetadataOperations(), b.useParentProjectForMetadataOperations());
+  }
 }

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryTest.java
@@ -333,6 +333,72 @@ public class BigQueryClientFactoryTest {
     assertNotSame(writeClient2, writeClient3);
   }
 
+  @Test
+  public void testGetReadClientWithSameAndDifferentBQConfig() {
+    BigQueryClientFactory clientFactory =
+        new BigQueryClientFactory(bigQueryCredentialsSupplier, headerProvider, bigQueryConfig);
+
+    BigQueryClientFactory clientFactory2 =
+        new BigQueryClientFactory(
+            bigQueryCredentialsSupplier,
+            headerProvider,
+            new TestBigQueryConfig(Optional.of("EU:8080")));
+
+    BigQueryClientFactory clientFactory3 =
+        new BigQueryClientFactory(
+            bigQueryCredentialsSupplier,
+            headerProvider,
+            new TestBigQueryConfig(Optional.of("EU:8080")));
+
+    when(bigQueryConfig.getBigQueryProxyConfig()).thenReturn(bigQueryProxyConfig);
+
+    BigQueryReadClient readClient = clientFactory.getBigQueryReadClient();
+    assertNotNull(readClient);
+
+    BigQueryReadClient readClient2 = clientFactory2.getBigQueryReadClient();
+    assertNotNull(readClient2);
+
+    BigQueryReadClient readClient3 = clientFactory3.getBigQueryReadClient();
+    assertNotNull(readClient3);
+
+    assertNotSame(readClient, readClient2);
+    assertNotSame(readClient, readClient3);
+    assertSame(readClient2, readClient3);
+  }
+
+  @Test
+  public void testGetWriteClientWithSameAndDifferentBQConfig() {
+    BigQueryClientFactory clientFactory =
+        new BigQueryClientFactory(bigQueryCredentialsSupplier, headerProvider, bigQueryConfig);
+
+    BigQueryClientFactory clientFactory2 =
+        new BigQueryClientFactory(
+            bigQueryCredentialsSupplier,
+            headerProvider,
+            new TestBigQueryConfig(Optional.of("EU:8080")));
+
+    BigQueryClientFactory clientFactory3 =
+        new BigQueryClientFactory(
+            bigQueryCredentialsSupplier,
+            headerProvider,
+            new TestBigQueryConfig(Optional.of("EU:8080")));
+
+    when(bigQueryConfig.getBigQueryProxyConfig()).thenReturn(bigQueryProxyConfig);
+
+    BigQueryWriteClient writeClient = clientFactory.getBigQueryWriteClient();
+    assertNotNull(writeClient);
+
+    BigQueryWriteClient writeClient2 = clientFactory2.getBigQueryWriteClient();
+    assertNotNull(writeClient2);
+
+    BigQueryWriteClient writeClient3 = clientFactory3.getBigQueryWriteClient();
+    assertNotNull(writeClient3);
+
+    assertNotSame(writeClient, writeClient2);
+    assertNotSame(writeClient, writeClient3);
+    assertSame(writeClient2, writeClient3);
+  }
+
   private ServiceAccountCredentials createServiceAccountCredentials(String clientId) {
     return ServiceAccountCredentials.newBuilder()
         .setClientId(clientId)
@@ -445,7 +511,7 @@ public class BigQueryClientFactoryTest {
 
     @Override
     public Optional<Long> getCreateReadSessionTimeoutInSeconds() {
-      return Optional.empty();
+      return Optional.of(500L);
     }
 
     @Override

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryTest.java
@@ -107,6 +107,8 @@ public class BigQueryClientFactoryTest {
         new BigQueryClientFactory(bigQueryCredentialsSupplier, headerProvider, bigQueryConfig);
 
     when(bigQueryConfig.getBigQueryProxyConfig()).thenReturn(bigQueryProxyConfig);
+    when(bigQueryConfig.getClientCreationHashCode()).thenReturn(1234);
+    when(bigQueryConfig.areClientCreationConfigsEqual(bigQueryConfig)).thenReturn(true);
 
     BigQueryReadClient readClient = clientFactory.getBigQueryReadClient();
     assertNotNull(readClient);
@@ -115,6 +117,8 @@ public class BigQueryClientFactoryTest {
         new BigQueryClientFactory(bigQueryCredentialsSupplier, headerProvider, bigQueryConfig);
 
     when(bigQueryConfig.getBigQueryProxyConfig()).thenReturn(bigQueryProxyConfig);
+    when(bigQueryConfig.getClientCreationHashCode()).thenReturn(1234);
+    when(bigQueryConfig.areClientCreationConfigsEqual(bigQueryConfig)).thenReturn(true);
 
     BigQueryReadClient readClient2 = clientFactory2.getBigQueryReadClient();
     assertNotNull(readClient2);
@@ -128,6 +132,8 @@ public class BigQueryClientFactoryTest {
             bigQueryConfig);
 
     when(bigQueryConfig.getBigQueryProxyConfig()).thenReturn(bigQueryProxyConfig);
+    when(bigQueryConfig.getClientCreationHashCode()).thenReturn(1234);
+    when(bigQueryConfig.areClientCreationConfigsEqual(bigQueryConfig)).thenReturn(true);
 
     BigQueryReadClient readClient3 = clientFactory3.getBigQueryReadClient();
     assertNotNull(readClient3);
@@ -179,6 +185,8 @@ public class BigQueryClientFactoryTest {
         new BigQueryClientFactory(bigQueryCredentialsSupplier, headerProvider, bigQueryConfig);
 
     when(bigQueryConfig.getBigQueryProxyConfig()).thenReturn(bigQueryProxyConfig);
+    when(bigQueryConfig.getClientCreationHashCode()).thenReturn(1234);
+    when(bigQueryConfig.areClientCreationConfigsEqual(bigQueryConfig)).thenReturn(true);
 
     BigQueryReadClient readClient = clientFactory.getBigQueryReadClient();
     assertNotNull(readClient);
@@ -189,6 +197,8 @@ public class BigQueryClientFactoryTest {
         new BigQueryClientFactory(bigQueryCredentialsSupplier, headerProvider, bigQueryConfig);
 
     when(bigQueryConfig.getBigQueryProxyConfig()).thenReturn(bigQueryProxyConfig);
+    when(bigQueryConfig.getClientCreationHashCode()).thenReturn(1234);
+    when(bigQueryConfig.areClientCreationConfigsEqual(bigQueryConfig)).thenReturn(true);
 
     BigQueryReadClient readClient2 = clientFactory2.getBigQueryReadClient();
     assertNotNull(readClient2);
@@ -201,6 +211,8 @@ public class BigQueryClientFactoryTest {
         new BigQueryClientFactory(bigQueryCredentialsSupplier, headerProvider, bigQueryConfig);
 
     when(bigQueryConfig.getBigQueryProxyConfig()).thenReturn(bigQueryProxyConfig);
+    when(bigQueryConfig.getClientCreationHashCode()).thenReturn(1234);
+    when(bigQueryConfig.areClientCreationConfigsEqual(bigQueryConfig)).thenReturn(true);
 
     BigQueryReadClient readClient3 = clientFactory3.getBigQueryReadClient();
     assertNotNull(readClient3);
@@ -231,6 +243,8 @@ public class BigQueryClientFactoryTest {
         new BigQueryClientFactory(bigQueryCredentialsSupplier, headerProvider, bigQueryConfig);
 
     when(bigQueryConfig.getBigQueryProxyConfig()).thenReturn(bigQueryProxyConfig);
+    when(bigQueryConfig.getClientCreationHashCode()).thenReturn(1234);
+    when(bigQueryConfig.areClientCreationConfigsEqual(bigQueryConfig)).thenReturn(true);
 
     BigQueryWriteClient writeClient = clientFactory.getBigQueryWriteClient();
     assertNotNull(writeClient);
@@ -239,6 +253,8 @@ public class BigQueryClientFactoryTest {
         new BigQueryClientFactory(bigQueryCredentialsSupplier, headerProvider, bigQueryConfig);
 
     when(bigQueryConfig.getBigQueryProxyConfig()).thenReturn(bigQueryProxyConfig);
+    when(bigQueryConfig.getClientCreationHashCode()).thenReturn(1234);
+    when(bigQueryConfig.areClientCreationConfigsEqual(bigQueryConfig)).thenReturn(true);
 
     BigQueryWriteClient writeClient2 = clientFactory2.getBigQueryWriteClient();
     assertNotNull(writeClient2);
@@ -252,6 +268,8 @@ public class BigQueryClientFactoryTest {
             bigQueryConfig);
 
     when(bigQueryConfig.getBigQueryProxyConfig()).thenReturn(bigQueryProxyConfig);
+    when(bigQueryConfig.getClientCreationHashCode()).thenReturn(1234);
+    when(bigQueryConfig.areClientCreationConfigsEqual(bigQueryConfig)).thenReturn(true);
 
     BigQueryWriteClient writeClient3 = clientFactory3.getBigQueryWriteClient();
     assertNotNull(writeClient3);
@@ -303,6 +321,8 @@ public class BigQueryClientFactoryTest {
         new BigQueryClientFactory(bigQueryCredentialsSupplier, headerProvider, bigQueryConfig);
 
     when(bigQueryConfig.getBigQueryProxyConfig()).thenReturn(bigQueryProxyConfig);
+    when(bigQueryConfig.getClientCreationHashCode()).thenReturn(1234);
+    when(bigQueryConfig.areClientCreationConfigsEqual(bigQueryConfig)).thenReturn(true);
 
     BigQueryWriteClient writeClient = clientFactory.getBigQueryWriteClient();
     assertNotNull(writeClient);
@@ -313,6 +333,8 @@ public class BigQueryClientFactoryTest {
         new BigQueryClientFactory(bigQueryCredentialsSupplier, headerProvider, bigQueryConfig);
 
     when(bigQueryConfig.getBigQueryProxyConfig()).thenReturn(bigQueryProxyConfig);
+    when(bigQueryConfig.getClientCreationHashCode()).thenReturn(1234);
+    when(bigQueryConfig.areClientCreationConfigsEqual(bigQueryConfig)).thenReturn(true);
 
     BigQueryWriteClient writeClient2 = clientFactory2.getBigQueryWriteClient();
     assertNotNull(writeClient2);
@@ -325,6 +347,8 @@ public class BigQueryClientFactoryTest {
         new BigQueryClientFactory(bigQueryCredentialsSupplier, headerProvider, bigQueryConfig);
 
     when(bigQueryConfig.getBigQueryProxyConfig()).thenReturn(bigQueryProxyConfig);
+    when(bigQueryConfig.getClientCreationHashCode()).thenReturn(1234);
+    when(bigQueryConfig.areClientCreationConfigsEqual(bigQueryConfig)).thenReturn(true);
 
     BigQueryWriteClient writeClient3 = clientFactory3.getBigQueryWriteClient();
     assertNotNull(writeClient3);
@@ -511,7 +535,7 @@ public class BigQueryClientFactoryTest {
 
     @Override
     public Optional<Long> getCreateReadSessionTimeoutInSeconds() {
-      return Optional.of(500L);
+      return Optional.empty();
     }
 
     @Override


### PR DESCRIPTION
BigQueryConfig doesn't overwrite hashCode() and equals(), causing to create a client for every request.