### PR TITLE
Format metrics; add (min, med, max) for timing metrics

### DIFF
--- a/spark-bigquery-dsv2/spark-bigquery-metrics/src/main/java/com/google/cloud/spark/bigquery/v2/customMetrics/MetricUtils.java
+++ b/spark-bigquery-dsv2/spark-bigquery-metrics/src/main/java/com/google/cloud/spark/bigquery/v2/customMetrics/MetricUtils.java
@@ -1,0 +1,37 @@
+package com.google.cloud.spark.bigquery.v2.customMetrics;
+
+import static org.apache.spark.util.Utils.bytesToString;
+import static org.apache.spark.util.Utils.msDurationToString;
+
+import java.text.NumberFormat;
+import java.util.Arrays;
+import java.util.Locale;
+
+class MetricUtils {
+
+  private static final String METRIC_FORMAT = "total (min, med, max)\n%s (%s, %s, %s)";
+  private static final NumberFormat NUMBER_FORMAT_US = NumberFormat.getIntegerInstance(Locale.US);
+
+  static String formatTimeMetrics(long[] taskMetrics) {
+    if (taskMetrics.length == 0) {
+      return msDurationToString(0);
+    }
+    if (taskMetrics.length == 1) {
+      return msDurationToString(taskMetrics[0]);
+    }
+    Arrays.sort(taskMetrics);
+    String sum = msDurationToString(Arrays.stream(taskMetrics).sum());
+    String min = msDurationToString(taskMetrics[0]);
+    String med = msDurationToString(taskMetrics[taskMetrics.length / 2]);
+    String max = msDurationToString(taskMetrics[taskMetrics.length - 1]);
+    return String.format(METRIC_FORMAT, sum, min, med, max);
+  }
+
+  static String formatSizeMetrics(long[] taskMetrics) {
+    return bytesToString(Arrays.stream(taskMetrics).sum());
+  }
+
+  static String formatSumMetrics(long[] taskMetrics) {
+    return NUMBER_FORMAT_US.format(Arrays.stream(taskMetrics).sum());
+  }
+}

--- a/spark-bigquery-dsv2/spark-bigquery-metrics/src/main/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryBytesReadMetric.java
+++ b/spark-bigquery-dsv2/spark-bigquery-metrics/src/main/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryBytesReadMetric.java
@@ -3,9 +3,9 @@ package com.google.cloud.spark.bigquery.v2.customMetrics;
 import static com.google.cloud.spark.bigquery.v2.customMetrics.SparkBigQueryCustomMetricConstants.BIG_QUERY_BYTES_READ_METRIC_DESCRIPTION;
 import static com.google.cloud.spark.bigquery.v2.customMetrics.SparkBigQueryCustomMetricConstants.BIG_QUERY_BYTES_READ_METRIC_NAME;
 
-import org.apache.spark.sql.connector.metric.CustomSumMetric;
+import org.apache.spark.sql.connector.metric.CustomMetric;
 
