### PR TITLE
Improve read session caching key

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Next
 
 * PR #1117: Make read session caching duration configurable
+* PR #1118: Improve read session caching key
 
 ## 0.34.0 - 2023-10-31
 


### PR DESCRIPTION
We use pushed filters indirectly as a key in read session cache. However, it misses caching opportunities for duplicated filters and out of order filters.
This fixes that.
