### PR TITLE
Handle NPE case when reading BQ table with NUMERIC fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+* PR #1061: Handle NPE case when reading BQ table with NUMERIC fields. Thanks @hayssams !
 * Issue #867: Support writing with RangePartitioning
 * Issue #144: allow writing Spark String to BQ TIME type
 * PR #1038: Logical plan now shows the BigQuery table of DirectBigQueryRelation. Thanks @idc101 !

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,13 +3,12 @@
 ## Next
 
 * PR #1061: Handle NPE case when reading BQ table with NUMERIC fields. Thanks @hayssams !
-* Issue #867: Support writing with RangePartitioning
 * Issue #144: allow writing Spark String to BQ TIME type
 * Issue #867: Support writing with RangePartitioning
 * PR #1008: Adding support to expose bigquery metrics using Spark custom metrics API.
 * PR #1038: Logical plan now shows the BigQuery table of DirectBigQueryRelation. Thanks @idc101 !
 * PR #1058: View names will appear in query plan instead of the materialized table
-*
+
 ## 0.32.2 - 2023-08-07
 
 * CVE-2023-34462: Upgrading netty to verision 4.1.96.Final

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SchemaConverters.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SchemaConverters.java
@@ -199,9 +199,16 @@ public class SchemaConverters {
     if (LegacySQLTypeName.NUMERIC.equals(bqField.getType())
         || LegacySQLTypeName.BIGNUMERIC.equals(bqField.getType())) {
       byte[] bytes = getBytes((ByteBuffer) value);
-      int scale = bqField.getScale().intValue();
+      int scale =
+              Optional.ofNullable(bqField.getScale())
+                      .map(Long::intValue)
+                      .orElse(BigQueryUtil.DEFAULT_NUMERIC_SCALE);
       BigDecimal b = new BigDecimal(new BigInteger(bytes), scale);
-      Decimal d = Decimal.apply(b, bqField.getPrecision().intValue(), scale);
+      int precision =
+              Optional.ofNullable(bqField.getPrecision())
+                      .map(Long::intValue)
+                      .orElse(BigQueryUtil.DEFAULT_NUMERIC_PRECISION);
+      Decimal d = Decimal.apply(b, precision, scale);
 
       return d;
     }

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SchemaConverters.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SchemaConverters.java
@@ -200,14 +200,14 @@ public class SchemaConverters {
         || LegacySQLTypeName.BIGNUMERIC.equals(bqField.getType())) {
       byte[] bytes = getBytes((ByteBuffer) value);
       int scale =
-              Optional.ofNullable(bqField.getScale())
-                      .map(Long::intValue)
-                      .orElse(BigQueryUtil.DEFAULT_NUMERIC_SCALE);
+          Optional.ofNullable(bqField.getScale())
+              .map(Long::intValue)
+              .orElse(BigQueryUtil.DEFAULT_NUMERIC_SCALE);
       BigDecimal b = new BigDecimal(new BigInteger(bytes), scale);
       int precision =
-              Optional.ofNullable(bqField.getPrecision())
-                      .map(Long::intValue)
-                      .orElse(BigQueryUtil.DEFAULT_NUMERIC_PRECISION);
+          Optional.ofNullable(bqField.getPrecision())
+              .map(Long::intValue)
+              .orElse(BigQueryUtil.DEFAULT_NUMERIC_PRECISION);
       Decimal d = Decimal.apply(b, precision, scale);
 
       return d;


### PR DESCRIPTION
Fix Null pointer exception when updating an existing bigquery table with NUMERIC attributes without scale and precision explicitly set