### PR TITLE
Upgrade bigquery storage library to pick up fix

### DIFF
--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -55,7 +55,7 @@
         <arrow.version>13.0.0</arrow.version>
         <gax.version>2.35.0</gax.version>
         <google-cloud-bigquery.version>2.33.2</google-cloud-bigquery.version>
-        <google-cloud-bigquerystorage.version>2.45.0</google-cloud-bigquerystorage.version>
+        <google-cloud-bigquerystorage.version>2.46.0</google-cloud-bigquerystorage.version>
         <google-cloud-dataproc.version>4.25.0</google-cloud-dataproc.version>
         <google-cloud-storage.version>2.28.0</google-cloud-storage.version>
         <google-truth.version>1.1.5</google-truth.version>


### PR DESCRIPTION
Pickup bugfix made to ensure the initial retry delay is respected

https://github.com/googleapis/java-bigquerystorage/releases/tag/v2.46.0