### PR TITLE
add option to request lz4 compressed ReadRowsResponse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ AdAdHocITSuite.scala
 
 # Mac
 .DS_Store
+
+# Visual Studio IDE
+.vscode/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,10 +1,10 @@
 # Release Notes
 
 ## Next
+* PR #1222: Add option to request lz4 compressed ReadRowsResponse
 
 ## 0.38.0 - 2024-05-01
 
-* PR #1222: Add option to request lz4 compressed ReadRowsResponse
 * PR #1205: Sending Identity token in the read API header
 * Issue #1195: Support map type with complex value
 * Issue #1215: Support predicate pushdown for DATETIME

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 ## 0.38.0 - 2024-05-01
 
+* PR #1222: Add option to request lz4 compressed ReadRowsResponse
 * PR #1205: Sending Identity token in the read API header
 * Issue #1195: Support map type with complex value
 * Issue #1215: Support predicate pushdown for DATETIME

--- a/README-template.md
+++ b/README-template.md
@@ -780,6 +780,16 @@ word-break:break-word
      <td>Read</td>
    </tr>
    <tr valign="top">
+     <td><code>responseCompressionCodec</code>
+     </td>
+     <td>  Compression codec used to compress the ReadRowsResponse data. Options:
+           <code>RESPONSE_COMPRESSION_CODEC_UNSPECIFIED</code>,
+           <code>RESPONSE_COMPRESSION_CODEC_LZ4</code>
+          <br/> (Optional. Defaults to <code>RESPONSE_COMPRESSION_CODEC_UNSPECIFIED</code> which means no compression will be used)
+     </td>
+     <td>Read</td>
+   </tr>
+   <tr valign="top">
      <td><code>cacheExpirationTimeInMinutes</code>
      </td>
      <td>  The expiration time of the in-memory cache storing query information.

--- a/README.md
+++ b/README.md
@@ -774,16 +774,6 @@ word-break:break-word
      <td>Read</td>
    </tr>
    <tr valign="top">
-     <td><code>responseCompressionCodec</code>
-     </td>
-     <td>  Compression codec used to compress the ReadRowsResponse data. Options:
-           <code>RESPONSE_COMPRESSION_CODEC_UNSPECIFIED</code>,
-           <code>RESPONSE_COMPRESSION_CODEC_LZ4</code>
-          <br/> (Optional. Defaults to <code>RESPONSE_COMPRESSION_CODEC_UNSPECIFIED</code> which means no compression will be used)
-     </td>
-     <td>Read</td>
-   </tr>
-   <tr valign="top">
      <td><code>cacheExpirationTimeInMinutes</code>
      </td>
      <td>  The expiration time of the in-memory cache storing query information.

--- a/README.md
+++ b/README.md
@@ -774,6 +774,16 @@ word-break:break-word
      <td>Read</td>
    </tr>
    <tr valign="top">
+     <td><code>responseCompressionCodec</code>
+     </td>
+     <td>  Compression codec used to compress the ReadRowsResponse data. Options:
+           <code>RESPONSE_COMPRESSION_CODEC_UNSPECIFIED</code>,
+           <code>RESPONSE_COMPRESSION_CODEC_LZ4</code>
+          <br/> (Optional. Defaults to <code>RESPONSE_COMPRESSION_CODEC_UNSPECIFIED</code> which means no compression will be used)
+     </td>
+     <td>Read</td>
+   </tr>
+   <tr valign="top">
      <td><code>cacheExpirationTimeInMinutes</code>
      </td>
      <td>  The expiration time of the in-memory cache storing query information.

--- a/bigquery-connector-common/pom.xml
+++ b/bigquery-connector-common/pom.xml
@@ -28,6 +28,11 @@
       <artifactId>proto-google-cloud-bigquerystorage-v1</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.lz4</groupId>
+      <artifactId>lz4-java</artifactId>
+      <version>1.8.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-bigquery</artifactId>
       <exclusions>

--- a/bigquery-connector-common/pom.xml
+++ b/bigquery-connector-common/pom.xml
@@ -31,6 +31,7 @@
       <groupId>org.lz4</groupId>
       <artifactId>lz4-java</artifactId>
       <version>1.8.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/DecompressReadRowsResponse.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/DecompressReadRowsResponse.java
