### PR TITLE
Forcing constant POM structure using the tidy plugin

### DIFF
--- a/.github/workflows/tidy.yaml
+++ b/.github/workflows/tidy.yaml
@@ -1,0 +1,24 @@
+name: POM Structure Check
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'maven'
+
+      - name: Checkout coding style
+        run: ./mvnw tidy:check -Pall

--- a/bigquery-connector-common/pom.xml
+++ b/bigquery-connector-common/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
@@ -10,6 +10,7 @@
   </parent>
 
   <artifactId>bigquery-connector-common</artifactId>
+
   <name>BigQuery Connector Common Library</name>
   <licenses>
     <license>
@@ -18,6 +19,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>com.google.api.grpc</groupId>
@@ -47,7 +49,8 @@
           <groupId>com.google.api.grpc</groupId>
           <artifactId>proto-google-cloud-bigquerystorage-v1beta2</artifactId>
         </exclusion>
-      </exclusions>    </dependency>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquerystorage</artifactId>
@@ -129,6 +132,7 @@
       <version>2.9.1</version>
     </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <plugin>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
@@ -10,8 +10,9 @@
   </parent>
 
   <artifactId>coverage</artifactId>
-  <name>Coverage Report</name>
   <packaging>pom</packaging>
+
+  <name>Coverage Report</name>
 
   <dependencies>
     <dependency>
@@ -321,4 +322,3 @@
     </profile>
   </profiles>
 </project>
-

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
@@ -11,8 +11,8 @@
 
   <artifactId>spark-bigquery-reactor</artifactId>
   <packaging>pom</packaging>
-  <name>Spark BigQuery Connector Reactor</name>
 
+  <name>Spark BigQuery Connector Reactor</name>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -28,6 +28,15 @@
     </developer>
   </developers>
 
+  <modules>
+    <module>spark-bigquery-parent</module>
+    <module>bigquery-connector-common</module>
+    <module>spark-bigquery-tests</module>
+    <module>spark-bigquery-scala-212-support</module>
+    <module>spark-bigquery-connector-common</module>
+    <module>spark-bigquery-python-lib</module>
+  </modules>
+
   <scm>
     <connection>
       scm:git:git@github.com:GoogleCloudDataproc/spark-bigquery-connector.git
@@ -37,22 +46,12 @@
     </developerConnection>
     <url>git@github.com:GoogleCloudDataproc/spark-bigquery-connector.git</url>
   </scm>
-
   <issueManagement>
     <system>GitHub Issues</system>
     <url>
       https://github.com/GoogleCloudDataproc/spark-bigquery-connector/issues
     </url>
   </issueManagement>
-
-  <modules>
-    <module>spark-bigquery-parent</module>
-    <module>bigquery-connector-common</module>
-    <module>spark-bigquery-tests</module>
-    <module>spark-bigquery-scala-212-support</module>
-    <module>spark-bigquery-connector-common</module>
-    <module>spark-bigquery-python-lib</module>
-  </modules>
 
   <profiles>
     <profile>

--- a/spark-bigquery-connector-common/pom.xml
+++ b/spark-bigquery-connector-common/pom.xml
@@ -1,6 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.google.cloud.spark</groupId>
         <artifactId>spark-bigquery-parent</artifactId>
@@ -9,6 +10,7 @@
     </parent>
 
     <artifactId>spark-bigquery-connector-common</artifactId>
+
     <name>Spark BigQuery Connector Common Library</name>
     <licenses>
         <license>
@@ -17,6 +19,7 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -81,6 +84,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/spark-bigquery-dsv1/pom.xml
+++ b/spark-bigquery-dsv1/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
@@ -10,8 +10,10 @@
   </parent>
 
   <artifactId>spark-bigquery-dsv1</artifactId>
-  <name>BigQuery DataSource v1 implementation</name>
   <packaging>pom</packaging>
+
+  <name>BigQuery DataSource v1 implementation</name>
+
   <modules>
     <module>spark-bigquery-dsv1-spark2-support</module>
     <module>spark-bigquery-dsv1-spark3-support</module>

