### PR TITLE
Issue #1254: fix getting partitioning fields for pseudo columns

### DIFF
--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
@@ -502,6 +502,15 @@ public class BigQueryUtil {
       StandardTableDefinition sdt = (StandardTableDefinition) definition;
       TimePartitioning timePartitioning = sdt.getTimePartitioning();
       if (timePartitioning != null) {
+        if (timePartitioning.getField() == null) {
+          // table contains pseudo columns
+          List<String> timePartitionFields = new ArrayList<>();
+          timePartitionFields.add("_PARTITIONTIME");
+          if (timePartitioning.getType().equals(TimePartitioning.Type.DAY)) {
+            timePartitionFields.add("_PARTITIONDATE");
+          }
+          return ImmutableList.copyOf(timePartitionFields);
+        }
         return ImmutableList.of(timePartitioning.getField());
       }
       RangePartitioning rangePartitioning = sdt.getRangePartitioning();
@@ -531,7 +540,7 @@ public class BigQueryUtil {
     }
 
     Clustering clustering = ((StandardTableDefinition) definition).getClustering();
-    if (clustering == null) {
+    if (clustering == null || clustering.getFields() == null) {
       return ImmutableList.of();
     }
     return ImmutableList.copyOf(clustering.getFields());

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryUtilTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryUtilTest.java
@@ -430,6 +430,34 @@ public class BigQueryUtilTest {
   }
 
   @Test
+  public void testGetPartitionField_time_partitioning_pseudoColumn() {
+    TableInfo info =
+        TableInfo.of(
+            TableId.of("foo", "bar"),
+            StandardTableDefinition.newBuilder()
+                .setTimePartitioning(
+                    TimePartitioning.newBuilder(TimePartitioning.Type.HOUR).build())
+                .build());
+    List<String> partitionFields = BigQueryUtil.getPartitionFields(info);
+    assertThat(partitionFields).hasSize(1);
+    assertThat(partitionFields).contains("_PARTITIONTIME");
+  }
+
+  @Test
+  public void testGetPartitionField_time_partitioning_pseudoColumn_day() {
+    TableInfo info =
+        TableInfo.of(
+            TableId.of("foo", "bar"),
+            StandardTableDefinition.newBuilder()
+                .setTimePartitioning(TimePartitioning.newBuilder(TimePartitioning.Type.DAY).build())
+                .build());
+    List<String> partitionFields = BigQueryUtil.getPartitionFields(info);
+    assertThat(partitionFields).hasSize(2);
+    assertThat(partitionFields).contains("_PARTITIONTIME");
+    assertThat(partitionFields).contains("_PARTITIONDATE");
+  }
+
+  @Test
   public void testGetPartitionField_range_partitioning() {
     TableInfo info =
         TableInfo.of(

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/ReadIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/ReadIntegrationTestBase.java
@@ -40,7 +40,6 @@ import java.util.stream.Stream;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
-import org.apache.spark.sql.catalyst.expressions.SparkVersion;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
@@ -721,7 +720,15 @@ public class ReadIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
         String.format(
             "CREATE TABLE `%s.%s` (%s INT64) PARTITION BY _PARTITIONDATE ",
             testDataset, testTable, "orderId"));
-    String dt = "2000-01-01";
+    IntegrationTestUtils.runQuery(
+        String.format(
+            "INSERT INTO `%s.%s` (%s, _PARTITIONTIME) VALUES "
+                + "(101, \"2024-01-05 00:00:00 UTC\"),"
+                + "(102, \"2024-01-05 00:00:00 UTC\"),"
+                + "(201, \"2024-01-10 00:00:00 UTC\"),"
+                + "(202, \"2024-01-10 00:00:00 UTC\");",
+            testDataset, testTable, "orderId"));
+    String dt = "2024-01-05";
     Dataset<Row> df =
         spark
             .read()
@@ -731,7 +738,10 @@ public class ReadIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
             .option("filter", "_PARTITIONDATE = '" + dt + "'")
             .load()
             .select("orderId");
-    df.join(df, "orderId").cache();
+    List<Row> rows = df.join(df, "orderId").orderBy("orderId").collectAsList();
+    assertThat(rows.size()).isEqualTo(2);
+    assertThat(rows.get(0).getLong(0)).isEqualTo(101);
+    assertThat(rows.get(1).getLong(0)).isEqualTo(102);
   }
 
   @Test
@@ -740,7 +750,15 @@ public class ReadIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
         String.format(
             "CREATE TABLE `%s.%s` (%s INT64) PARTITION BY TIMESTAMP_TRUNC(_PARTITIONTIME, HOUR) ",
             testDataset, testTable, "orderId"));
-    String dt = "2000-01-01 18:00:00 UTC";
+    IntegrationTestUtils.runQuery(
+        String.format(
+            "INSERT INTO `%s.%s` (%s, _PARTITIONTIME) VALUES "
+                + "(101, \"2024-01-05 18:00:00 UTC\"),"
+                + "(102, \"2024-01-05 18:00:00 UTC\"),"
+                + "(201, \"2024-01-10 06:00:00 UTC\"),"
+                + "(202, \"2024-01-10 08:00:00 UTC\");",
+            testDataset, testTable, "orderId"));
+    String dt = "2024-01-05 18:00:00 UTC";
     Dataset<Row> df =
         spark
             .read()
@@ -750,6 +768,9 @@ public class ReadIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
             .option("filter", "_PARTITIONTIME = '" + dt + "'")
             .load()
             .select("orderId");
-    df.join(df, "orderId").cache();
+    List<Row> rows = df.join(df, "orderId").orderBy("orderId").collectAsList();
+    assertThat(rows.size()).isEqualTo(2);
+    assertThat(rows.get(0).getLong(0)).isEqualTo(101);
+    assertThat(rows.get(1).getLong(0)).isEqualTo(102);
   }
 }


### PR DESCRIPTION
When getting partitioning fields, `timePartitioning.getField()` returns null when the table is ingestion time partitioned (partitioned by `_PARTITIONTIME` OR `_PARTITIONDATE`).
The change fixes this bug.