### PR TITLE
Add additional parentheses for EqualNullSafe filter generation

### DIFF
--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkFilterUtils.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkFilterUtils.java
@@ -233,7 +233,7 @@ public class SparkFilterUtils {
       String left = quote(equalNullSafe.attribute());
       String right = compileValue(equalNullSafe.value());
       return format(
-          "%1$s IS NULL AND %2$s IS NULL OR %1$s IS NOT NULL AND %2$s IS NOT NULL AND %1$s = %2$s",
+          "(%1$s IS NULL AND %2$s IS NULL) OR (%1$s IS NOT NULL AND %2$s IS NOT NULL AND %1$s = %2$s)",
           left, right);
     }
     if (filter instanceof GreaterThan) {

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkFilterUtilsTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkFilterUtilsTest.java
@@ -181,7 +181,7 @@ public class SparkFilterUtilsTest {
     assertThat(SparkFilterUtils.compileFilter(EqualTo.apply("foo", 1))).isEqualTo("`foo` = 1");
     assertThat(SparkFilterUtils.compileFilter(EqualNullSafe.apply("foo", 1)))
         .isEqualTo(
-            "`foo` IS NULL AND 1 IS NULL OR `foo` IS NOT NULL AND 1 IS NOT NULL AND `foo` = 1");
+            "(`foo` IS NULL AND 1 IS NULL) OR (`foo` IS NOT NULL AND 1 IS NOT NULL AND `foo` = 1)");
     assertThat(SparkFilterUtils.compileFilter(GreaterThan.apply("foo", 2))).isEqualTo("`foo` > 2");
     assertThat(SparkFilterUtils.compileFilter(GreaterThanOrEqual.apply("foo", 3)))
         .isEqualTo("`foo` >= 3");
@@ -396,14 +396,14 @@ public class SparkFilterUtilsTest {
         pushAllFilters,
         dataFormat,
         "",
-        "((NOT (`c1` IS NULL AND 500 IS NULL OR `c1` IS NOT NULL "
+        "((NOT ((`c1` IS NULL AND 500 IS NULL) OR (`c1` IS NOT NULL "
+            + "AND 500 IS NOT NULL AND `c1` = 500))) "
+            + "OR (NOT ((`c2` IS NULL AND 500 IS NULL) OR (`c2` IS NOT NULL "
+            + "AND 500 IS NOT NULL AND `c2` = 500)))) "
+            + "AND ((`c1` IS NULL AND 500 IS NULL) OR (`c1` IS NOT NULL "
             + "AND 500 IS NOT NULL AND `c1` = 500)) "
-            + "OR (NOT (`c2` IS NULL AND 500 IS NULL OR `c2` IS NOT NULL "
-            + "AND 500 IS NOT NULL AND `c2` = 500))) "
-            + "AND (`c1` IS NULL AND 500 IS NULL OR `c1` IS NOT NULL "
-            + "AND 500 IS NOT NULL AND `c1` = 500) "
-            + "AND (`c2` IS NULL AND 500 IS NULL OR `c2` IS NOT NULL "
-            + "AND 500 IS NOT NULL AND `c2` = 500)",
+            + "AND ((`c2` IS NULL AND 500 IS NULL) OR (`c2` IS NOT NULL "
+            + "AND 500 IS NOT NULL AND `c2` = 500))",
         Optional.empty(),
         part1,
         part2,


### PR DESCRIPTION
https://github.com/GoogleCloudDataproc/spark-bigquery-connector/pull/1166 added parentheses when joining multiple filters together. There were already surrounding parentheses for `And` `Or` and `Not` filters. This updates `EqualNullSafe` to also surround the two separate `OR` clauses.

At a minimum I feel this improves the readability of the generated filters. Unsure whether, as in the other PR, there is the risk of query correctness when multiple filters are combined together?