--- a/spark-bigquery-dsv1/spark-bigquery-dsv1-parent/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery-dsv1-parent/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
@@ -10,12 +10,9 @@
   </parent>
 
   <artifactId>spark-bigquery-dsv1-parent</artifactId>
-  <name>BigQuery DataSource v1 implementation common settings</name>
   <packaging>pom</packaging>
-  <properties>
-    <scala.binary.version>2.11</scala.binary.version>
-    <spark.version>2.4.0</spark.version>
-  </properties>
+
+  <name>BigQuery DataSource v1 implementation common settings</name>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -23,6 +20,12 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <properties>
+    <scala.binary.version>2.11</scala.binary.version>
+    <spark.version>2.4.0</spark.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -85,15 +88,15 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>bigquery-connector-common</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>spark-bigquery-connector-common</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -102,6 +105,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
   <build>
     <sourceDirectory>src/main/scala</sourceDirectory>
     <plugins>

--- a/spark-bigquery-dsv1/spark-bigquery-dsv1-parent/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery-dsv1-parent/pom.xml
@@ -204,6 +204,6 @@
           </execution>
         </executions>
       </plugin>
-    </plugins>
+     </plugins>
   </build>
 </project>

--- a/spark-bigquery-dsv1/spark-bigquery-dsv1-spark2-support/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery-dsv1-spark2-support/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
@@ -10,6 +10,7 @@
   </parent>
 
   <artifactId>spark-bigquery-dsv1-spark2-support</artifactId>
+
   <name>Spark BigQuery Connector Spark 2 Support</name>
   <licenses>
     <license>
@@ -18,6 +19,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/spark-bigquery-dsv1/spark-bigquery-dsv1-spark3-support/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery-dsv1-spark3-support/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
@@ -10,6 +10,7 @@
   </parent>
 
   <artifactId>spark-bigquery-dsv1-spark3-support</artifactId>
+
   <name>Spark BigQuery Connector Spark 3 Support</name>
   <licenses>
     <license>
@@ -18,6 +19,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/spark-bigquery-dsv1/spark-bigquery-with-dependencies-parent/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery-with-dependencies-parent/pom.xml
@@ -1,16 +1,18 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
     <version>${revision}</version>
     <relativePath>../../spark-bigquery-parent</relativePath>
   </parent>
+
   <artifactId>spark-bigquery-with-dependencies-parent</artifactId>
-  <name>BigQuery DataSource v1 shaded distributable common settings</name>
   <packaging>pom</packaging>
+
+  <name>BigQuery DataSource v1 shaded distributable common settings</name>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -18,6 +20,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -26,6 +29,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <!-- generating empty javadoc jar, for Maven Central publishing -->

--- a/spark-bigquery-dsv1/spark-bigquery-with-dependencies_2.11/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery-with-dependencies_2.11/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-with-dependencies-parent</artifactId>
@@ -10,11 +10,8 @@
   </parent>
 
   <artifactId>spark-bigquery-with-dependencies_2.11</artifactId>
+
   <name>BigQuery DataSource v1 shaded distributable for Scala 2.11</name>
-  <properties>
-    <scala.binary.version>2.11</scala.binary.version>
-    <shade.skip>false</shade.skip>
-  </properties>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -22,6 +19,12 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <properties>
+    <scala.binary.version>2.11</scala.binary.version>
+    <shade.skip>false</shade.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/spark-bigquery-dsv1/spark-bigquery-with-dependencies_2.12/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery-with-dependencies_2.12/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.google.cloud.spark</groupId>
         <artifactId>spark-bigquery-with-dependencies-parent</artifactId>
@@ -10,11 +10,8 @@
     </parent>
 
     <artifactId>spark-bigquery-with-dependencies_2.12</artifactId>
+
     <name>BigQuery DataSource v1 shaded distributable for Scala 2.12</name>
-    <properties>
-        <scala.binary.version>2.12</scala.binary.version>
-        <shade.skip>false</shade.skip>
-    </properties>
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
@@ -22,6 +19,12 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
+    <properties>
+        <scala.binary.version>2.12</scala.binary.version>
+        <shade.skip>false</shade.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -29,6 +32,7 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/spark-bigquery-dsv1/spark-bigquery-with-dependencies_2.13/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery-with-dependencies_2.13/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.google.cloud.spark</groupId>
         <artifactId>spark-bigquery-with-dependencies-parent</artifactId>
