### PR TITLE
Get lineage out of query

### DIFF
--- a/spark-bigquery-dsv2/spark-3.1-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark31BigQueryTable.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark31BigQueryTable.java
@@ -109,10 +109,16 @@ public class Spark31BigQueryTable implements Table, SupportsRead, SupportsWrite 
   @Override
   public Map<String, String> properties() {
     SparkBigQueryConfig config = injector.getInstance(SparkBigQueryConfig.class);
-    return ImmutableMap.<String, String>builder()
-        .put("openlineage.dataset.name", BigQueryUtil.friendlyTableName(config.getTableId()))
-        .put("openlineage.dataset.namespace", "bigquery")
-        .put("openlineage.dataset.storageDatasetFacet.storageLayer", "bigquery")
-        .build();
+    ImmutableMap.Builder<String, String> propertiesBuilder =
+        ImmutableMap.<String, String>builder()
+            .put("openlineage.dataset.namespace", "bigquery")
+            .put("openlineage.dataset.storageDatasetFacet.storageLayer", "bigquery");
+    if (config.getQuery().isPresent()) {
+      propertiesBuilder.put("openlineage.dataset.query", config.getQuery().get());
+    } else {
+      propertiesBuilder.put(
+          "openlineage.dataset.name", BigQueryUtil.friendlyTableName(config.getTableId()));
+    }
+    return propertiesBuilder.build();
   }
 }

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -55,7 +55,7 @@
         <guava.version>33.4.0-jre</guava.version>
         <jackson.version>2.18.3</jackson.version>
         <netty.version>4.1.119.Final</netty.version>
-        <openlineage-spark.version>1.27.0</openlineage-spark.version>
+        <openlineage-spark.version>1.32.0</openlineage-spark.version>
         <paranamer.version>2.8.3</paranamer.version>
         <!-- Don't upgrade protobuf until bigquerystorage is compatible with 4.x version of proto.
         Ref : https://github.com/protocolbuffers/protobuf/issues/16452-->


### PR DESCRIPTION
Utilize `openlineage-spark` feature to extract lineage out of query