### PR TITLE
Avoid empty partitions during DPP

### DIFF
--- a/spark-bigquery-dsv2/spark-3.2-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark32BigQueryScanBuilder.java
+++ b/spark-bigquery-dsv2/spark-3.2-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark32BigQueryScanBuilder.java
@@ -53,6 +53,8 @@ public class Spark32BigQueryScanBuilder extends Spark31BigQueryScanBuilder
   @Override
   public void filter(Filter[] filters) {
     ctx.filter(filters);
+    // force partitions re-assignment
+    super.partitions = null;
   }
 
   @Override

--- a/spark-bigquery-dsv2/spark-3.2-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark32BigQueryScanBuilder.java
+++ b/spark-bigquery-dsv2/spark-3.2-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark32BigQueryScanBuilder.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.apache.spark.sql.connector.expressions.Expressions;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.metric.CustomMetric;
@@ -55,14 +56,14 @@ public class Spark32BigQueryScanBuilder extends Spark31BigQueryScanBuilder
 
   @Override
   public void filter(Filter[] filters) {
-    List<ArrowInputPartitionContext> newInputPartitionContexts = ctx.filter(filters);
+    Optional<List<ArrowInputPartitionContext>> newInputPartitionContexts = ctx.filter(filters);
     // re-assign partitions
-    if (newInputPartitionContexts != null) {
-      super.partitions =
-          newInputPartitionContexts.stream()
-              .map(inputPartitionContext -> new BigQueryInputPartition(inputPartitionContext))
-              .toArray(InputPartition[]::new);
-    }
+    newInputPartitionContexts.ifPresent(
+        arrowInputPartitionContexts ->
+            super.partitions =
+                arrowInputPartitionContexts.stream()
+                    .map(BigQueryInputPartition::new)
+                    .toArray(InputPartition[]::new));
   }
 
   @Override

--- a/spark-bigquery-dsv2/spark-3.2-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark32BigQueryScanBuilder.java
+++ b/spark-bigquery-dsv2/spark-3.2-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark32BigQueryScanBuilder.java
@@ -16,14 +16,17 @@
 package com.google.cloud.spark.bigquery.v2;
 
 import com.google.cloud.bigquery.connector.common.BigQueryUtil;
+import com.google.cloud.spark.bigquery.v2.context.ArrowInputPartitionContext;
 import com.google.cloud.spark.bigquery.v2.context.BigQueryDataSourceReaderContext;
 import com.google.cloud.spark.bigquery.v2.customMetrics.*;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Arrays;
+import java.util.List;
 import org.apache.spark.sql.connector.expressions.Expressions;
 import org.apache.spark.sql.connector.expressions.NamedReference;
 import org.apache.spark.sql.connector.metric.CustomMetric;
+import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 import org.apache.spark.sql.connector.read.SupportsRuntimeFiltering;
 import org.apache.spark.sql.sources.Filter;
@@ -52,9 +55,14 @@ public class Spark32BigQueryScanBuilder extends Spark31BigQueryScanBuilder
 
   @Override
   public void filter(Filter[] filters) {
-    ctx.filter(filters);
-    // force partitions re-assignment
-    super.partitions = null;
+    List<ArrowInputPartitionContext> newInputPartitionContexts = ctx.filter(filters);
+    // re-assign partitions
+    if (newInputPartitionContexts != null) {
+      super.partitions =
+          newInputPartitionContexts.stream()
+              .map(inputPartitionContext -> new BigQueryInputPartition(inputPartitionContext))
+              .toArray(InputPartition[]::new);
+    }
   }
 
   @Override

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/ArrowInputPartitionContext.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/ArrowInputPartitionContext.java
@@ -28,7 +28,6 @@ import com.google.cloud.spark.bigquery.metrics.SparkMetricsSource;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -93,13 +92,5 @@ public class ArrowInputPartitionContext implements InputPartitionContext<Columna
   @Override
   public boolean supportColumnarReads() {
     return true;
-  }
-
-  public void resetStreamNamesFrom(ArrowInputPartitionContext ctx) {
-    this.streamNames = ImmutableList.copyOf(ctx.streamNames);
-  }
-
-  public void clearStreamsList() {
-    this.streamNames = Collections.emptyList();
   }
 }

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryDataSourceReaderContext.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryDataSourceReaderContext.java
@@ -386,22 +386,6 @@ public class BigQueryDataSourceReaderContext {
         String.format(
             "Use Dynamic Partition Pruning, originally planned %d, adjust to %d partitions",
             previousInputPartitionContexts.size(), plannedInputPartitionContexts.size()));
-
-    // TODO: Spread streams more evenly. This solution reduces the parallelism as it potentially
-    // leaves partitions without streams while other may have more than one stream.
-
-    // first let's update the streams in the previous planned partitions
-    for (int i = 0; i < plannedInputPartitionContexts.size(); i++) {
-      previousInputPartitionContexts
-          .get(i)
-          .resetStreamNamesFrom(plannedInputPartitionContexts.get(i));
-    }
-    // second, clear the redundant partitions
-    for (int i = plannedInputPartitionContexts.size();
-        i < previousInputPartitionContexts.size();
-        i++) {
-      previousInputPartitionContexts.get(i).clearStreamsList();
-    }
   }
 
   public void pruneColumns(StructType requiredSchema) {


### PR DESCRIPTION
During Dynamic partition pruning, we currently retain the number of partitions. To reassign new (fewer) DPP partitions to the older reported partitions, we assign empty partition values to the remaining partitions.

This change resets the partitions entirely and does not attempt to retain partition numbers.