@@ -10,11 +10,8 @@
     </parent>
 
     <artifactId>spark-bigquery-with-dependencies_2.13</artifactId>
+
     <name>BigQuery DataSource v1 shaded distributable for Scala 2.13</name>
-    <properties>
-        <scala.binary.version>2.13</scala.binary.version>
-        <shade.skip>false</shade.skip>
-    </properties>
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
@@ -22,6 +19,12 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
+    <properties>
+        <scala.binary.version>2.13</scala.binary.version>
+        <shade.skip>false</shade.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -29,6 +32,7 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/spark-bigquery-dsv1/spark-bigquery_2.11/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery_2.11/pom.xml
@@ -1,6 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-dsv1-parent</artifactId>
@@ -9,11 +10,8 @@
   </parent>
 
   <artifactId>spark-bigquery_2.11</artifactId>
+
   <name>BigQuery DataSource v1 for Scala 2.11</name>
-  <properties>
-    <scala.binary.version>2.11</scala.binary.version>
-    <spark.version>2.4.0</spark.version>
-  </properties>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -21,6 +19,12 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <properties>
+    <scala.binary.version>2.11</scala.binary.version>
+    <spark.version>2.4.0</spark.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -29,6 +33,7 @@
       <version>${project.version}</version>
     </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <!-- make sure we don't have any _2.10 or _2.12 dependencies when building

--- a/spark-bigquery-dsv1/spark-bigquery_2.12/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery_2.12/pom.xml
@@ -1,6 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-dsv1-parent</artifactId>
@@ -9,11 +10,8 @@
   </parent>
 
   <artifactId>spark-bigquery_2.12</artifactId>
+
   <name>BigQuery DataSource v1 for Scala 2.12</name>
-  <properties>
-    <scala.binary.version>2.12</scala.binary.version>
-    <spark.version>2.4.0</spark.version>
-  </properties>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -21,6 +19,12 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <properties>
+    <scala.binary.version>2.12</scala.binary.version>
+    <spark.version>2.4.0</spark.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -41,6 +45,7 @@
       <version>${project.version}</version>
     </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <!-- make sure we don't have any _2.10 or _2.11 dependencies when building

--- a/spark-bigquery-dsv1/spark-bigquery_2.13/pom.xml
+++ b/spark-bigquery-dsv1/spark-bigquery_2.13/pom.xml
@@ -1,6 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-dsv1-parent</artifactId>
@@ -9,11 +10,8 @@
   </parent>
 
   <artifactId>spark-bigquery_2.13</artifactId>
+
   <name>BigQuery DataSource v1 for Scala 2.13</name>
-  <properties>
-    <scala.binary.version>2.13</scala.binary.version>
-    <spark.version>3.2.0</spark.version>
-  </properties>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -21,6 +19,12 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <properties>
+    <scala.binary.version>2.13</scala.binary.version>
+    <spark.version>3.2.0</spark.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -35,6 +39,7 @@
       <version>${project.version}</version>
     </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <!-- make sure we don't have any _2.10 or _2.11 dependencies when building

--- a/spark-bigquery-dsv2/pom.xml
+++ b/spark-bigquery-dsv2/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
@@ -10,8 +10,10 @@
   </parent>
 
   <artifactId>spark-bigquery-dsv2</artifactId>
-  <name>BigQuery DataSource v2 implementation</name>
   <packaging>pom</packaging>
+
+  <name>BigQuery DataSource v2 implementation</name>
+
   <modules>
     <module>spark-bigquery-dsv2-common</module>
     <module>spark-bigquery-dsv2-parent</module>

--- a/spark-bigquery-dsv2/spark-2.4-bigquery/pom.xml
+++ b/spark-bigquery-dsv2/spark-2.4-bigquery/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.google.cloud.spark</groupId>
         <artifactId>spark-bigquery-dsv2-parent</artifactId>
