### PR TITLE
Fix assembly config in branch-0.42

### DIFF
--- a/spark-bigquery-python-lib/pom.xml
+++ b/spark-bigquery-python-lib/pom.xml
@@ -18,7 +18,10 @@
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
-          <descriptor>src/assembly/descriptor.xml</descriptor>
+          <appendAssemblyId>false</appendAssemblyId>
+          <descriptors>
+            <descriptor>src/assembly/descriptor.xml</descriptor>
+          </descriptors>
         </configuration>
         <executions>
           <execution>

--- a/spark-bigquery-python-lib/src/assembly/descriptor.xml
+++ b/spark-bigquery-python-lib/src/assembly/descriptor.xml
@@ -1,4 +1,5 @@
 <assembly>
+    <id>python-support-lib</id>
     <includeBaseDirectory>false</includeBaseDirectory>
     <formats>
         <format>zip</format>


### PR DESCRIPTION
This fixes the following build errors

```
 Execution default of goal org.apache.maven.plugins:maven-assembly-plugin:3.7.1:single failed: parameter 'descriptor' has been removed from the plugin
```
and
```
 Assembly: null is not configured correctly: Assembly ID must be present and non-empty.
```