### PR TITLE
allow writing spark string to BQ datetime

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+* PR #1153: allow writing spark string to BQ datetime
+
 ## 0.35.0 - 2023-12-19
 
 * PR #1115: Added new connector, `spark-3.5-bigquery` aimed to be used in Spark 3.5. This connector implements new APIs and capabilities provided by the Spark Data Source V2 API.

--- a/README-template.md
+++ b/README-template.md
@@ -1016,11 +1016,13 @@ With the exception of `DATETIME` and `TIME` all BigQuery data types directed map
   <tr valign="top">
    <td><strong><code>DATETIME</code></strong>
    </td>
-   <td><strong><code>StringType</code></strong>
+   <td><strong><code>StringType</code>, </strong><strong><code>TimestampNTZType</code>*</strong>
    </td>
    <td>Spark has no DATETIME type.
     <p>
     Spark string can be written to an existing BQ DATETIME column provided it is in the <a href="https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#canonical_format_for_datetime_literals">format for BQ DATETIME literals</a>.
+    <p>
+    * For Spark 3.4+, BQ DATETIME is read as Spark's TimestampNTZ type i.e. java LocalDateTime
    </td>
   </tr>
   <tr valign="top">

--- a/README-template.md
+++ b/README-template.md
@@ -1019,6 +1019,8 @@ With the exception of `DATETIME` and `TIME` all BigQuery data types directed map
    <td><strong><code>StringType</code></strong>
    </td>
    <td>Spark has no DATETIME type.
+    <p>
+    Spark string can be written to an existing BQ DATETIME column provided it is in the <a href="https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#canonical_format_for_datetime_literals">format for BQ DATETIME literals</a>.
    </td>
   </tr>
   <tr valign="top">

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
@@ -347,6 +347,8 @@ public class BigQueryUtil {
             && destinationType.equals(LegacySQLTypeName.BIGNUMERIC))
         || (sourceType.equals(LegacySQLTypeName.STRING)
             && destinationType.equals(LegacySQLTypeName.TIME))
+        || (sourceType.equals(LegacySQLTypeName.STRING)
+            && destinationType.equals(LegacySQLTypeName.DATETIME))
         || sourceType.equals(destinationType);
   }
 

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -55,6 +55,7 @@ import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1480,8 +1481,16 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
     assertThat(result).hasSize(1);
     Row head = result.get(0);
     assertThat(head.getString(head.fieldIndex("name"))).isEqualTo("abc");
-    assertThat(head.getString(head.fieldIndex("datetime1")))
-        .isEqualTo("0001-01-01T01:22:24.999888");
+    if (timeStampNTZType.isPresent()) {
+      // For Spark 3.4+, BQ's datetime is converted to Spark's TimestampNTZ i.e. LocalDateTime
+      LocalDateTime expected = LocalDateTime.of(1,1,1,1,22,24).plus(999888, ChronoUnit.MICROS);
+      assertThat(head.get(head.fieldIndex("datetime1")))
+          .isEqualTo(expected);
+    } else {
+      assertThat(head.get(head.fieldIndex("datetime1")))
+          .isEqualTo("0001-01-01T01:22:24.999888");
+    }
+
   }
 
   protected Dataset<Row> writeAndLoadDatasetOverwriteDynamicPartition(Dataset<Row> df) {

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -1480,7 +1480,8 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
     assertThat(result).hasSize(1);
     Row head = result.get(0);
     assertThat(head.getString(head.fieldIndex("name"))).isEqualTo("abc");
-    assertThat(head.getString(head.fieldIndex("datetime1"))).isEqualTo("0001-01-01T01:22:24.999888");
+    assertThat(head.getString(head.fieldIndex("datetime1")))
+        .isEqualTo("0001-01-01T01:22:24.999888");
   }
 
   protected Dataset<Row> writeAndLoadDatasetOverwriteDynamicPartition(Dataset<Row> df) {

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -1482,15 +1482,12 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
     Row head = result.get(0);
     assertThat(head.getString(head.fieldIndex("name"))).isEqualTo("abc");
     if (timeStampNTZType.isPresent()) {
-      // For Spark 3.4+, BQ's datetime is converted to Spark's TimestampNTZ i.e. LocalDateTime
-      LocalDateTime expected = LocalDateTime.of(1,1,1,1,22,24).plus(999888, ChronoUnit.MICROS);
-      assertThat(head.get(head.fieldIndex("datetime1")))
-          .isEqualTo(expected);
+      // For Spark 3.4+, BQ's datetime is converted to Spark's TimestampNTZ i.e. java LocalDateTime
+      LocalDateTime expected = LocalDateTime.of(1, 1, 1, 1, 22, 24).plus(999888, ChronoUnit.MICROS);
+      assertThat(head.get(head.fieldIndex("datetime1"))).isEqualTo(expected);
     } else {
-      assertThat(head.get(head.fieldIndex("datetime1")))
-          .isEqualTo("0001-01-01T01:22:24.999888");
+      assertThat(head.get(head.fieldIndex("datetime1"))).isEqualTo("0001-01-01T01:22:24.999888");
     }
-
   }
 
   protected Dataset<Row> writeAndLoadDatasetOverwriteDynamicPartition(Dataset<Row> df) {


### PR DESCRIPTION
Currently, there is no way to write to a BQ datetime column from Spark <= 3.3 (Spark 3.4+ has TimestampNTZ).
This PR adds the functionality to do so by allowing String to write to datetime.