@@ -11,11 +11,8 @@
 
     <artifactId>spark-2.4-bigquery</artifactId>
     <version>${revision}</version>
+
     <name>BigQuery DataSource v2 for Spark 2.4</name>
-    <properties>
-        <spark.version>2.4.0</spark.version>
-        <shade.skip>false</shade.skip>
-    </properties>
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
@@ -23,6 +20,12 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
+    <properties>
+        <spark.version>2.4.0</spark.version>
+        <shade.skip>false</shade.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/spark-bigquery-dsv2/spark-3.1-bigquery-lib/pom.xml
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery-lib/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-dsv2-parent</artifactId>
@@ -11,11 +11,8 @@
 
   <artifactId>spark-3.1-bigquery-lib</artifactId>
   <version>${revision}</version>
+
   <name>Connector code for BigQuery DataSource v2 for Spark 3.1</name>
-  <properties>
-    <spark.version>3.1.0</spark.version>
-    <shade.skip>true</shade.skip>
-  </properties>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -23,6 +20,12 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <properties>
+    <spark.version>3.1.0</spark.version>
+    <shade.skip>true</shade.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>

--- a/spark-bigquery-dsv2/spark-3.1-bigquery/pom.xml
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-dsv2-parent</artifactId>
@@ -11,11 +11,8 @@
 
   <artifactId>spark-3.1-bigquery</artifactId>
   <version>${revision}</version>
+
   <name>BigQuery DataSource v2 for Spark 3.1</name>
-  <properties>
-    <spark.version>3.1.0</spark.version>
-    <shade.skip>false</shade.skip>
-  </properties>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -23,6 +20,12 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <properties>
+    <spark.version>3.1.0</spark.version>
+    <shade.skip>false</shade.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/spark-bigquery-dsv2/spark-3.2-bigquery-lib/pom.xml
+++ b/spark-bigquery-dsv2/spark-3.2-bigquery-lib/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-dsv2-parent</artifactId>
@@ -11,11 +11,8 @@
 
   <artifactId>spark-3.2-bigquery-lib</artifactId>
   <version>${revision}</version>
+
   <name>Connector code for BigQuery DataSource v2 for Spark 3.2</name>
-  <properties>
-    <spark.version>3.2.0</spark.version>
-    <shade.skip>true</shade.skip>
-  </properties>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -23,6 +20,12 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <properties>
+    <spark.version>3.2.0</spark.version>
+    <shade.skip>true</shade.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/spark-bigquery-dsv2/spark-3.2-bigquery/pom.xml
+++ b/spark-bigquery-dsv2/spark-3.2-bigquery/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-dsv2-parent</artifactId>
@@ -11,11 +11,8 @@
 
   <artifactId>spark-3.2-bigquery</artifactId>
   <version>${revision}</version>
+
   <name>BigQuery DataSource v2 for Spark 3.2</name>
-  <properties>
-    <spark.version>3.2.0</spark.version>
-    <shade.skip>false</shade.skip>
-  </properties>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -23,6 +20,12 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <properties>
+    <spark.version>3.2.0</spark.version>
+    <shade.skip>false</shade.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/spark-bigquery-dsv2/spark-3.3-bigquery-lib/pom.xml
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery-lib/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-dsv2-parent</artifactId>
@@ -11,11 +11,8 @@
 
   <artifactId>spark-3.3-bigquery-lib</artifactId>
   <version>${revision}</version>
+
   <name>Connector code for BigQuery DataSource v2 for Spark 3.3</name>
-  <properties>
-    <spark.version>3.3.0</spark.version>
-    <shade.skip>true</shade.skip>
-  </properties>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -23,6 +20,12 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <properties>
+    <spark.version>3.3.0</spark.version>
+    <shade.skip>true</shade.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/spark-bigquery-dsv2/spark-3.3-bigquery/pom.xml
+++ b/spark-bigquery-dsv2/spark-3.3-bigquery/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-dsv2-parent</artifactId>
@@ -11,11 +11,8 @@
 
   <artifactId>spark-3.3-bigquery</artifactId>
   <version>${revision}</version>
+
   <name>BigQuery DataSource v2 for Spark 3.3</name>
