### PR TITLE
Support spark.sql.datetime.java8API.enabled

### DIFF
--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryUtil.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryUtil.java
@@ -48,6 +48,7 @@ import org.apache.spark.SparkConf;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.Metadata;
@@ -199,19 +200,14 @@ public class SparkBigQueryUtil {
     if (sparkValue instanceof Long) {
       return ((Number) sparkValue).longValue();
     }
-    // need to return timestamp in epoch microseconds
-    java.sql.Timestamp timestamp = (java.sql.Timestamp) sparkValue;
-    long epochMillis = timestamp.getTime();
-    int micros = (timestamp.getNanos() / 1000) % 1000;
-    return epochMillis * 1000 + micros;
+    return DateTimeUtils.anyToMicros(sparkValue);
   }
 
   public static int sparkDateToBigQuery(Object sparkValue) {
     if (sparkValue instanceof Number) {
       return ((Number) sparkValue).intValue();
     }
-    java.sql.Date sparkDate = (java.sql.Date) sparkValue;
-    return (int) sparkDate.toLocalDate().toEpochDay();
+    return DateTimeUtils.anyToDays(sparkValue);
   }
 
   public static String getTableNameFromOptions(Map<String, String> options) {

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryUtilTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryUtilTest.java
@@ -25,6 +25,11 @@ import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TimePartitioning;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.TimeZone;
 import org.apache.spark.SparkConf;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
@@ -149,5 +154,24 @@ public class SparkBigQueryUtilTest {
     assertThat(labels).hasSize(2);
     assertThat(labels).containsEntry("dataproc_job_id", "d8f27392957446dbbd7dc28df568e4eb");
     assertThat(labels).containsEntry("dataproc_job_uuid", "df379ef3-eeda-3234-8941-e1a36a1959a3");
+  }
+
+  @Test
+  public void testSparkDateToBigQuery() {
+    assertThat(SparkBigQueryUtil.sparkDateToBigQuery(16929L)).isEqualTo(16929L);
+    assertThat(SparkBigQueryUtil.sparkDateToBigQuery(Date.valueOf("2016-05-08"))).isEqualTo(16929);
+    assertThat(SparkBigQueryUtil.sparkDateToBigQuery(LocalDate.of(2016, 5, 8))).isEqualTo(16929);
+  }
+
+  @Test
+  public void testSparkTimestampToBigQuery() {
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    assertThat(SparkBigQueryUtil.sparkTimestampToBigQuery(10L)).isEqualTo(10L);
+    assertThat(
+            SparkBigQueryUtil.sparkTimestampToBigQuery(Timestamp.valueOf("2016-05-08 00:00:01.01")))
+        .isEqualTo(1462665601010000L);
+    assertThat(
+            SparkBigQueryUtil.sparkTimestampToBigQuery(Instant.parse("2016-05-08T00:00:01.010Z")))
+        .isEqualTo(1462665601010000L);
   }
 }


### PR DESCRIPTION
When `spark.sql.datetime.java8API.enabled` is `true`, Spark dates and timestamps will be returned as `java.time.LocalDate`/`java.time.Instant` rather than `java.sql.Date`/`java.sql.Timestamp`. 

https://issues.apache.org/jira/browse/SPARK-38437 addressed this in https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/util/DateTimeUtils.scala so perhaps this code path could leverage that?

Currently if this config is enabled you hit `java.lang.ClassCastException`.