### PR TITLE
fix(writer): Initialise retry settings with a delay between retires

### DIFF
--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -207,9 +207,6 @@ public class SparkBigQueryConfig
   private CompressionCodec arrowCompressionCodec = DEFAULT_ARROW_COMPRESSION_CODEC;
   private WriteMethod writeMethod = DEFAULT_WRITE_METHOD;
   boolean writeAtLeastOnce = false;
-  // for V2 write with BigQuery Storage Write API
-  RetrySettings bigqueryDataWriteHelperRetrySettings =
-      RetrySettings.newBuilder().setMaxAttempts(5).build();
   private int cacheExpirationTimeInMinutes = DEFAULT_CACHE_EXPIRATION_IN_MINUTES;
   // used to create BigQuery ReadSessions
   private com.google.common.base.Optional<String> traceId;
@@ -924,11 +921,14 @@ public class SparkBigQueryConfig
 
   @Override
   public RetrySettings getBigQueryClientRetrySettings() {
+    int maxAttempts =
+        sparkBigQueryProxyAndHttpConfig.getHttpMaxRetry().orElse(DEFAULT_BIGQUERY_CLIENT_RETRIES);
+    return getRetrySettings(maxAttempts);
+  }
+
+  private static RetrySettings getRetrySettings(int maxAttempts) {
     return RetrySettings.newBuilder()
-        .setMaxAttempts(
-            sparkBigQueryProxyAndHttpConfig
-                .getHttpMaxRetry()
-                .orElse(DEFAULT_BIGQUERY_CLIENT_RETRIES))
+        .setMaxAttempts(maxAttempts)
         .setTotalTimeout(Duration.ofMinutes(10))
         .setInitialRpcTimeout(Duration.ofSeconds(60))
         .setMaxRpcTimeout(Duration.ofMinutes(5))
@@ -939,8 +939,9 @@ public class SparkBigQueryConfig
         .build();
   }
 
+  // for V2 write with BigQuery Storage Write API
   public RetrySettings getBigqueryDataWriteHelperRetrySettings() {
-    return bigqueryDataWriteHelperRetrySettings;
+    return getRetrySettings(5);
   }
 
   public WriteMethod getWriteMethod() {


### PR DESCRIPTION
- The current retry settings was initialised with max attempts only, this initialises the delay between runs to 0, meaning that the 5 calls will happen with 0 millis between them and not actually an exponential retry strategy like it implies here: https://github.com/GoogleCloudDataproc/spark-bigquery-connector/blob/741bdb33bf5c06fb3fad9defffa65ea1470d2690/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryDirectDataWriterHelper.java#L133-L142 (ran a test for the retryCallable method with the current settings and indeed the delay was 0 between calls)
- So we initialise, it with the same settings as reading (can be tuned later) as otherwise the API is hammered leading to all failures

Testing main:
```java
public static void main(String[] args) throws ExecutionException, InterruptedException {
    // This one prints 0 (or nearly zero) for the 5 retries
    // RetrySettings retrySettings = RetrySettings.newBuilder().setMaxAttempts(5).build();
    // This one uses the expected delays from the setup below (prints the right values)
    RetrySettings retrySettings = getRetrySettings(5);
    DirectRetryingExecutor<Long> directRetryingExecutor =
            new DirectRetryingExecutor<>(
                    new RetryAlgorithm<>(
                            new BasicResultRetryAlgorithm<>(),
                            new ExponentialRetryAlgorithm(retrySettings, NanoClock.getDefaultClock())));
    
    AtomicReference<Instant> last = new AtomicReference<>(Instant.now());
    RetryingFuture<Long> retryingFuture = directRetryingExecutor.createFuture(() -> {
        Instant now = Instant.now();
        Instant previous = last.getAndSet(now);
        System.out.println(now.toEpochMilli() - previous.toEpochMilli());
        throw new RuntimeException("test");
    });
    directRetryingExecutor.submit(retryingFuture).get();
}

private static RetrySettings getRetrySettings(int maxAttempts) {
    return RetrySettings.newBuilder()
            .setMaxAttempts(maxAttempts)
            .setTotalTimeout(Duration.ofMinutes(10))
            .setInitialRpcTimeout(Duration.ofSeconds(60))
            .setMaxRpcTimeout(Duration.ofMinutes(5))
            .setRpcTimeoutMultiplier(1.6)
            .setRetryDelayMultiplier(1.6)
            .setInitialRetryDelay(Duration.ofMillis(1250))
            .setMaxRetryDelay(Duration.ofSeconds(5))
            .build();
}
```