### PR TITLE
Wrap filter parentheses in compileFilter

### DIFF
--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkFilterUtils.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkFilterUtils.java
@@ -301,6 +301,7 @@ public class SparkFilterUtils {
     return StreamSupport.stream(filters.spliterator(), false)
         .map(SparkFilterUtils::compileFilter)
         .sorted()
+        .map(filter -> "(" + filter.get() + ")")
         .collect(Collectors.joining(" AND "));
   }
 


### PR DESCRIPTION
I believe there is a bug with this line of code https://github.com/GoogleCloudDataproc/spark-bigquery-connector/blob/51d8105f73b278296b814d4de9360563c655b346/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkFilterUtils.java#L304

Specifically, this function compiles multiple filters and joins them with `" AND "` but doesn't wrap each filter in parentheses. I noticed weird behavior when compiling this filter:

```
[
    Or(Not(EqualNullSafe(foo, 0.0)), Not(EqualNullSafe(bar, 0.0))),
    EqualNullSafe(foo, 0.0),
    EqualNullSafe(bar, 0.0),
]
```

which should *never* return any rows (a clearer way of reading this is `NOT ((foo == 0) AND (bar == 0)) AND ((foo == 0) AND (bar == 0))`).

After compiling though, you get the following SQL:
```sql
(
    ((NOT (`foo` IS NULL AND 0 IS NULL OR `foo` IS NOT NULL AND 0 IS NOT NULL AND `foo` = 0))) OR
    ((NOT (`bar` IS NULL AND 0 IS NULL OR `bar` IS NOT NULL AND 0 IS NOT NULL AND `bar` = 0)))
) AND
`bar` IS NULL AND 0 IS NULL OR `bar` IS NOT NULL AND 0 IS NOT NULL AND `bar` = 0 AND
`foo` IS NULL AND 0 IS NULL OR `foo` IS NOT NULL AND 0 IS NOT NULL AND `foo` = 0
```


I believe the solution is adding `.map(filter -> "(" + filter.get() + ")")` before the joining with `" AND "`.