-public class SparkBigQueryBytesReadMetric extends CustomSumMetric {
+public class SparkBigQueryBytesReadMetric implements CustomMetric {
 
   @Override
   public String name() {
@@ -15,5 +15,10 @@ public class SparkBigQueryBytesReadMetric extends CustomSumMetric {
   @Override
   public String description() {
     return BIG_QUERY_BYTES_READ_METRIC_DESCRIPTION;
+  }
+
+  @Override
+  public String aggregateTaskMetrics(long[] taskMetrics) {
+    return MetricUtils.formatSizeMetrics(taskMetrics);
   }
 }

--- a/spark-bigquery-dsv2/spark-bigquery-metrics/src/main/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryCustomMetricConstants.java
+++ b/spark-bigquery-dsv2/spark-bigquery-metrics/src/main/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryCustomMetricConstants.java
@@ -6,10 +6,9 @@ public class SparkBigQueryCustomMetricConstants {
   public static final String BIG_QUERY_ROWS_READ_METRIC_NAME = "bqRowsRead";
   static final String BIG_QUERY_ROWS_READ_METRIC_DESCRIPTION = "number of BQ rows read";
   public static final String BIG_QUERY_SCAN_TIME_METRIC_NAME = "bqScanTime";
-  static final String BIG_QUERY_SCAN_TIME_METRIC_DESCRIPTION = "scan time for BQ in milli sec";
+  static final String BIG_QUERY_SCAN_TIME_METRIC_DESCRIPTION = "scan time for BQ";
   public static final String BIG_QUERY_PARSE_TIME_METRIC_NAME = "bqParseTime";
-  static final String BIG_QUERY_PARSE_TIME_METRIC_DESCRIPTION = "parsing time for BQ in milli sec";
+  static final String BIG_QUERY_PARSE_TIME_METRIC_DESCRIPTION = "parsing time for BQ";
   public static final String BIG_QUERY_TIME_IN_SPARK_METRIC_NAME = "bqTimeInSpark";
-  static final String BIG_QUERY_TIME_IN_SPARK_METRIC_DESCRIPTION =
-      "time spent in spark in milli sec";
+  static final String BIG_QUERY_TIME_IN_SPARK_METRIC_DESCRIPTION = "time spent in spark";
 }

--- a/spark-bigquery-dsv2/spark-bigquery-metrics/src/main/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryParseTimeMetric.java
+++ b/spark-bigquery-dsv2/spark-bigquery-metrics/src/main/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryParseTimeMetric.java
@@ -1,10 +1,11 @@
 package com.google.cloud.spark.bigquery.v2.customMetrics;
 
-import static com.google.cloud.spark.bigquery.v2.customMetrics.SparkBigQueryCustomMetricConstants.*;
+import static com.google.cloud.spark.bigquery.v2.customMetrics.SparkBigQueryCustomMetricConstants.BIG_QUERY_PARSE_TIME_METRIC_DESCRIPTION;
+import static com.google.cloud.spark.bigquery.v2.customMetrics.SparkBigQueryCustomMetricConstants.BIG_QUERY_PARSE_TIME_METRIC_NAME;
 
-import org.apache.spark.sql.connector.metric.CustomSumMetric;
+import org.apache.spark.sql.connector.metric.CustomMetric;
 
-public class SparkBigQueryParseTimeMetric extends CustomSumMetric {
+public class SparkBigQueryParseTimeMetric implements CustomMetric {
 
   @Override
   public String name() {
@@ -14,5 +15,10 @@ public class SparkBigQueryParseTimeMetric extends CustomSumMetric {
   @Override
   public String description() {
     return BIG_QUERY_PARSE_TIME_METRIC_DESCRIPTION;
+  }
+
+  @Override
+  public String aggregateTaskMetrics(long[] taskMetrics) {
+    return MetricUtils.formatTimeMetrics(taskMetrics);
   }
 }

--- a/spark-bigquery-dsv2/spark-bigquery-metrics/src/main/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryRowsReadMetric.java
+++ b/spark-bigquery-dsv2/spark-bigquery-metrics/src/main/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryRowsReadMetric.java
@@ -1,10 +1,11 @@
 package com.google.cloud.spark.bigquery.v2.customMetrics;
 
-import static com.google.cloud.spark.bigquery.v2.customMetrics.SparkBigQueryCustomMetricConstants.*;
+import static com.google.cloud.spark.bigquery.v2.customMetrics.SparkBigQueryCustomMetricConstants.BIG_QUERY_ROWS_READ_METRIC_DESCRIPTION;
+import static com.google.cloud.spark.bigquery.v2.customMetrics.SparkBigQueryCustomMetricConstants.BIG_QUERY_ROWS_READ_METRIC_NAME;
 
-import org.apache.spark.sql.connector.metric.CustomSumMetric;
+import org.apache.spark.sql.connector.metric.CustomMetric;
 
-public class SparkBigQueryRowsReadMetric extends CustomSumMetric {
+public class SparkBigQueryRowsReadMetric implements CustomMetric {
   @Override
   public String name() {
     return BIG_QUERY_ROWS_READ_METRIC_NAME;
@@ -13,5 +14,10 @@ public class SparkBigQueryRowsReadMetric extends CustomSumMetric {
   @Override
   public String description() {
     return BIG_QUERY_ROWS_READ_METRIC_DESCRIPTION;
+  }
+
+  @Override
+  public String aggregateTaskMetrics(long[] taskMetrics) {
+    return MetricUtils.formatSumMetrics(taskMetrics);
   }
 }

--- a/spark-bigquery-dsv2/spark-bigquery-metrics/src/main/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryScanTimeMetric.java
+++ b/spark-bigquery-dsv2/spark-bigquery-metrics/src/main/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryScanTimeMetric.java
@@ -3,9 +3,9 @@ package com.google.cloud.spark.bigquery.v2.customMetrics;
 import static com.google.cloud.spark.bigquery.v2.customMetrics.SparkBigQueryCustomMetricConstants.BIG_QUERY_SCAN_TIME_METRIC_DESCRIPTION;
 import static com.google.cloud.spark.bigquery.v2.customMetrics.SparkBigQueryCustomMetricConstants.BIG_QUERY_SCAN_TIME_METRIC_NAME;
 
-import org.apache.spark.sql.connector.metric.CustomSumMetric;
+import org.apache.spark.sql.connector.metric.CustomMetric;
 
-public class SparkBigQueryScanTimeMetric extends CustomSumMetric {
+public class SparkBigQueryScanTimeMetric implements CustomMetric {
 
   @Override
   public String name() {
@@ -15,5 +15,10 @@ public class SparkBigQueryScanTimeMetric extends CustomSumMetric {
   @Override
   public String description() {
     return BIG_QUERY_SCAN_TIME_METRIC_DESCRIPTION;
+  }
+
+  @Override
+  public String aggregateTaskMetrics(long[] taskMetrics) {
+    return MetricUtils.formatTimeMetrics(taskMetrics);
   }
 }

--- a/spark-bigquery-dsv2/spark-bigquery-metrics/src/main/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryTimeInSparkMetric.java
+++ b/spark-bigquery-dsv2/spark-bigquery-metrics/src/main/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryTimeInSparkMetric.java
@@ -2,9 +2,9 @@ package com.google.cloud.spark.bigquery.v2.customMetrics;
 
 import static com.google.cloud.spark.bigquery.v2.customMetrics.SparkBigQueryCustomMetricConstants.*;
 
-import org.apache.spark.sql.connector.metric.CustomSumMetric;
+import org.apache.spark.sql.connector.metric.CustomMetric;
 
-public class SparkBigQueryTimeInSparkMetric extends CustomSumMetric {
+public class SparkBigQueryTimeInSparkMetric implements CustomMetric {
 
   @Override
   public String name() {
@@ -14,5 +14,10 @@ public class SparkBigQueryTimeInSparkMetric extends CustomSumMetric {
   @Override
   public String description() {
     return BIG_QUERY_TIME_IN_SPARK_METRIC_DESCRIPTION;
+  }
+
+  @Override
+  public String aggregateTaskMetrics(long[] taskMetrics) {
+    return MetricUtils.formatTimeMetrics(taskMetrics);
   }
 }

--- a/spark-bigquery-dsv2/spark-bigquery-metrics/src/test/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryBytesReadMetricTest.java
+++ b/spark-bigquery-dsv2/spark-bigquery-metrics/src/test/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryBytesReadMetricTest.java
@@ -23,7 +23,7 @@ public class SparkBigQueryBytesReadMetricTest {
 
   @Test
   public void testAggregateMetrics() {
-    assertThat(sparkBigQueryBytesReadMetric.aggregateTaskMetrics(new long[] {1000L, 2000L}))
-        .isEqualTo("3000");
+    assertThat(sparkBigQueryBytesReadMetric.aggregateTaskMetrics(new long[] {1024L, 2048L}))
+        .isEqualTo("3.0 KiB");
   }
 }

--- a/spark-bigquery-dsv2/spark-bigquery-metrics/src/test/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryParseTimeMetricTest.java
+++ b/spark-bigquery-dsv2/spark-bigquery-metrics/src/test/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryParseTimeMetricTest.java
@@ -22,7 +22,7 @@ public class SparkBigQueryParseTimeMetricTest {
 
   @Test
   public void testAggregateMetrics() {
-    assertThat(sparkBigQueryParseTimeMetric.aggregateTaskMetrics(new long[] {1000L, 2000L}))
-        .isEqualTo("3000");
+    assertThat(sparkBigQueryParseTimeMetric.aggregateTaskMetrics(new long[] {1020L, 2030L, 3040L}))
+        .isEqualTo("total (min, med, max)\n" + "6.1 s (1.0 s, 2.0 s, 3.0 s)");
   }
 }

--- a/spark-bigquery-dsv2/spark-bigquery-metrics/src/test/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryRowsReadMetricTest.java
+++ b/spark-bigquery-dsv2/spark-bigquery-metrics/src/test/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryRowsReadMetricTest.java
@@ -23,6 +23,6 @@ public class SparkBigQueryRowsReadMetricTest {
   @Test
   public void testAggregateMetrics() {
     assertThat(sparkBigQueryRowsReadMetric.aggregateTaskMetrics(new long[] {1000L, 2000L}))
-        .isEqualTo("3000");
+        .isEqualTo("3,000");
   }
 }

--- a/spark-bigquery-dsv2/spark-bigquery-metrics/src/test/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryScanTimeMetricTest.java
+++ b/spark-bigquery-dsv2/spark-bigquery-metrics/src/test/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryScanTimeMetricTest.java
@@ -22,7 +22,7 @@ public class SparkBigQueryScanTimeMetricTest {
 
   @Test
   public void testAggregateMetrics() {
-    assertThat(sparkBigQueryScanTimeMetric.aggregateTaskMetrics(new long[] {1000L, 2000L}))
-        .isEqualTo("3000");
+    assertThat(sparkBigQueryScanTimeMetric.aggregateTaskMetrics(new long[] {1010L, 2020L, 3030L}))
+        .isEqualTo("total (min, med, max)\n" + "6.1 s (1.0 s, 2.0 s, 3.0 s)");
   }
 }

--- a/spark-bigquery-dsv2/spark-bigquery-metrics/src/test/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryTimeInSparkMetricTest.java
+++ b/spark-bigquery-dsv2/spark-bigquery-metrics/src/test/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryTimeInSparkMetricTest.java
@@ -23,7 +23,8 @@ public class SparkBigQueryTimeInSparkMetricTest {
 
   @Test
   public void testAggregateMetrics() {
-    assertThat(sparkBigQueryTimeInSparkMetric.aggregateTaskMetrics(new long[] {1000L, 2000L}))
-        .isEqualTo("3000");
+    assertThat(
+            sparkBigQueryTimeInSparkMetric.aggregateTaskMetrics(new long[] {1020L, 2010L, 3030L}))
+        .isEqualTo("total (min, med, max)\n" + "6.1 s (1.0 s, 2.0 s, 3.0 s)");
   }
 }


### PR DESCRIPTION
Shows up like this now: 
<img width="391" alt="Screenshot 2023-08-29 at 9 40 49 PM" src="https://github.com/GoogleCloudDataproc/spark-bigquery-connector/assets/25999807/508b67a7-583d-49b4-9e28-86f17c1788f0">
