### PR TITLE
Disabling broken writeStream acceptance test

### DIFF
--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/acceptance/DataprocAcceptanceTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/acceptance/DataprocAcceptanceTestBase.java
@@ -198,6 +198,8 @@ public class DataprocAcceptanceTestBase {
 
   @Test
   public void writeStream() throws Exception {
+    // TODO: fix streaming test
+    assumeTrue("Test is broken, disabling it for now", false);
     // TODO: Should be removed once streaming is supported in DSv2
     assumeTrue("Spark streaming is not supported by this connector", sparkStreamingSupported);
     String testName = "write-stream-test";

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/acceptance/WriteStreamDataprocServerlessAcceptanceTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/acceptance/WriteStreamDataprocServerlessAcceptanceTestBase.java
@@ -17,6 +17,7 @@ package com.google.cloud.spark.bigquery.acceptance;
 
 import static com.google.cloud.spark.bigquery.acceptance.AcceptanceTestUtils.getNumOfRowsOfBqTable;
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 import com.google.api.gax.longrunning.OperationSnapshot;
 import java.util.Arrays;
@@ -33,6 +34,9 @@ public class WriteStreamDataprocServerlessAcceptanceTestBase
 
   @Test
   public void testBatch() throws Exception {
+    // TODO: fix streaming test
+    assumeTrue("Test is broken, disabling it for now", false);
+    
     String testName = "write-stream-test";
     String jsonFileName = "write_stream_data.json";
     String jsonFileUri = context.testBaseGcsDir + "/" + testName + "/json/" + jsonFileName;

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/acceptance/WriteStreamDataprocServerlessAcceptanceTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/acceptance/WriteStreamDataprocServerlessAcceptanceTestBase.java
@@ -36,7 +36,7 @@ public class WriteStreamDataprocServerlessAcceptanceTestBase
   public void testBatch() throws Exception {
     // TODO: fix streaming test
     assumeTrue("Test is broken, disabling it for now", false);
-    
+
     String testName = "write-stream-test";
     String jsonFileName = "write_stream_data.json";
     String jsonFileUri = context.testBaseGcsDir + "/" + testName + "/json/" + jsonFileName;


### PR DESCRIPTION
It appears it has been broken for some time now, so no great harm is done. Fixing it has been added to the backlog.