@@ -10,51 +10,31 @@ import net.jpountz.lz4.LZ4FastDecompressor;
 
 public class DecompressReadRowsResponse {
 
-  public static InputStream decompressArrowRecordBatch(
+  public static byte[] decompressArrowRecordBatch(
       ReadRowsResponse response, ResponseCompressionCodec compressionCodec) throws IOException {
-    // step 1: read the uncompressed_byte_size
-    // https://cloud.google.com/java/docs/reference/google-cloud-bigquerystorage/latest/com.google.cloud.bigquery.storage.v1.ReadRowsResponse#com_google_cloud_bigquery_storage_v1_ReadRowsResponse_getUncompressedByteSize__
-    //
-    long uncompressedByteSize = response.getUncompressedByteSize();
-    if (uncompressedByteSize <= 0) {
-      // response was not compressed, return directly
-      return response.getArrowRecordBatch().getSerializedRecordBatch().newInput();
-    }
-
-    byte[] compressed = response.getArrowRecordBatch().getSerializedRecordBatch().toByteArray();
-    switch (compressionCodec) {
-      case RESPONSE_COMPRESSION_CODEC_LZ4:
-        // decompress LZ4
-        // https://github.com/lz4/lz4-java
-        LZ4Factory factory = LZ4Factory.fastestInstance();
-        LZ4FastDecompressor decompressor = factory.fastDecompressor();
-        byte[] decompressed = new byte[(int) uncompressedByteSize];
-        decompressor.decompress(compressed, 0, decompressed, 0, (int) uncompressedByteSize);
-        return new ByteArrayInputStream(decompressed);
-      case RESPONSE_COMPRESSION_CODEC_UNSPECIFIED:
-      default:
-        // error! the response claims that it was compressed, but you did not specify which
-        // compression codec to use.
-        throw new IOException(
-            "Missing a compression codec to decode a compressed ReadRowsResponse");
-    }
+    byte[] responseBytes = response.getArrowRecordBatch().getSerializedRecordBatch().toByteArray();
+    return decompressRecordBatchInternal(response, compressionCodec, responseBytes);
   }
-
   public static byte[] decompressAvroRecordBatch(
       ReadRowsResponse response, ResponseCompressionCodec compressionCodec) throws IOException {
+    byte[] responseBytes = response.getAvroRows().getSerializedBinaryRows().toByteArray();
+    return decompressRecordBatchInternal(response, compressionCodec, responseBytes);
+  }
+
+  private static byte[] decompressRecordBatchInternal(ReadRowsResponse response,
+      ResponseCompressionCodec compressionCodec, byte[] responseBytes) throws IOException {
     // step 1: read the uncompressed_byte_size
     // https://cloud.google.com/java/docs/reference/google-cloud-bigquerystorage/latest/com.google.cloud.bigquery.storage.v1.ReadRowsResponse#com_google_cloud_bigquery_storage_v1_ReadRowsResponse_getUncompressedByteSize__
     //
     long uncompressedByteSize = response.getUncompressedByteSize();
     if (uncompressedByteSize <= 0) {
       // response was not compressed, return directly
-      return response.getAvroRows().getSerializedBinaryRows().toByteArray();
+      return responseBytes;
     }
 
     // step 2: decompress using the compression codec
     // If the uncompressed byte size is set, then we want to decompress it, using the specified
     // compression codec.
-    byte[] compressed = response.getAvroRows().getSerializedBinaryRows().toByteArray();
     switch (compressionCodec) {
       case RESPONSE_COMPRESSION_CODEC_LZ4:
         // decompress LZ4
@@ -62,7 +42,7 @@ public class DecompressReadRowsResponse {
         LZ4Factory factory = LZ4Factory.fastestInstance();
         LZ4FastDecompressor decompressor = factory.fastDecompressor();
         byte[] decompressed = new byte[(int) uncompressedByteSize];
-        decompressor.decompress(compressed, 0, decompressed, 0, (int) uncompressedByteSize);
+        decompressor.decompress(responseBytes, 0, decompressed, 0, (int) uncompressedByteSize);
         return decompressed;
       case RESPONSE_COMPRESSION_CODEC_UNSPECIFIED:
       default:

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/DecompressReadRowsResponse.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/DecompressReadRowsResponse.java
@@ -49,7 +49,7 @@ public class DecompressReadRowsResponse {
         // error! the response claims that it was compressed, but you did not specify which
         // compression codec to use.
         throw new IOException(
-            "Missing a compression codec to decode a compressed ReadRowsResponse");
+            "Missing a compression codec to decode a compressed ReadRowsResponse.");
     }
   }
 }

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/DecompressReadRowsResponse.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/DecompressReadRowsResponse.java
@@ -2,9 +2,7 @@ package com.google.cloud.bigquery.connector.common;
 
 import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
 import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions.ResponseCompressionCodec;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.lz4.LZ4FastDecompressor;
 
@@ -15,14 +13,16 @@ public class DecompressReadRowsResponse {
     byte[] responseBytes = response.getArrowRecordBatch().getSerializedRecordBatch().toByteArray();
     return decompressRecordBatchInternal(response, compressionCodec, responseBytes);
   }
+
   public static byte[] decompressAvroRecordBatch(
       ReadRowsResponse response, ResponseCompressionCodec compressionCodec) throws IOException {
     byte[] responseBytes = response.getAvroRows().getSerializedBinaryRows().toByteArray();
     return decompressRecordBatchInternal(response, compressionCodec, responseBytes);
   }
 
-  private static byte[] decompressRecordBatchInternal(ReadRowsResponse response,
-      ResponseCompressionCodec compressionCodec, byte[] responseBytes) throws IOException {
+  private static byte[] decompressRecordBatchInternal(
+      ReadRowsResponse response, ResponseCompressionCodec compressionCodec, byte[] responseBytes)
+      throws IOException {
     // step 1: read the uncompressed_byte_size
     // https://cloud.google.com/java/docs/reference/google-cloud-bigquerystorage/latest/com.google.cloud.bigquery.storage.v1.ReadRowsResponse#com_google_cloud_bigquery_storage_v1_ReadRowsResponse_getUncompressedByteSize__
     //

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/DecompressReadRowsResponse.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/DecompressReadRowsResponse.java
@@ -1,0 +1,75 @@
+package com.google.cloud.bigquery.connector.common;
+
+import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
+import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions.ResponseCompressionCodec;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import net.jpountz.lz4.LZ4Factory;
+import net.jpountz.lz4.LZ4FastDecompressor;
+
+public class DecompressReadRowsResponse {
+
+  public static InputStream decompressArrowRecordBatch(
+      ReadRowsResponse response, ResponseCompressionCodec compressionCodec) throws IOException {
+    // step 1: read the uncompressed_byte_size
+    // https://cloud.google.com/java/docs/reference/google-cloud-bigquerystorage/latest/com.google.cloud.bigquery.storage.v1.ReadRowsResponse#com_google_cloud_bigquery_storage_v1_ReadRowsResponse_getUncompressedByteSize__
+    //
+    long uncompressedByteSize = response.getUncompressedByteSize();
+    if (uncompressedByteSize <= 0) {
+      // response was not compressed, return directly
+      return response.getArrowRecordBatch().getSerializedRecordBatch().newInput();
+    }
+
+    byte[] compressed = response.getArrowRecordBatch().getSerializedRecordBatch().toByteArray();
+    switch (compressionCodec) {
+      case RESPONSE_COMPRESSION_CODEC_LZ4:
+        // decompress LZ4
+        // https://github.com/lz4/lz4-java
+        LZ4Factory factory = LZ4Factory.fastestInstance();
+        LZ4FastDecompressor decompressor = factory.fastDecompressor();
+        byte[] decompressed = new byte[(int) uncompressedByteSize];
+        decompressor.decompress(compressed, 0, decompressed, 0, (int) uncompressedByteSize);
+        return new ByteArrayInputStream(decompressed);
+      case RESPONSE_COMPRESSION_CODEC_UNSPECIFIED:
+      default:
+        // error! the response claims that it was compressed, but you did not specify which
+        // compression codec to use.
+        throw new IOException(
+            "Missing a compression codec to decode a compressed ReadRowsResponse");
+    }
+  }
+
+  public static byte[] decompressAvroRecordBatch(
+      ReadRowsResponse response, ResponseCompressionCodec compressionCodec) throws IOException {
+    // step 1: read the uncompressed_byte_size
+    // https://cloud.google.com/java/docs/reference/google-cloud-bigquerystorage/latest/com.google.cloud.bigquery.storage.v1.ReadRowsResponse#com_google_cloud_bigquery_storage_v1_ReadRowsResponse_getUncompressedByteSize__
+    //
+    long uncompressedByteSize = response.getUncompressedByteSize();
+    if (uncompressedByteSize <= 0) {
+      // response was not compressed, return directly
+      return response.getAvroRows().getSerializedBinaryRows().toByteArray();
+    }
+
+    // step 2: decompress using the compression codec
+    // If the uncompressed byte size is set, then we want to decompress it, using the specified
+    // compression codec.
+    byte[] compressed = response.getAvroRows().getSerializedBinaryRows().toByteArray();
+    switch (compressionCodec) {
+      case RESPONSE_COMPRESSION_CODEC_LZ4:
+        // decompress LZ4
+        // https://github.com/lz4/lz4-java
+        LZ4Factory factory = LZ4Factory.fastestInstance();
+        LZ4FastDecompressor decompressor = factory.fastDecompressor();
+        byte[] decompressed = new byte[(int) uncompressedByteSize];
+        decompressor.decompress(compressed, 0, decompressed, 0, (int) uncompressedByteSize);
+        return decompressed;
+      case RESPONSE_COMPRESSION_CODEC_UNSPECIFIED:
+      default:
+        // error! the response claims that it was compressed, but you did not specify which
+        // compression codec to use.
+        throw new IOException(
+            "Missing a compression codec to decode a compressed ReadRowsResponse");
+    }
+  }
+}

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/DecompressReadRowsResponse.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/DecompressReadRowsResponse.java
@@ -2,26 +2,31 @@ package com.google.cloud.bigquery.connector.common;
 
 import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
 import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions.ResponseCompressionCodec;
+import com.google.protobuf.ByteString;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.lz4.LZ4FastDecompressor;
 
 public class DecompressReadRowsResponse {
 
-  public static byte[] decompressArrowRecordBatch(
+  public static InputStream decompressArrowRecordBatch(
       ReadRowsResponse response, ResponseCompressionCodec compressionCodec) throws IOException {
-    byte[] responseBytes = response.getArrowRecordBatch().getSerializedRecordBatch().toByteArray();
+    ByteString responseBytes = response.getArrowRecordBatch().getSerializedRecordBatch();
     return decompressRecordBatchInternal(response, compressionCodec, responseBytes);
   }
 
-  public static byte[] decompressAvroRecordBatch(
+  public static InputStream decompressAvroRecordBatch(
       ReadRowsResponse response, ResponseCompressionCodec compressionCodec) throws IOException {
-    byte[] responseBytes = response.getAvroRows().getSerializedBinaryRows().toByteArray();
+    ByteString responseBytes = response.getAvroRows().getSerializedBinaryRows();
     return decompressRecordBatchInternal(response, compressionCodec, responseBytes);
   }
 
-  private static byte[] decompressRecordBatchInternal(
-      ReadRowsResponse response, ResponseCompressionCodec compressionCodec, byte[] responseBytes)
+  private static InputStream decompressRecordBatchInternal(
+      ReadRowsResponse response,
+      ResponseCompressionCodec compressionCodec,
+      ByteString responseBytes)
       throws IOException {
     // step 1: read the uncompressed_byte_size
     // https://cloud.google.com/java/docs/reference/google-cloud-bigquerystorage/latest/com.google.cloud.bigquery.storage.v1.ReadRowsResponse#com_google_cloud_bigquery_storage_v1_ReadRowsResponse_getUncompressedByteSize__
@@ -29,12 +34,13 @@ public class DecompressReadRowsResponse {
     long uncompressedByteSize = response.getUncompressedByteSize();
     if (uncompressedByteSize <= 0) {
       // response was not compressed, return directly
-      return responseBytes;
+      return responseBytes.newInput();
     }
 
     // step 2: decompress using the compression codec
     // If the uncompressed byte size is set, then we want to decompress it, using the specified
     // compression codec.
+    byte[] compressed = responseBytes.toByteArray();
     switch (compressionCodec) {
       case RESPONSE_COMPRESSION_CODEC_LZ4:
         // decompress LZ4
@@ -42,8 +48,8 @@ public class DecompressReadRowsResponse {
         LZ4Factory factory = LZ4Factory.fastestInstance();
         LZ4FastDecompressor decompressor = factory.fastDecompressor();
         byte[] decompressed = new byte[(int) uncompressedByteSize];
-        decompressor.decompress(responseBytes, 0, decompressed, 0, (int) uncompressedByteSize);
-        return decompressed;
+        decompressor.decompress(compressed, 0, decompressed, 0, (int) uncompressedByteSize);
+        return new ByteArrayInputStream(decompressed);
       case RESPONSE_COMPRESSION_CODEC_UNSPECIFIED:
       default:
         // error! the response claims that it was compressed, but you did not specify which

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadRowsResponseInputStreamEnumeration.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadRowsResponseInputStreamEnumeration.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigquery.connector.common;
 
 import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
 import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions.ResponseCompressionCodec;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -55,8 +56,8 @@ public class ReadRowsResponseInputStreamEnumeration implements java.util.Enumera
     ReadRowsResponse ret = currentResponse;
     loadNextResponse();
     try {
-      return DecompressReadRowsResponse.decompressArrowRecordBatch(
-          ret, this.responseCompressionCodec);
+      return new ByteArrayInputStream(DecompressReadRowsResponse.decompressArrowRecordBatch(
+          ret, this.responseCompressionCodec));
     } catch (IOException e) {
       throw new UncheckedIOException("Could not read rows", e);
     }

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadRowsResponseInputStreamEnumeration.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadRowsResponseInputStreamEnumeration.java
@@ -17,7 +17,6 @@ package com.google.cloud.bigquery.connector.common;
 
 import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
 import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions.ResponseCompressionCodec;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -56,9 +55,8 @@ public class ReadRowsResponseInputStreamEnumeration implements java.util.Enumera
     ReadRowsResponse ret = currentResponse;
     loadNextResponse();
     try {
-      return new ByteArrayInputStream(
-          DecompressReadRowsResponse.decompressArrowRecordBatch(
-              ret, this.responseCompressionCodec));
+      return DecompressReadRowsResponse.decompressArrowRecordBatch(
+          ret, this.responseCompressionCodec);
     } catch (IOException e) {
       throw new UncheckedIOException("Could not read rows", e);
     }

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadRowsResponseInputStreamEnumeration.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadRowsResponseInputStreamEnumeration.java
@@ -56,8 +56,9 @@ public class ReadRowsResponseInputStreamEnumeration implements java.util.Enumera
     ReadRowsResponse ret = currentResponse;
     loadNextResponse();
     try {
-      return new ByteArrayInputStream(DecompressReadRowsResponse.decompressArrowRecordBatch(
-          ret, this.responseCompressionCodec));
+      return new ByteArrayInputStream(
+          DecompressReadRowsResponse.decompressArrowRecordBatch(
+              ret, this.responseCompressionCodec));
     } catch (IOException e) {
       throw new UncheckedIOException("Could not read rows", e);
     }

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfig.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfig.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigquery.connector.common;
 
 import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions.CompressionCodec;
 import com.google.cloud.bigquery.storage.v1.DataFormat;
+import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions.ResponseCompressionCodec;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
@@ -40,6 +41,7 @@ public class ReadSessionCreatorConfig {
   private final int prebufferResponses;
   private final int streamsPerPartition;
   private final CompressionCodec arrowCompressionCodec;
+  private final ResponseCompressionCodec responseCompressionCodec;
   private final Optional<String> traceId;
   private final boolean enableReadSessionCaching;
   private final long readSessionCacheDurationMins;
@@ -64,6 +66,7 @@ public class ReadSessionCreatorConfig {
       int prebufferResponses,
       int streamsPerPartition,
       CompressionCodec arrowCompressionCodec,
+      ResponseCompressionCodec responseCompressionCodec,
       Optional<String> traceId,
       boolean enableReadSessionCaching,
       long readSessionCacheDurationMins,
@@ -86,6 +89,7 @@ public class ReadSessionCreatorConfig {
     this.prebufferResponses = prebufferResponses;
     this.streamsPerPartition = streamsPerPartition;
     this.arrowCompressionCodec = arrowCompressionCodec;
+    this.responseCompressionCodec = responseCompressionCodec;
     this.traceId = traceId;
     this.enableReadSessionCaching = enableReadSessionCaching;
     this.readSessionCacheDurationMins = readSessionCacheDurationMins;
@@ -118,6 +122,10 @@ public class ReadSessionCreatorConfig {
 
   public CompressionCodec getArrowCompressionCodec() {
     return arrowCompressionCodec;
+  }
+
+  public ResponseCompressionCodec getResponseCompressionCodec() {
+    return responseCompressionCodec;
   }
 
   public int getMaxReadRowsRetries() {

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfigBuilder.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorConfigBuilder.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigquery.connector.common;
 
 import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions.CompressionCodec;
 import com.google.cloud.bigquery.storage.v1.DataFormat;
+import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions.ResponseCompressionCodec;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -42,6 +43,8 @@ public class ReadSessionCreatorConfigBuilder {
   int prebufferResponses = 1;
   int streamsPerPartition = 1;
   private CompressionCodec arrowCompressionCodec = CompressionCodec.COMPRESSION_UNSPECIFIED;
+  private ResponseCompressionCodec responseCompressionCodec =
+      ResponseCompressionCodec.RESPONSE_COMPRESSION_CODEC_UNSPECIFIED;
   private Optional<String> traceId = Optional.empty();
   private boolean enableReadSessionCaching = true;
   private long readSessionCacheDurationMins = 5L;
@@ -164,6 +167,13 @@ public class ReadSessionCreatorConfigBuilder {
   }
 
   @CanIgnoreReturnValue
+  public ReadSessionCreatorConfigBuilder setResponseCompressionCodec(
+      ResponseCompressionCodec responseCompressionCodec) {
+    this.responseCompressionCodec = responseCompressionCodec;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
   public ReadSessionCreatorConfigBuilder setTraceId(Optional<String> traceId) {
     this.traceId = traceId;
     return this;
@@ -207,6 +217,7 @@ public class ReadSessionCreatorConfigBuilder {
         prebufferResponses,
         streamsPerPartition,
         arrowCompressionCodec,
+        responseCompressionCodec,
         traceId,
         enableReadSessionCaching,
         readSessionCacheDurationMins,

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/ReadSessionCreatorTest.java
@@ -43,6 +43,7 @@ import com.google.cloud.bigquery.storage.v1.MockBigQueryRead;
 import com.google.cloud.bigquery.storage.v1.ReadSession;
 import com.google.cloud.bigquery.storage.v1.ReadSession.TableModifiers;
 import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions;
+import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions.ResponseCompressionCodec;
 import com.google.cloud.bigquery.storage.v1.ReadStream;
 import com.google.cloud.bigquery.storage.v1.stub.EnhancedBigQueryReadStub;
 import com.google.common.cache.Cache;
@@ -375,6 +376,7 @@ public class ReadSessionCreatorTest {
         ArrowSerializationOptions.newBuilder()
             .setBufferCompression(config.getArrowCompressionCodec())
             .build());
+    readOptions.setResponseCompressionCodec(config.getResponseCompressionCodec());
     CreateReadSessionRequest key =
         CreateReadSessionRequest.newBuilder()
             .setParent("projects/" + bigQueryClient.getProjectId())
@@ -419,6 +421,8 @@ public class ReadSessionCreatorTest {
             .setReadDataFormat(DataFormat.ARROW)
             .setEnableReadSessionCaching(true)
             .setArrowCompressionCodec(CompressionCodec.COMPRESSION_UNSPECIFIED)
+            .setResponseCompressionCodec(
+                ResponseCompressionCodec.RESPONSE_COMPRESSION_CODEC_UNSPECIFIED)
             .build();
     ReadSessionCreator creator =
         new ReadSessionCreator(config, bigQueryClient, mockBigQueryClientFactory);

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/direct/BigQueryRDDContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/direct/BigQueryRDDContext.java
@@ -117,7 +117,8 @@ class BigQueryRDDContext implements Serializable {
               readSession.getAvroSchema().getSchema(),
               Optional.of(schema),
               Optional.of(tracer),
-              SchemaConvertersConfiguration.from(options));
+              SchemaConvertersConfiguration.from(options),
+              options.getResponseCompressionCodec());
     } else {
       converter =
           ReadRowsResponseToInternalRowIteratorConverter.arrow(

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/direct/BigQueryRDDContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/direct/BigQueryRDDContext.java
@@ -125,7 +125,8 @@ class BigQueryRDDContext implements Serializable {
               Arrays.asList(columnsInOrder),
               readSession.getArrowSchema().getSerializedSchema(),
               Optional.of(schema),
-              Optional.of(tracer));
+              Optional.of(tracer),
+              options.getResponseCompressionCodec());
     }
 
     return new InterruptibleIterator<InternalRow>(

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -372,12 +372,6 @@ public class SparkBigQueryConfigTest {
             "Compression codec 'RANDOMCOMPRESSION' for Arrow is not supported."
                 + " Supported formats are "
                 + Arrays.toString(CompressionCodec.values()));
-    assertThat(exception)
-        .hasMessageThat()
-        .contains(
-            "Response compression codec 'RANDOMCOMPRESSION' is not supported."
-                + " Supported formats are "
-                + Arrays.toString(CompressionCodec.values()));
   }
 
   @Test

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -29,6 +29,7 @@ import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions.CompressionCodec;
 import com.google.cloud.bigquery.storage.v1.DataFormat;
+import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions.ResponseCompressionCodec;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.ByteArrayOutputStream;
@@ -120,6 +121,8 @@ public class SparkBigQueryConfigTest {
     assertThat(config.getBigQueryClientRetrySettings().getMaxAttempts()).isEqualTo(10);
     assertThat(config.getArrowCompressionCodec())
         .isEqualTo(CompressionCodec.COMPRESSION_UNSPECIFIED);
+    assertThat(config.getResponseCompressionCodec())
+        .isEqualTo(ResponseCompressionCodec.RESPONSE_COMPRESSION_CODEC_UNSPECIFIED);
     assertThat(config.getWriteMethod()).isEqualTo(SparkBigQueryConfig.WriteMethod.INDIRECT);
     assertThat(config.getCacheExpirationTimeInMinutes())
         .isEqualTo(SparkBigQueryConfig.DEFAULT_CACHE_EXPIRATION_IN_MINUTES);
@@ -170,6 +173,7 @@ public class SparkBigQueryConfigTest {
                 .put("httpReadTimeout", "20000")
                 .put("httpMaxRetry", "5")
                 .put("arrowCompressionCodec", "ZSTD")
+                .put("responseCompressionCodec", "RESPONSE_COMPRESSION_CODEC_LZ4")
                 .put("writeMethod", "direct")
                 .put("cacheExpirationTimeInMinutes", "100")
                 .put("traceJobId", "traceJobId")
@@ -225,6 +229,8 @@ public class SparkBigQueryConfigTest {
     assertThat(config.getBigQueryClientReadTimeout()).isEqualTo(20000);
     assertThat(config.getBigQueryClientRetrySettings().getMaxAttempts()).isEqualTo(5);
     assertThat(config.getArrowCompressionCodec()).isEqualTo(CompressionCodec.ZSTD);
+    assertThat(config.getResponseCompressionCodec())
+        .isEqualTo(ResponseCompressionCodec.RESPONSE_COMPRESSION_CODEC_LZ4);
     assertThat(config.getWriteMethod()).isEqualTo(SparkBigQueryConfig.WriteMethod.DIRECT);
     assertThat(config.getCacheExpirationTimeInMinutes()).isEqualTo(100);
     assertThat(config.getTraceId())
@@ -340,6 +346,7 @@ public class SparkBigQueryConfigTest {
                 .put("dataset", "test_d")
                 .put("project", "test_p")
                 .put("arrowCompressionCodec", "randomCompression")
+                .put("responseCompressionCodec", "randomCompression")
                 .build());
 
     IllegalArgumentException exception =

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -27,6 +27,7 @@ import com.google.cloud.bigquery.QueryJobConfiguration.Priority;
 import com.google.cloud.bigquery.RangePartitioning;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TimePartitioning;
+import com.google.cloud.bigquery.connector.common.BigQueryUtil;
 import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions.CompressionCodec;
 import com.google.cloud.bigquery.storage.v1.DataFormat;
 import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions.ResponseCompressionCodec;
@@ -244,6 +245,7 @@ public class SparkBigQueryConfigTest {
     assertThat(config.getBigQueryJobTimeoutInMinutes()).isEqualTo(30);
     assertThat(config.getGpn().get()).isEqualTo("testUser");
     assertThat(config.getSnapshotTimeMillis()).hasValue(123456789L);
+    BigQueryUtil.verifySerialization(config);
   }
 
   @Test

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -372,6 +372,12 @@ public class SparkBigQueryConfigTest {
             "Compression codec 'RANDOMCOMPRESSION' for Arrow is not supported."
                 + " Supported formats are "
                 + Arrays.toString(CompressionCodec.values()));
+    assertThat(exception)
+        .hasMessageThat()
+        .contains(
+            "Response compression codec 'RANDOMCOMPRESSION' is not supported."
+                + " Supported formats are "
+                + Arrays.toString(CompressionCodec.values()));
   }
 
   @Test

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/ReadIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/ReadIntegrationTestBase.java
@@ -410,6 +410,80 @@ public class ReadIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
   }
 
   @Test
+  public void testArrowResponseCompressionCodec() {
+    List<Row> avroResultsUncompressed =
+        spark
+            .read()
+            .format("bigquery")
+            .option("table", "bigquery-public-data.samples.shakespeare")
+            .option("filter", "word_count = 1 OR corpus_date = 0")
+            .option("readDataFormat", "AVRO")
+            .load()
+            .collectAsList();
+
+    List<Row> arrowResultsUncompressed =
+        spark
+            .read()
+            .format("bigquery")
+            .option("table", "bigquery-public-data.samples.shakespeare")
+            .option("readDataFormat", "ARROW")
+            .load()
+            .where("word_count = 1 OR corpus_date = 0")
+            .collectAsList();
+
+    List<Row> arrowResultsWithLZ4ResponseCompression =
+        spark
+            .read()
+            .format("bigquery")
+            .option("table", "bigquery-public-data.samples.shakespeare")
+            .option("readDataFormat", "ARROW")
+            .option("responseCompressionCodec", "RESPONSE_COMPRESSION_CODEC_LZ4")
+            .load()
+            .where("word_count = 1 OR corpus_date = 0")
+            .collectAsList();
+
+    assertThat(avroResultsUncompressed).isEqualTo(arrowResultsWithLZ4ResponseCompression);
+    assertThat(arrowResultsUncompressed).isEqualTo(arrowResultsWithLZ4ResponseCompression);
+  }
+
+  @Test
+  public void testAvroResponseCompressionCodec() {
+    List<Row> arrowResultsUncompressed =
+        spark
+            .read()
+            .format("bigquery")
+            .option("table", "bigquery-public-data.samples.shakespeare")
+            .option("filter", "word_count = 1 OR corpus_date = 0")
+            .option("readDataFormat", "ARROW")
+            .load()
+            .collectAsList();
+
+    List<Row> avroResultsUncompressed =
+        spark
+            .read()
+            .format("bigquery")
+            .option("table", "bigquery-public-data.samples.shakespeare")
+            .option("readDataFormat", "AVRO")
+            .load()
+            .where("word_count = 1 OR corpus_date = 0")
+            .collectAsList();
+
+    List<Row> avroResultsWithLZ4ResponseCompression =
+        spark
+            .read()
+            .format("bigquery")
+            .option("table", "bigquery-public-data.samples.shakespeare")
+            .option("readDataFormat", "AVRO")
+            .option("responseCompressionCodec", "RESPONSE_COMPRESSION_CODEC_LZ4")
+            .load()
+            .where("word_count = 1 OR corpus_date = 0")
+            .collectAsList();
+
+    assertThat(arrowResultsUncompressed).isEqualTo(avroResultsWithLZ4ResponseCompression);
+    assertThat(avroResultsUncompressed).isEqualTo(avroResultsWithLZ4ResponseCompression);
+  }
+
+  @Test
   public void testArrowCompressionCodec() {
     List<Row> avroResults =
         spark
@@ -573,7 +647,8 @@ public class ReadIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
         com.google.api.gax.rpc.DeadlineExceededException.class,
         () -> {
           df.where(
-                  "views>1000 AND title='Google' AND DATE(datehour) BETWEEN DATE('2021-01-01') AND DATE('2021-07-01')")
+                  "views>1000 AND title='Google' AND DATE(datehour) BETWEEN DATE('2021-01-01') AND"
+                      + " DATE('2021-07-01')")
               .collect();
         });
   }
@@ -585,7 +660,8 @@ public class ReadIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
     List<Row> repositoryUrlRows =
         githubNestedDF
             .filter(
-                "repository.has_downloads = true AND url = 'https://github.com/googleapi/googleapi'")
+                "repository.has_downloads = true AND url ="
+                    + " 'https://github.com/googleapi/googleapi'")
             .select("repository.url")
             .collectAsList();
     assertThat(repositoryUrlRows).hasSize(4);

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/ArrowInputPartitionContext.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/ArrowInputPartitionContext.java
@@ -24,6 +24,7 @@ import com.google.cloud.bigquery.connector.common.ReadRowsHelper;
 import com.google.cloud.bigquery.connector.common.ReadSessionResponse;
 import com.google.cloud.bigquery.storage.v1.ReadRowsRequest;
 import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
+import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions.ResponseCompressionCodec;
 import com.google.cloud.spark.bigquery.metrics.SparkBigQueryReadSessionMetrics;
 import com.google.cloud.spark.bigquery.metrics.SparkMetricsSource;
 import com.google.common.base.Joiner;
@@ -48,6 +49,7 @@ public class ArrowInputPartitionContext implements InputPartitionContext<Columna
   private final ByteString serializedArrowSchema;
   private final com.google.common.base.Optional<StructType> userProvidedSchema;
   private final SparkBigQueryReadSessionMetrics sparkBigQueryReadSessionMetrics;
+  private final ResponseCompressionCodec responseCompressionCodec;
 
   public ArrowInputPartitionContext(
       BigQueryClientFactory bigQueryReadClientFactory,
@@ -57,7 +59,8 @@ public class ArrowInputPartitionContext implements InputPartitionContext<Columna
       ImmutableList<String> selectedFields,
       ReadSessionResponse readSessionResponse,
       Optional<StructType> userProvidedSchema,
-      SparkBigQueryReadSessionMetrics sparkBigQueryReadSessionMetrics) {
+      SparkBigQueryReadSessionMetrics sparkBigQueryReadSessionMetrics,
+      ResponseCompressionCodec responseCompressionCodec) {
     this.bigQueryReadClientFactory = bigQueryReadClientFactory;
     this.streamNames = names;
     this.options = options;
@@ -71,6 +74,7 @@ public class ArrowInputPartitionContext implements InputPartitionContext<Columna
       this.bigQueryReadClientFactory.setAudienceForIdentityToken(
           readSessionResponse.getReadSession().getName());
     }
+    this.responseCompressionCodec = responseCompressionCodec;
   }
 
   public InputPartitionReaderContext<ColumnarBatch> createPartitionReaderContext() {
@@ -105,7 +109,8 @@ public class ArrowInputPartitionContext implements InputPartitionContext<Columna
         selectedFields,
         tracer,
         userProvidedSchema.toJavaUtil(),
-        options.numBackgroundThreads());
+        options.numBackgroundThreads(),
+        responseCompressionCodec);
   }
 
   @Override

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryDataSourceReaderContext.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryDataSourceReaderContext.java
@@ -274,7 +274,8 @@ public class BigQueryDataSourceReaderContext {
                         partitionSelectedFields,
                         readSessionResponse.get(),
                         arrowSchema,
-                        sparkBigQueryReadSessionMetrics))
+                        sparkBigQueryReadSessionMetrics,
+                        readSessionCreatorConfig.getResponseCompressionCodec()))
             .collect(Collectors.toList());
     return plannedInputPartitionContexts.stream()
         .map(ctx -> (InputPartitionContext<ColumnarBatch>) ctx);
@@ -314,7 +315,8 @@ public class BigQueryDataSourceReaderContext {
           readSessionResponse.getReadSession().getAvroSchema().getSchema(),
           userProvidedSchema,
           /* bigQueryStorageReadRowTracer */ Optional.empty(),
-          SchemaConvertersConfiguration.from(options));
+          SchemaConvertersConfiguration.from(options),
+          readSessionCreatorConfig.getResponseCompressionCodec());
     }
     throw new IllegalArgumentException(
         "No known converted for " + readSessionCreatorConfig.getReadDataFormat());
@@ -400,7 +402,8 @@ public class BigQueryDataSourceReaderContext {
       // It means the filter combined filter won't change, so no need to create another read session
       // we are done here.
       logger.info(
-          "Could not find filters for partition of clustering field for table {}, aborting DPP filter",
+          "Could not find filters for partition of clustering field for table {}, aborting DPP"
+              + " filter",
           BigQueryUtil.friendlyTableName(tableId));
       return Optional.empty();
     }
@@ -421,7 +424,8 @@ public class BigQueryDataSourceReaderContext {
     if (plannedInputPartitionContexts.size() > previousInputPartitionContexts.size()) {
       logger.warn(
           String.format(
-              "New partitions should not be more than originally planned. Previously had %d streams, now has %d.",
+              "New partitions should not be more than originally planned. Previously had %d"
+                  + " streams, now has %d.",
               previousInputPartitionContexts.size(), plannedInputPartitionContexts.size()));
       return Optional.of(plannedInputPartitionContexts);
     }

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/test/java/com/google/cloud/spark/bigquery/v2/context/ArrowInputPartitionContextTest.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/test/java/com/google/cloud/spark/bigquery/v2/context/ArrowInputPartitionContextTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.spark.bigquery.v2.context;
 import com.google.cloud.bigquery.connector.common.ReadRowsHelper;
 import com.google.cloud.bigquery.connector.common.ReadSessionResponse;
 import com.google.cloud.bigquery.storage.v1.ReadSession;
+import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions.ResponseCompressionCodec;
 import com.google.common.collect.Lists;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -26,22 +27,24 @@ import java.util.Optional;
 import org.junit.Test;
 
 public class ArrowInputPartitionContextTest {
+  // TODO: test with and without response compression!
   @Test
   public void testSerializability() throws IOException {
     new ObjectOutputStream(new ByteArrayOutputStream())
         .writeObject(
             new ArrowInputPartitionContext(
-                /*bigQueryClientFactory=*/ null,
-                /*tracerFactory=*/ null,
+                /* bigQueryClientFactory= */ null,
+                /* tracerFactory= */ null,
                 Lists.newArrayList("streamName"),
                 new ReadRowsHelper.Options(
-                    /*maxRetries=*/ 5,
+                    /* maxRetries= */ 5,
                     Optional.of("endpoint"),
-                    /*backgroundParsingThreads=*/ 5,
-                    /*prebufferResponses=*/ 1),
+                    /* backgroundParsingThreads= */ 5,
+                    /* prebufferResponses= */ 1),
                 null,
                 new ReadSessionResponse(ReadSession.getDefaultInstance(), null),
                 null,
-                null));
+                null,
+                ResponseCompressionCodec.RESPONSE_COMPRESSION_CODEC_UNSPECIFIED));
   }
 }

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/test/java/com/google/cloud/spark/bigquery/v2/context/BigQueryInputPartitionReaderContextTest.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/test/java/com/google/cloud/spark/bigquery/v2/context/BigQueryInputPartitionReaderContextTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.*;
 
 import com.google.cloud.bigquery.*;
 import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
+import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions.ResponseCompressionCodec;
 import com.google.cloud.spark.bigquery.ReadRowsResponseToInternalRowIteratorConverter;
 import com.google.cloud.spark.bigquery.SchemaConvertersConfiguration;
 import com.google.common.collect.ImmutableList;
@@ -85,7 +86,12 @@ public class BigQueryInputPartitionReaderContextTest {
           + "  }\n"
           + "}\n"
           + "avro_rows {\n"
-          + "  serialized_binary_rows: \"\\002\\nhello\\002\\b\\001\\002\\003\\004\\002\\310\\001\\0023333336@\\002 \\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\nX\\324\\226\\000\\002\\001\\002\\244\\234\\205\\342\\275\\242\\312\\005\\002\\204\\235\\002\\002\\340\\232\\206\\213\\330\\004\\00222019-11-11T11:11:11.11111\\002 POINT(31.2 44.5)\\002\\002\\fin_rec\\002\\\"\\000\\004\\006big\\nquery\\000\\000\"\n"
+          + "  serialized_binary_rows: \"\\002\\n"
+          + "hello\\002\\b\\001\\002\\003\\004\\002\\310\\001\\0023333336@\\002"
+          + " \\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\000\\n"
+          + "X\\324\\226\\000\\002\\001\\002\\244\\234\\205\\342\\275\\242\\312\\005\\002\\204\\235\\002\\002\\340\\232\\206\\213\\330\\004\\00222019-11-11T11:11:11.11111\\002"
+          + " POINT(31.2 44.5)\\002\\002\\fin_rec\\002\\\"\\000\\004\\006big\\n"
+          + "query\\000\\000\"\n"
           + "  row_count: 1\n"
           + "}\n"
           + "row_count: 1\n";
@@ -105,7 +111,8 @@ public class BigQueryInputPartitionReaderContextTest {
             ALL_TYPES_TABLE_AVRO_RAW_SCHEMA,
             Optional.empty(),
             Optional.empty(),
-            SchemaConvertersConfiguration.createDefault());
+            SchemaConvertersConfiguration.createDefault(),
+            ResponseCompressionCodec.RESPONSE_COMPRESSION_CODEC_UNSPECIFIED);
 
     BigQueryInputPartitionReaderContext reader =
         new BigQueryInputPartitionReaderContext(readRowsResponses, converter, null);


### PR DESCRIPTION
This adds the ability to request compressed ReadRowsResponses.
If the server decides to give back a ReadRowsResponse, we use the specified compression algorithm (LZ4) to decompress the results. 
This also adds two integration tests to test requesting compressed results for both arrow and avro.