-  <properties>
-    <spark.version>3.3.0</spark.version>
-    <shade.skip>false</shade.skip>
-  </properties>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -23,6 +20,12 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <properties>
+    <spark.version>3.3.0</spark.version>
+    <shade.skip>false</shade.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/spark-bigquery-dsv2/spark-3.4-bigquery-lib/pom.xml
+++ b/spark-bigquery-dsv2/spark-3.4-bigquery-lib/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-dsv2-parent</artifactId>
@@ -11,11 +11,8 @@
 
   <artifactId>spark-3.4-bigquery-lib</artifactId>
   <version>${revision}</version>
+
   <name>Connector code for BigQuery DataSource v2 for Spark 3.3</name>
-  <properties>
-    <spark.version>3.4.0</spark.version>
-    <shade.skip>true</shade.skip>
-  </properties>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -23,6 +20,12 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <properties>
+    <spark.version>3.4.0</spark.version>
+    <shade.skip>true</shade.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/spark-bigquery-dsv2/spark-3.4-bigquery/pom.xml
+++ b/spark-bigquery-dsv2/spark-3.4-bigquery/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-dsv2-parent</artifactId>
@@ -11,11 +11,8 @@
 
   <artifactId>spark-3.4-bigquery</artifactId>
   <version>${revision}</version>
+
   <name>BigQuery DataSource v2 for Spark 3.4</name>
-  <properties>
-    <spark.version>3.4.0</spark.version>
-    <shade.skip>false</shade.skip>
-  </properties>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -23,6 +20,12 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <properties>
+    <spark.version>3.4.0</spark.version>
+    <shade.skip>false</shade.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/pom.xml
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.google.cloud.spark</groupId>
         <artifactId>spark-bigquery-parent</artifactId>
@@ -10,10 +10,8 @@
     </parent>
 
     <artifactId>spark-bigquery-dsv2-common</artifactId>
+
     <name>BigQuery DataSource v2 implementation common implementation</name>
-    <properties>
-        <spark.version>2.4.0</spark.version>
-    </properties>
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
@@ -21,6 +19,11 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
+    <properties>
+        <spark.version>2.4.0</spark.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -58,6 +61,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-parent/pom.xml
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-parent/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
@@ -10,11 +10,9 @@
   </parent>
 
   <artifactId>spark-bigquery-dsv2-parent</artifactId>
-  <name>BigQuery DataSource v2 implementation common settings</name>
   <packaging>pom</packaging>
-  <properties>
-    <spark.version>2.4.0</spark.version>
-  </properties>
+
+  <name>BigQuery DataSource v2 implementation common settings</name>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -22,6 +20,11 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <properties>
+    <spark.version>2.4.0</spark.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -59,6 +62,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <plugin>

--- a/spark-bigquery-dsv2/spark-bigquery-metrics/pom.xml
+++ b/spark-bigquery-dsv2/spark-bigquery-metrics/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.google.cloud.spark</groupId>
         <artifactId>spark-bigquery-dsv2-parent</artifactId>
@@ -11,11 +11,8 @@
 
     <artifactId>spark-bigquery-metrics</artifactId>
     <version>${revision}</version>
+
     <name>Custom Metrics code for BigQuery DataSource v2 for Spark 3.2</name>
-    <properties>
-        <spark.version>3.2.0</spark.version>
-        <shade.skip>true</shade.skip>
-    </properties>
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
@@ -23,6 +20,12 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
+    <properties>
+        <spark.version>3.2.0</spark.version>
+        <shade.skip>true</shade.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -485,6 +485,20 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>tidy-maven-plugin</artifactId>
+                <version>1.2.0</version>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
                 <configuration>

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -1,16 +1,16 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
     <version>${revision}</version>
     <packaging>pom</packaging>
+
     <name>Spark BigQuery Connector Build Parent</name>
     <description>Parent project for all the Spark BigQuery Connector artifacts
     </description>
     <url>https://github.com/GoogleCloudDataproc/spark-bigquery-connector</url>
-
     <licenses>
         <license>
             <name>Apache License, Version 2.0</name>
@@ -35,7 +35,6 @@
         </developerConnection>
         <url>git@github.com:GoogleCloudDataproc/spark-bigquery-connector.git</url>
     </scm>
