### PR TITLE
add missing backslashes for multi-line python example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1127,15 +1127,15 @@ using the following code:
 **Python:**
 ```python
 from pyspark.sql import SparkSession
-spark = SparkSession.builder
-  .config("spark.jars.packages", "com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:0.33.0")
+spark = SparkSession.builder \
+  .config("spark.jars.packages", "com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:0.33.0") \
   .getOrCreate()
-df = spark.read.format("bigquery")
+df = spark.read.format("bigquery") \
   .load("dataset.table")
 ```
 
 **Scala:**
-```python
+```scala
 val spark = SparkSession.builder
 .config("spark.jars.packages", "com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:0.33.0")
 .getOrCreate()


### PR DESCRIPTION
Fixing example under [**Using in Jupyter Notebooks**](https://github.com/GoogleCloudDataproc/spark-bigquery-connector#using-in-jupyter-notebooks). 

The python example was missing `\` for the multi-line statement. Also, the scala example was tagged as python language so syntax highlighting wasn't working.