### PR TITLE
Propagate stats from BigLake tables.

### DIFF
--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -53,9 +53,9 @@
 
         <avro.version>1.11.1</avro.version>
         <arrow.version>12.0.0</arrow.version>
-        <gax.version>2.26.0</gax.version>
+        <gax.version>2.30.0</gax.version>
         <google-cloud-bigquery.version>2.26.0</google-cloud-bigquery.version>
-        <google-cloud-bigquerystorage.version>2.36.1</google-cloud-bigquerystorage.version>
+        <google-cloud-bigquerystorage.version>2.39.0</google-cloud-bigquerystorage.version>
         <google-cloud-dataproc.version>4.11.0</google-cloud-dataproc.version>
         <google-cloud-storage.version>2.20.2</google-cloud-storage.version>
         <google-truth.version>1.1.3</google-truth.version>


### PR DESCRIPTION
This will enable broadcast joins (without AQE intervention) and dynamic partition pruning on BigLake tables.

I had to upgrade the client library to use the new field and had to upgrade GAX because the newer version of client libraries require newer GAX version.

Testing: Verified that DPP works on TPC-DS query 25.