### PR TITLE
Fix filters by adding surrounding parenthesis

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * PR #1155: allow lazy materialization of query on load
 * PR #1163: Added config to set the BigQuery Job timeout
+* PR #1166: Fix filters by adding surrounding parenthesis. Thanks @tom-s-powell !
 * Issue #1116: BigQuery write fails with MessageSize is too large
 
 ## 0.35.1 - 2023-12-28

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkFilterUtilsTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkFilterUtilsTest.java
@@ -187,12 +187,12 @@ public class SparkFilterUtilsTest {
         .isEqualTo("`foo` IS NOT NULL");
     assertThat(
             SparkFilterUtils.compileFilter(And.apply(IsNull.apply("foo"), IsNotNull.apply("bar"))))
-        .isEqualTo("((`foo` IS NULL) AND (`bar` IS NOT NULL))");
+        .isEqualTo("(`foo` IS NULL) AND (`bar` IS NOT NULL)");
     assertThat(
             SparkFilterUtils.compileFilter(Or.apply(IsNull.apply("foo"), IsNotNull.apply("bar"))))
-        .isEqualTo("((`foo` IS NULL) OR (`bar` IS NOT NULL))");
+        .isEqualTo("(`foo` IS NULL) OR (`bar` IS NOT NULL)");
     assertThat(SparkFilterUtils.compileFilter(Not.apply(IsNull.apply("foo"))))
-        .isEqualTo("(NOT (`foo` IS NULL))");
+        .isEqualTo("NOT (`foo` IS NULL)");
   }
 
   @Test
@@ -261,9 +261,9 @@ public class SparkFilterUtilsTest {
         pushAllFilters,
         dataFormat,
         "",
-        "(((((`c1` >= 100) OR (`c1` <= 700))) OR (`c2` <= 900)) "
-            + "AND ((((`c1` >= 500) OR (`c1` <= 70))) OR (((`c1` >= 900) OR "
-            + "(`c3` <= 50)))) AND ((`c1` >= 5000) OR (`c1` <= 701)))",
+        "(((`c1` >= 100) OR (`c1` <= 700)) OR (`c2` <= 900)) "
+            + "AND (((`c1` >= 500) OR (`c1` <= 70)) OR ((`c1` >= 900) OR "
+            + "(`c3` <= 50))) AND ((`c1` >= 5000) OR (`c1` <= 701))",
         Optional.empty(),
         part1,
         part2,
@@ -289,7 +289,7 @@ public class SparkFilterUtilsTest {
         pushAllFilters,
         dataFormat,
         "",
-        "(((((`c1` >= 500) AND (`c2` <= 300))) OR (((`c1` <= 800) AND (`c3` >= 230)))))",
+        "(((`c1` >= 500) AND (`c2` <= 300)) OR ((`c1` <= 800) AND (`c3` >= 230)))",
         Optional.empty(),
         filter);
   }
