### PR TITLE
Issue #1290: Stopped using metadata for optimized count path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## Next
+* Issue #1290: Stopped using metadata for optimized count path
 
 ## 0.41.0 - 2024-09-05
 

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
@@ -15,8 +15,10 @@
  */
 package com.google.cloud.bigquery.connector.common;
 
+import static com.google.cloud.bigquery.connector.common.BigQueryUtil.getPartitionFields;
 import static com.google.cloud.bigquery.connector.common.BigQueryUtil.getQueryForRangePartitionedTable;
 import static com.google.cloud.bigquery.connector.common.BigQueryUtil.getQueryForTimePartitionedTable;
+import static com.google.cloud.bigquery.connector.common.BigQueryUtil.isBigQueryNativeTable;
 
 import com.google.cloud.BaseServiceException;
 import com.google.cloud.RetryOption;
@@ -606,6 +608,21 @@ public class BigQueryClient {
     TableDefinition.Type type = tableInfo.getDefinition().getType();
     if ((type == TableDefinition.Type.EXTERNAL || type == TableDefinition.Type.TABLE)
         && !filter.isPresent()) {
+      if (isBigQueryNativeTable(tableInfo)
+          && tableInfo.getRequirePartitionFilter() != null
+          && tableInfo.getRequirePartitionFilter()) {
+        List<String> partitioningFields = getPartitionFields(tableInfo);
+        if (partitioningFields.isEmpty()) {
+          throw new IllegalStateException(
+              "Could not find partitioning columns for table requiring partition filter: "
+                  + tableInfo.getTableId());
+        }
+        String table = fullTableName(tableInfo.getTableId());
+        return getNumberOfRows(
+            String.format(
+                "SELECT COUNT(*) from `%s` WHERE %s IS NOT NULL",
+                table, partitioningFields.get(0)));
+      }
       String table = fullTableName(tableInfo.getTableId());
       return getNumberOfRows(String.format("SELECT COUNT(*) from `%s`", table));
     } else if (type == TableDefinition.Type.VIEW

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
@@ -604,9 +604,8 @@ public class BigQueryClient {
 
   public long calculateTableSize(TableInfo tableInfo, Optional<String> filter) {
     TableDefinition.Type type = tableInfo.getDefinition().getType();
-    if (type == TableDefinition.Type.TABLE && !filter.isPresent()) {
-      return tableInfo.getNumRows().longValue();
-    } else if (type == TableDefinition.Type.EXTERNAL && !filter.isPresent()) {
+    if ((type == TableDefinition.Type.EXTERNAL || type == TableDefinition.Type.TABLE)
+        && !filter.isPresent()) {
       String table = fullTableName(tableInfo.getTableId());
       return getNumberOfRows(String.format("SELECT COUNT(*) from `%s`", table));
     } else if (type == TableDefinition.Type.VIEW

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -117,7 +117,7 @@ steps:
 
 
 # Tests take around 1 hr 15 mins in general.
-timeout: 7200s
+timeout: 9000s
 
 options:
   machineType: 'N1_HIGHCPU_32'

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -2664,6 +2664,34 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
         .isEqualTo(bq.getTable(testDataset.toString(), testTable).getDescription());
   }
 
+  @Test
+  public void testDirectWriteCountAfterWrite() throws InterruptedException {
+    assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
+    testCountAfterWrite_internal();
+  }
+
+  @Test
+  public void testIndirectWriteCountAfterWrite() throws InterruptedException {
+    assumeThat(writeMethod, equalTo(WriteMethod.INDIRECT));
+    testCountAfterWrite_internal();
+  }
+
+  private void testCountAfterWrite_internal() throws InterruptedException {
+    IntegrationTestUtils.runQuery(
+        String.format("CREATE TABLE `%s.%s` (name STRING, age INT64)", testDataset, testTable));
+    Dataset<Row> read1Df = spark.read().format("bigquery").load(fullTableName());
+    assertThat(read1Df.count()).isEqualTo(0L);
+
+    Dataset<Row> dfToWrite =
+        spark.createDataFrame(
+            Arrays.asList(RowFactory.create("foo", 10), RowFactory.create("bar", 20)),
+            new StructType().add("name", DataTypes.StringType).add("age", DataTypes.IntegerType));
+    writeToBigQueryAvroFormat(dfToWrite, SaveMode.Append, "false");
+
+    Dataset<Row> read2Df = spark.read().format("bigquery").load(fullTableName());
+    assertThat(read2Df.count()).isEqualTo(2L);
+  }
+
   private TableResult insertAndGetTimestampNTZToBigQuery(LocalDateTime time, String format)
       throws InterruptedException {
     Preconditions.checkArgument(timeStampNTZType.isPresent(), "timestampNTZType not present");

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -2665,18 +2665,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   }
 
   @Test
-  public void testDirectWriteCountAfterWrite() throws InterruptedException {
-    assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
-    testCountAfterWrite_internal();
-  }
-
-  @Test
-  public void testIndirectWriteCountAfterWrite() throws InterruptedException {
-    assumeThat(writeMethod, equalTo(WriteMethod.INDIRECT));
-    testCountAfterWrite_internal();
-  }
-
-  private void testCountAfterWrite_internal() throws InterruptedException {
+  public void testCountAfterWrite() {
     IntegrationTestUtils.runQuery(
         String.format("CREATE TABLE `%s.%s` (name STRING, age INT64)", testDataset, testTable));
     Dataset<Row> read1Df = spark.read().format("bigquery").load(fullTableName());


### PR DESCRIPTION
TableInfo.getNumRows() only covers the data that's materialized to data files, without including the data in streaming buffer. The data in streaming buffer (a.k.a, ingested through Write API, but not converted to data file yet) is readable using ReadAPI, but accessing TableInfo.getNumRows() won't reflect whatever changes are made in the streaming buffer. Running a select count(1) query works, as it triggers actual data scan through ReadAPI.

This issue only affects direct write.