### PR TITLE
Detect presence of policy tags in destination table.

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -545,7 +545,7 @@ word-break:break-word
     guarantee than exactly once. This is suitable for streaming scenarios
     in which data is continuously being written in small batches.
        <br/>(Optional. Defaults to <code>false</code>)
-       <br/><i>Supported only by the `DIRECT` write method and mode is <b>NOT</b> `Overwrite`.</i>
+       <br/><i>Supported only by the `DIRECT` write method and mode is <b>NOT</b> `Overwrite` for tables containing policy tags.</i>
    </td>
    <td>Write</td>
   </tr>

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
@@ -30,6 +30,7 @@ import com.google.cloud.bigquery.Field.Mode;
 import com.google.cloud.bigquery.FieldList;
 import com.google.cloud.bigquery.HivePartitioningOptions;
 import com.google.cloud.bigquery.LegacySQLTypeName;
+import com.google.cloud.bigquery.PolicyTags;
 import com.google.cloud.bigquery.RangePartitioning;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.StandardTableDefinition;
@@ -269,6 +270,28 @@ public class BigQueryUtil {
     // compare field by field
     return fieldListWritable(
         sourceSchema.getFields(), destinationSchema.getFields(), enableModeCheckForSchemaFields);
+  }
+
+  /**
+   * Checks whether at least one policy tag is present.
+   *
+   * @param schema the schema to check
+   * @return true if at least one policy tag is present, false otherwise
+   */
+  public static boolean schemaHasPolicyTags(Schema schema) {
+    FieldList fieldList = schema.getFields();
+    if (fieldList != null) {
+      for (Field field : fieldList) {
+        PolicyTags policyTags = field.getPolicyTags();
+        if (policyTags != null) {
+          List<String> list = policyTags.getNames();
+          if ((list != null) && (list.size() > 0)) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
   }
 
   /**

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/model/LinkPolicy.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/model/LinkPolicy.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration.model;
+
+import com.google.common.base.Objects;
+
+public class LinkPolicy {
+
+  private String uri;
+  private String uriPolicy;
+
+  public LinkPolicy() {}
+
+  public LinkPolicy(String uri, String uriPolicy) {
+    this.uri = uri;
+    this.uriPolicy = uriPolicy;
+  }
+
+  public String getUri() {
+    return uri;
+  }
+
+  public void setUri(String uri) {
+    this.uri = uri;
+  }
+
+  public String getUriPolicy() {
+    return uriPolicy;
+  }
+
+  public void setUriPolicy(String uriPolicy) {
+    this.uriPolicy = uriPolicy;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof LinkPolicy)) {
+      return false;
+    }
+    LinkPolicy linkPolicy = (LinkPolicy) o;
+    return Objects.equal(uri, linkPolicy.uri) && Objects.equal(uriPolicy, linkPolicy.uriPolicy);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(uri, uriPolicy);
+  }
+
+  @Override
+  public String toString() {
+    return "LinkPolicy{" + "uri='" + uri + '\'' + ", uriPolicy=" + uriPolicy + '}';
+  }
+}

--- a/spark-bigquery-dsv1/src/test/java/com/google/cloud/spark/bigquery/integration/DataSourceV1WriteIntegrationTestBase.java
+++ b/spark-bigquery-dsv1/src/test/java/com/google/cloud/spark/bigquery/integration/DataSourceV1WriteIntegrationTestBase.java
@@ -128,7 +128,7 @@ public class DataSourceV1WriteIntegrationTestBase extends WriteIntegrationTestBa
     assertThat(testTableNumberOfRows()).isEqualTo(2);
     assertThat(initialDataValuesExist()).isTrue();
     // Write to stream
-    stream.addData(toSeq(additonalData().collectAsList()));
+    stream.addData(toSeq(additionalData().collectAsList()));
     while (writeStream.lastProgress().batchId() <= lastBatchId) {
       Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
     }


### PR DESCRIPTION
Revise restriction on writeAtLeastOnce.
Add integration tests to verify preservation of policy tags.