### PR TITLE
add toString to DirectBigQueryRelation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 ## Next
 
+* PR #1038: Logical plan now shows the BigQuery table of DirectBigQueryRelation. Thanks @idc101 !
 * PR #1025: Handle Java 8 types for dates and timestamps when compiling filters. Thanks @tom-s-powell !
 * Issue #1026: Fixing Numeric conversion
 * Issue #1028: Fixing PolicyTags removal on overwrite

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/direct/DirectBigQueryRelation.java
@@ -242,4 +242,9 @@ public class DirectBigQueryRelation extends BigQueryRelation
   public int hashCode() {
     return Objects.hash(getTableId(), schema(), compiledFilter);
   }
+
+  @Override
+  public String toString() {
+    return "DirectBigQueryRelation[" + toSqlTableReference(getTableId()) + "]";
+  }
 }


### PR DESCRIPTION
Currently Spark execution plans are rendered using the default toString implementation:
```
(3) LogicalRelation
Arguments: com.google.cloud.spark.bigquery.direct.DirectBigQueryRelation@18db53e9, [d_date_sk#516L, ...]
```

This adds a `toString()` implementation to output the actual table being read:
```
scala> res0.explain()
== Physical Plan ==
*(1) Scan DirectBigQueryRelation[anaml-dev-nonprod.tpcds_scale_1000.catalog_sales] [cs_sold_date_sk#0L,cs_sold_time_sk#1L...]
```