### PR TITLE
Fixing the nightly build

### DIFF
--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryUtil.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryUtil.java
@@ -37,7 +37,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.validation.constraints.NotNull;
 import org.apache.hadoop.conf.Configuration;
@@ -46,13 +45,9 @@ import org.apache.hadoop.fs.Path;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.catalyst.expressions.AttributeReference;
-import org.apache.spark.sql.catalyst.expressions.NamedExpression;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.Metadata;
-import org.apache.spark.sql.types.StructType;
-import scala.collection.mutable.ListBuffer;
 
 /** Spark related utilities */
 public class SparkBigQueryUtil {
@@ -285,21 +280,5 @@ public class SparkBigQueryUtil {
         .findFirst()
         .ifPresent(tag -> labels.put("dataproc_job_uuid", tag.substring(tag.lastIndexOf('_') + 1)));
     return labels.build();
-  }
-
-  public static List<AttributeReference> schemaToAttributeReferences(StructType schema) {
-    List<AttributeReference> result =
-        Stream.of(schema.fields())
-            .map(
-                field ->
-                    new AttributeReference(
-                        field.name(),
-                        field.dataType(),
-                        field.nullable(),
-                        field.metadata(),
-                        NamedExpression.newExprId(),
-                        new ListBuffer<String>().toStream()))
-            .collect(Collectors.toList());
-    return result;
   }
 }

--- a/spark-bigquery-connector-common/src/main/java/org/apache/spark/sql/Scala213SparkSqlUtils.java
+++ b/spark-bigquery-connector-common/src/main/java/org/apache/spark/sql/Scala213SparkSqlUtils.java
@@ -15,17 +15,19 @@
  */
 package org.apache.spark.sql;
 
-import com.google.cloud.spark.bigquery.SparkBigQueryUtil;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer$;
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder;
 import org.apache.spark.sql.catalyst.encoders.RowEncoder;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.catalyst.expressions.AttributeReference;
+import org.apache.spark.sql.catalyst.expressions.NamedExpression;
 import org.apache.spark.sql.types.StructType;
 import scala.collection.JavaConverters;
+import scala.collection.mutable.ListBuffer;
 
 public class Scala213SparkSqlUtils extends SparkSqlUtils {
 
@@ -59,7 +61,18 @@ public class Scala213SparkSqlUtils extends SparkSqlUtils {
   // `toAttributes` is protected[sql] starting spark 3.2.0, so we need this call to be in the same
   // package. Since Scala 2.13/Spark 3.3 forbids it, the implementation has been ported to Java
   public static scala.collection.immutable.Seq<AttributeReference> toAttributes(StructType schema) {
-    return JavaConverters.asScalaBuffer(SparkBigQueryUtil.schemaToAttributeReferences(schema))
+    return JavaConverters.asScalaBuffer(
+            Stream.of(schema.fields())
+                .map(
+                    field ->
+                        new AttributeReference(
+                            field.name(),
+                            field.dataType(),
+                            field.nullable(),
+                            field.metadata(),
+                            NamedExpression.newExprId(),
+                            new ListBuffer<String>().toStream()))
+                .collect(Collectors.toList()))
         .toSeq();
   }
 }

--- a/spark-bigquery-scala-212-support/src/main/java/org/apache/spark/sql/PreScala213SparkSqlUtils.java
+++ b/spark-bigquery-scala-212-support/src/main/java/org/apache/spark/sql/PreScala213SparkSqlUtils.java
@@ -15,17 +15,19 @@
  */
 package org.apache.spark.sql;
 
-import com.google.cloud.spark.bigquery.SparkBigQueryUtil;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.analysis.SimpleAnalyzer$;
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder;
 import org.apache.spark.sql.catalyst.encoders.RowEncoder;
 import org.apache.spark.sql.catalyst.expressions.Attribute;
 import org.apache.spark.sql.catalyst.expressions.AttributeReference;
+import org.apache.spark.sql.catalyst.expressions.NamedExpression;
 import org.apache.spark.sql.types.StructType;
 import scala.collection.JavaConverters;
+import scala.collection.mutable.ListBuffer;
 
 public class PreScala213SparkSqlUtils extends SparkSqlUtils {
 
@@ -57,8 +59,19 @@ public class PreScala213SparkSqlUtils extends SparkSqlUtils {
 
   // `toAttributes` is protected[sql] starting spark 3.2.0, so we need this call to be in the same
   // package. Since Scala 2.13/Spark 3.3 forbids it, the implementation has been ported to Java
-  public static scala.collection.Seq<AttributeReference> toAttributes(StructType schema) {
-    return JavaConverters.asScalaBuffer(SparkBigQueryUtil.schemaToAttributeReferences(schema))
+  public static scala.collection.Seq<AttributeReference> toAttributes(StructType schema212) {
+    return JavaConverters.asScalaBuffer(
+            Stream.of(schema212.fields())
+                .map(
+                    field212 ->
+                        new AttributeReference(
+                            field212.name(),
+                            field212.dataType(),
+                            field212.nullable(),
+                            field212.metadata(),
+                            NamedExpression.newExprId(),
+                            new ListBuffer<String>().toStream()))
+                .collect(Collectors.toList()))
         .toSeq();
   }
 }


### PR DESCRIPTION
The `AttributeReference` class depends on Scala's `Seq`. As scala 2.13 has changed the Seq alias, we need to compile it's usages in different artifacts as the final bytecode  contains the aliased Seq, not `scala.Seq`. It means that if we compile using spark-sql_2.12 dependency it won't work on Scala 2.13, and vice versa.

The names of the variables were changed in order to avoid CPD errors.