-
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
@@ -73,6 +72,7 @@
         <checkstyle.header.file>${reactor.project.basedir}/java.header</checkstyle.header.file>
         -->
     </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -85,8 +85,8 @@
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
-                <scope>import</scope>
                 <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -303,6 +303,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>
@@ -662,6 +663,7 @@
             </plugin>
         </plugins>
     </build>
+
     <reporting>
         <plugins>
             <plugin>

--- a/spark-bigquery-pushdown/pom.xml
+++ b/spark-bigquery-pushdown/pom.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
-    <artifactId>spark-bigquery-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
+    <artifactId>spark-bigquery-parent</artifactId>
     <version>${revision}</version>
     <relativePath>../spark-bigquery-parent</relativePath>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
   <artifactId>spark-bigquery-pushdown</artifactId>
-  <name>Spark BigQuery Predicate Pushdown Implementation</name>
   <packaging>pom</packaging>
+
+  <name>Spark BigQuery Predicate Pushdown Implementation</name>
 
   <modules>
     <module>spark-bigquery-pushdown-parent</module>
@@ -27,5 +27,4 @@
     <module>spark-bigquery-pushdown-common_2.12</module>
     <module>spark-bigquery-pushdown-common_2.13</module>
   </modules>
-
 </project>

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11/pom.xml
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.11/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
-    <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
+    <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <version>${revision}</version>
     <relativePath>../spark-bigquery-pushdown-parent</relativePath>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
   <artifactId>spark-2.4-bigquery-pushdown_2.11</artifactId>
 
@@ -31,5 +30,4 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-
 </project>

--- a/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/pom.xml
+++ b/spark-bigquery-pushdown/spark-2.4-bigquery-pushdown_2.12/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
-    <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
+    <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <version>${revision}</version>
     <relativePath>../spark-bigquery-pushdown-parent</relativePath>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
   <artifactId>spark-2.4-bigquery-pushdown_2.12</artifactId>
 

--- a/spark-bigquery-pushdown/spark-3.1-bigquery-pushdown_2.12/pom.xml
+++ b/spark-bigquery-pushdown/spark-3.1-bigquery-pushdown_2.12/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
-    <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
+    <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <version>${revision}</version>
     <relativePath>../spark-bigquery-pushdown-parent</relativePath>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
   <artifactId>spark-3.1-bigquery-pushdown_2.12</artifactId>
 

--- a/spark-bigquery-pushdown/spark-3.2-bigquery-pushdown_2.12/pom.xml
+++ b/spark-bigquery-pushdown/spark-3.2-bigquery-pushdown_2.12/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
-    <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
+    <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <version>${revision}</version>
     <relativePath>../spark-bigquery-pushdown-parent</relativePath>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
   <artifactId>spark-3.2-bigquery-pushdown_2.12</artifactId>
 
@@ -31,5 +30,4 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-
 </project>

--- a/spark-bigquery-pushdown/spark-3.2-bigquery-pushdown_2.13/pom.xml
+++ b/spark-bigquery-pushdown/spark-3.2-bigquery-pushdown_2.13/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
-    <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
+    <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <version>${revision}</version>
     <relativePath>../spark-bigquery-pushdown-parent</relativePath>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
   <artifactId>spark-3.2-bigquery-pushdown_2.13</artifactId>
 
@@ -31,5 +30,4 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-
 </project>

--- a/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.12/pom.xml
+++ b/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.12/pom.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
-    <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
+    <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <version>${revision}</version>
     <relativePath>../spark-bigquery-pushdown-parent</relativePath>
   </parent>
@@ -31,5 +30,4 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-
 </project>

--- a/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.13/pom.xml
+++ b/spark-bigquery-pushdown/spark-3.3-bigquery-pushdown_2.13/pom.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
-    <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
+    <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <version>${revision}</version>
     <relativePath>../spark-bigquery-pushdown-parent</relativePath>
   </parent>
@@ -31,5 +30,4 @@
       <scope>provided</scope>
     </dependency>
   </dependencies>
-
 </project>

