### PR TITLE
Handle Java 8 types for dates and timestamps when compiling filters

### DIFF
--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkFilterUtils.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkFilterUtils.java
@@ -23,7 +23,6 @@ import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkFilterUtils.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkFilterUtils.java
@@ -21,6 +21,9 @@ import com.google.cloud.bigquery.storage.v1.DataFormat;
 import com.google.common.collect.ImmutableList;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
@@ -315,10 +318,10 @@ public class SparkFilterUtils {
     if (value instanceof String) {
       return "'" + escape((String) value) + "'";
     }
-    if (value instanceof Date) {
+    if (value instanceof Date || value instanceof LocalDate) {
       return "DATE '" + value + "'";
     }
-    if (value instanceof Timestamp) {
+    if (value instanceof Timestamp || value instanceof Instant) {
       return "TIMESTAMP '" + value + "'";
     }
     if (value instanceof Object[]) {

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkFilterUtilsTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkFilterUtilsTest.java
@@ -230,7 +230,7 @@ public class SparkFilterUtilsTest {
     Instant ts2 = LocalDateTime.of(2020, 1, 25, 2, 10, 10).toInstant(ZoneOffset.UTC);
     assertThat(SparkFilterUtils.compileFilter(In.apply("tsfield", new Object[] {ts1, ts2})))
         .isEqualTo(
-            "`tsfield` IN (TIMESTAMP '2008-12-25 15:30:00Z', TIMESTAMP '2020-01-25 02:10:10Z')");
+            "`tsfield` IN (TIMESTAMP '2008-12-25T15:30:00Z', TIMESTAMP '2020-01-25T02:10:10Z')");
   }
 
   @Test

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkFilterUtilsTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkFilterUtilsTest.java
@@ -208,10 +208,10 @@ public class SparkFilterUtilsTest {
   @Test
   public void testDateFilters_java8Time() {
     assertThat(
-        SparkFilterUtils.compileFilter(
-            In.apply(
-                "datefield",
-                new Object[] {LocalDate.of(2020, 9, 1), LocalDate.of(2020, 11, 3)})))
+            SparkFilterUtils.compileFilter(
+                In.apply(
+                    "datefield",
+                    new Object[] {LocalDate.of(2020, 9, 1), LocalDate.of(2020, 11, 3)})))
         .isEqualTo("`datefield` IN (DATE '2020-09-01', DATE '2020-11-03')");
   }
 

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkFilterUtilsTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkFilterUtilsTest.java
@@ -21,6 +21,10 @@ import com.google.cloud.bigquery.storage.v1.DataFormat;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.text.ParseException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Optional;
@@ -202,12 +206,31 @@ public class SparkFilterUtilsTest {
   }
 
   @Test
+  public void testDateFilters_java8Time() {
+    assertThat(
+        SparkFilterUtils.compileFilter(
+            In.apply(
+                "datefield",
+                new Object[] {LocalDate.of(2020, 9, 1), LocalDate.of(2020, 11, 3)})))
+        .isEqualTo("`datefield` IN (DATE '2020-09-01', DATE '2020-11-03')");
+  }
+
+  @Test
   public void testTimestampFilters() throws ParseException {
     Timestamp ts1 = Timestamp.valueOf("2008-12-25 15:30:00");
     Timestamp ts2 = Timestamp.valueOf("2020-01-25 02:10:10");
     assertThat(SparkFilterUtils.compileFilter(In.apply("tsfield", new Object[] {ts1, ts2})))
         .isEqualTo(
             "`tsfield` IN (TIMESTAMP '2008-12-25 15:30:00.0', TIMESTAMP '2020-01-25 02:10:10.0')");
+  }
+
+  @Test
+  public void testTimestampFilters_java8Time() {
+    Instant ts1 = LocalDateTime.of(2008, 12, 25, 15, 30, 0).toInstant(ZoneOffset.UTC);
+    Instant ts2 = LocalDateTime.of(2020, 1, 25, 2, 10, 10).toInstant(ZoneOffset.UTC);
+    assertThat(SparkFilterUtils.compileFilter(In.apply("tsfield", new Object[] {ts1, ts2})))
+        .isEqualTo(
+            "`tsfield` IN (TIMESTAMP '2008-12-25 15:30:00Z', TIMESTAMP '2020-01-25 02:10:10Z')");
   }
 
   @Test


### PR DESCRIPTION
The `spark.sql.datetime.java8API.enabled` configuration as described in https://spark.apache.org/docs/3.0.0/configuration.html is not currently handled (when set to `true`) when compiling filters. Date or timestamp literals will be `java.time.LocalDate` or `java.time.Instant` respectively and thus not properly escaped by https://github.com/GoogleCloudDataproc/spark-bigquery-connector/blob/master/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkFilterUtils.java#L318 resulting in query failures due to invalid syntax.