@@ -329,11 +329,44 @@ public class SparkFilterUtilsTest {
         pushAllFilters,
         dataFormat,
         "",
-        "(((((((`c1` >= 5000) OR (`c1` <= 701))) AND "
-            + "(((`c2` >= 150) OR (`c3` >= 100))))) OR (((((`c1` >= 50) OR "
-            + "(`c1` <= 71))) AND (((`c2` >= 15) OR (`c3` >= 10)))))) AND "
+        "((((`c1` >= 5000) OR (`c1` <= 701)) AND "
+            + "((`c2` >= 150) OR (`c3` >= 100))) OR (((`c1` >= 50) OR "
+            + "(`c1` <= 71)) AND ((`c2` >= 15) OR (`c3` >= 10)))) AND "
             + "((`c1` >= 500) OR (`c1` <= 70)) AND ((`c1` >= 900) OR "
-            + "(((`c3` <= 50) AND (((`c2` >= 20) OR (`c3` > 200)))))))",
+            + "((`c3` <= 50) AND ((`c2` >= 20) OR (`c3` > 200))))",
+        Optional.empty(),
+        part1,
+        part2,
+        part3);
+  }
+
+  @Test
+  public void testFiltersWithNestedOrAnd_4() {
+    if (dataFormat == ARROW && !pushAllFilters) {
+      // If pushAllFilters isn't true, the following test won't pass for ARROW.
+      return;
+    }
+
+    Filter part1 =
+        Or.apply(
+            Not.apply(EqualNullSafe.apply("c1", 500)), Not.apply(EqualNullSafe.apply("c2", 500)));
+
+    Filter part2 = EqualNullSafe.apply("c1", 500);
+
+    Filter part3 = EqualNullSafe.apply("c2", 500);
+
+    checkFilters(
+        pushAllFilters,
+        dataFormat,
+        "",
+        "((NOT (`c1` IS NULL AND 500 IS NULL OR `c1` IS NOT NULL "
+            + "AND 500 IS NOT NULL AND `c1` = 500)) "
+            + "OR (NOT (`c2` IS NULL AND 500 IS NULL OR `c2` IS NOT NULL "
+            + "AND 500 IS NOT NULL AND `c2` = 500))) "
+            + "AND (`c1` IS NULL AND 500 IS NULL OR `c1` IS NOT NULL "
+            + "AND 500 IS NOT NULL AND `c1` = 500) "
+            + "AND (`c2` IS NULL AND 500 IS NULL OR `c2` IS NOT NULL "
+            + "AND 500 IS NOT NULL AND `c2` = 500)",
         Optional.empty(),
         part1,
         part2,


### PR DESCRIPTION
Below is an example of a filter where the SQL generated is incorrect:
```
[
    Or(Not(EqualNullSafe(foo, 0.0)), Not(EqualNullSafe(bar, 0.0))),
    EqualNullSafe(foo, 0.0),
    EqualNullSafe(bar, 0.0),
]
```
This generates the following SQL query:
```
(((NOT (`foo` IS NULL AND 0 IS NULL OR `foo` IS NOT NULL AND 0 IS NOT NULL AND `foo` = 0))) OR ((NOT (`bar` IS NULL AND 0 IS NULL OR `bar` IS NOT NULL AND 0 IS NOT NULL AND `bar` = 0)))) AND `bar` IS NULL AND 0 IS NULL OR `bar` IS NOT NULL AND 0 IS NOT NULL AND `bar` = 0 AND `foo` IS NULL AND 0 IS NULL OR `foo` IS NOT NULL AND 0 IS NOT NULL AND `foo` = 0
```
If you take a simple table as follows:
![Screenshot 2024-01-11 at 17 59 44](https://github.com/GoogleCloudDataproc/spark-bigquery-connector/assets/5518857/b19a30cc-3c5c-43ba-bbd1-c27e85f42c0d)

The query above returns the following results, whereas it clearly should be empty:
![Screenshot 2024-01-11 at 17 59 59](https://github.com/GoogleCloudDataproc/spark-bigquery-connector/assets/5518857/1e6f7cee-bb14-4fac-9c5a-0cbbfa0066ba)

With this change each filter will be surrounded by `(...)`, getting you:
```
(((NOT (`foo` IS NULL AND 0 IS NULL OR `foo` IS NOT NULL AND 0 IS NOT NULL AND `foo` = 0))) OR ((NOT (`bar` IS NULL AND 0 IS NULL OR `bar` IS NOT NULL AND 0 IS NOT NULL AND `bar` = 0)))) AND (`bar` IS NULL AND 0 IS NULL OR `bar` IS NOT NULL AND 0 IS NOT NULL AND `bar` = 0) AND (`foo` IS NULL AND 0 IS NULL OR `foo` IS NOT NULL AND 0 IS NOT NULL AND `foo` = 0)
```
This correctly returns an empty set of results.
