### PR TITLE
Move misplaced entry in CHANGES file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -183,6 +183,7 @@
 * gRPC has been upgraded to version 1.54.0
 * Netty has been upgraded to version 4.1.90.Final
 * PR #944: Added support to set query job priority
+* Issue #908: Making sure that `preferred_min_stream_count` must be less than or equal to `max_stream_count`
 
 ## 0.29.0 - 2023-03-03
 
@@ -198,7 +199,6 @@
 * GAX has been upgraded to version 2.23.0
 * gRPC has been upgraded to version 1.53.0
 * Netty has been upgraded to version 4.1.89.Final
-* Issue #908: Making sure that `preferred_min_stream_count` must be less than or equal to `max_stream_count`
 
 ## 0.28.1 - 2023-02-27
 


### PR DESCRIPTION
Fix for #908 (`preferred_min_stream_count`) is available from version 0.30.0 of the connector and not 0.29.0 as `CHANGES.md` states. Move the entry to the proper version section to reduce confusion for users who use old versions.