--- a/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.11/pom.xml
+++ b/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.11/pom.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
-    <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
+    <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <version>${revision}</version>
     <relativePath>../spark-bigquery-pushdown-parent</relativePath>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
   <artifactId>spark-bigquery-pushdown-common_2.11</artifactId>
+
   <properties>
     <scala.binary.version>2.11</scala.binary.version>
     <spark.version>2.4.0</spark.version>
@@ -45,5 +45,4 @@
       </plugin>
     </plugins>
   </build>
-
 </project>

--- a/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.12/pom.xml
+++ b/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.12/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
-    <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
+    <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <version>${revision}</version>
     <relativePath>../spark-bigquery-pushdown-parent</relativePath>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
   <artifactId>spark-bigquery-pushdown-common_2.12</artifactId>
 

--- a/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.13/pom.xml
+++ b/spark-bigquery-pushdown/spark-bigquery-pushdown-common_2.13/pom.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
-    <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
+    <artifactId>spark-bigquery-pushdown-parent</artifactId>
     <version>${revision}</version>
     <relativePath>../spark-bigquery-pushdown-parent</relativePath>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
   <artifactId>spark-bigquery-pushdown-common_2.13</artifactId>
 

--- a/spark-bigquery-pushdown/spark-bigquery-pushdown-parent/pom.xml
+++ b/spark-bigquery-pushdown/spark-bigquery-pushdown-parent/pom.xml
@@ -1,23 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
-    <artifactId>spark-bigquery-parent</artifactId>
     <groupId>com.google.cloud.spark</groupId>
+    <artifactId>spark-bigquery-parent</artifactId>
     <version>${revision}</version>
     <relativePath>../../spark-bigquery-parent</relativePath>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
   <artifactId>spark-bigquery-pushdown-parent</artifactId>
-  <name>Spark BigQuery Predicate Pushdown Implementation common settings</name>
-
   <packaging>pom</packaging>
-  <properties>
-    <scala.binary.version>2.11</scala.binary.version>
-    <spark.version>2.4.0</spark.version>
-  </properties>
+
+  <name>Spark BigQuery Predicate Pushdown Implementation common settings</name>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -25,6 +20,12 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
+  <properties>
+    <scala.binary.version>2.11</scala.binary.version>
+    <spark.version>2.4.0</spark.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -82,8 +83,8 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>spark-bigquery-connector-common</artifactId>
       <version>${project.version}</version>
-      <scope>test</scope>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -92,6 +93,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
   <build>
     <sourceDirectory>src/main/scala</sourceDirectory>
     <plugins>

--- a/spark-bigquery-python-lib/pom.xml
+++ b/spark-bigquery-python-lib/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
@@ -10,8 +10,9 @@
   </parent>
 
   <artifactId>spark-bigquery-support</artifactId>
-  <name>PySpark-BigQuery support library</name>
   <packaging>pom</packaging>
+
+  <name>PySpark-BigQuery support library</name>
 
   <build>
     <plugins>
@@ -31,5 +32,4 @@
       </plugin>
     </plugins>
   </build>
-
 </project>

--- a/spark-bigquery-scala-212-support/pom.xml
+++ b/spark-bigquery-scala-212-support/pom.xml
@@ -1,6 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>com.google.cloud.spark</groupId>
         <artifactId>spark-bigquery-parent</artifactId>
@@ -9,6 +10,7 @@
     </parent>
 
     <artifactId>spark-bigquery-scala-212-support</artifactId>
+
     <name>Spark BigQuery Scala 2.12 Support Library</name>
     <licenses>
         <license>
@@ -17,6 +19,7 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/spark-bigquery-tests/pom.xml
+++ b/spark-bigquery-tests/pom.xml
@@ -1,7 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>com.google.cloud.spark</groupId>
     <artifactId>spark-bigquery-parent</artifactId>
@@ -10,6 +10,7 @@
   </parent>
 
   <artifactId>spark-bigquery-tests</artifactId>
+
   <name>BigQuery Connector Tests Support</name>
   <licenses>
     <license>
@@ -18,6 +19,7 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
No code changes were made. The first (larges) commit was done by calling `./mvnw tidy:pom`