### PR TITLE
Support reading from BigQuery tables with spaces in their names

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -175,6 +175,16 @@ import com.google.cloud.spark.bigquery._
 val df = spark.read.bigquery("bigquery-public-data.samples.shakespeare")
 ```
 
+The connector supports reading from tables that contain spaces in their names. 
+
+**Note on ambiguous table names**: If a table name contains both spaces and a SQL keyword (e.g., "from", "where", "join"), it may be misinterpreted as a SQL query. To resolve this ambiguity, quote the table identifier with backticks \`. For example:
+
+```
+df = spark.read \
+  .format("bigquery") \
+  .load("`my_project.my_dataset.orders from 2023`")
+```
+
 For more information, see additional code samples in
 [Python](examples/python/shakespeare.py),
 [Scala](spark-bigquery-dsv1/src/main/scala/com/google/cloud/spark/bigquery/examples/Shakespeare.scala)

--- a/README-template.md
+++ b/README-template.md
@@ -175,7 +175,7 @@ import com.google.cloud.spark.bigquery._
 val df = spark.read.bigquery("bigquery-public-data.samples.shakespeare")
 ```
 
-The connector supports reading from tables that contain spaces in their names. 
+The connector supports reading from tables that contain spaces in their names.
 
 **Note on ambiguous table names**: If a table name contains both spaces and a SQL keyword (e.g., "from", "where", "join"), it may be misinterpreted as a SQL query. To resolve this ambiguity, quote the table identifier with backticks \`. For example:
 

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
@@ -97,7 +97,7 @@ public class BigQueryUtil {
   private static final String DATASET_PATTERN = "\\w+";
   // Allow all non-whitespace beside ':' and '.'.
   // These confuse the qualified table parsing.
-  private static final String TABLE_PATTERN = "[\\S&&[^.:]]+";
+  private static final String TABLE_PATTERN = "[^.:]+";
 
   private static final String NAMED_PARAM_PREFIX = "namedparameters.";
   private static final String POSITIONAL_PARAM_PREFIX = "positionalparameters.";

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
@@ -208,7 +208,7 @@ public class BigQueryUtil {
       Optional<String> project,
       Optional<String> datePartition) {
     String effectiveTable = rawTable.trim();
-    if (effectiveTable.startsWith("`") && effectiveTable.endsWith("`")) {
+    if (effectiveTable.length() >= 2 && effectiveTable.startsWith("`") && effectiveTable.endsWith("`")) {
       effectiveTable = effectiveTable.substring(1, effectiveTable.length() - 1);
     }
 

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
@@ -207,7 +207,12 @@ public class BigQueryUtil {
       Optional<String> dataset,
       Optional<String> project,
       Optional<String> datePartition) {
-    Matcher matcher = QUALIFIED_TABLE_REGEX.matcher(rawTable);
+    String effectiveTable = rawTable.trim();
+    if (effectiveTable.startsWith("`") && effectiveTable.endsWith("`")) {
+      effectiveTable = effectiveTable.substring(1, effectiveTable.length() - 1);
+    }
+
+    Matcher matcher = QUALIFIED_TABLE_REGEX.matcher(effectiveTable);
     if (!matcher.matches()) {
       throw new IllegalArgumentException(
           format("Invalid Table ID '%s'. Must match '%s'", rawTable, QUALIFIED_TABLE_REGEX));

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
@@ -95,7 +95,7 @@ public class BigQueryUtil {
 
   private static final String PROJECT_PATTERN = "\\S+";
   private static final String DATASET_PATTERN = "\\w+";
-  // Allow all non-whitespace beside ':' and '.'.
+  // Allow any character except ':' and '.', which are used as delimiters in qualified names.
   // These confuse the qualified table parsing.
   private static final String TABLE_PATTERN = "[^.:]+";
 

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
@@ -208,7 +208,9 @@ public class BigQueryUtil {
       Optional<String> project,
       Optional<String> datePartition) {
     String effectiveTable = rawTable.trim();
-    if (effectiveTable.length() >= 2 && effectiveTable.startsWith("`") && effectiveTable.endsWith("`")) {
+    if (effectiveTable.length() >= 2
+        && effectiveTable.startsWith("`")
+        && effectiveTable.endsWith("`")) {
       effectiveTable = effectiveTable.substring(1, effectiveTable.length() - 1);
     }
 

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryUtilTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryUtilTest.java
@@ -150,6 +150,34 @@ public class BigQueryUtilTest {
   }
 
   @Test
+  public void testParseTableIdWithSpaces() {
+    // 1. Unqualified table name with spaces, relying on default dataset and project
+    TableId tableId1 =
+            BigQueryUtil.parseTableId(
+                    "my cool table", Optional.of("default_dataset"), Optional.of("default-project"));
+    assertThat(tableId1)
+            .isEqualTo(TableId.of("default-project", "default_dataset", "my cool table"));
+
+    // 2. Partially qualified table name with spaces
+    TableId tableId2 =
+            BigQueryUtil.parseTableId(
+                    "my_dataset.my other table", Optional.empty(), Optional.of("default-project"));
+    assertThat(tableId2).isEqualTo(TableId.of("default-project", "my_dataset", "my other table"));
+
+    // 3. Fully qualified table name with spaces
+    TableId tableId3 = BigQueryUtil.parseTableId("my-project.my_dataset.a table with spaces");
+    assertThat(tableId3).isEqualTo(TableId.of("my-project", "my_dataset", "a table with spaces"));
+
+    // 4. Fully qualified table with spaces, ignoring provided defaults
+    TableId tableId4 =
+            BigQueryUtil.parseTableId(
+                    "my-project.my_dataset.a table with spaces",
+                    Optional.of("other_dataset"),
+                    Optional.of("other-project"));
+    assertThat(tableId4).isEqualTo(TableId.of("my-project", "my_dataset", "a table with spaces"));
+  }
+
+  @Test
   public void testUnparsableTable() {
     assertThrows(IllegalArgumentException.class, () -> BigQueryUtil.parseTableId("foo:bar:baz"));
   }

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryUtilTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryUtilTest.java
@@ -158,19 +158,19 @@ public class BigQueryUtilTest {
   @Test
   public void testParseAmbiguousTableWithSpaces() {
     TableId tableId =
-            BigQueryUtil.parseTableId(
-                    "orders from 2023", Optional.of("default_dataset"), Optional.of("default-project"));
+        BigQueryUtil.parseTableId(
+            "orders from 2023", Optional.of("default_dataset"), Optional.of("default-project"));
     assertThat(tableId)
-            .isEqualTo(TableId.of("default-project", "default_dataset", "orders from 2023"));
+        .isEqualTo(TableId.of("default-project", "default_dataset", "orders from 2023"));
   }
 
   @Test
-  public void testParseAmbiguousTableWithBackticks(){
+  public void testParseAmbiguousTableWithBackticks() {
     TableId tableId =
-            BigQueryUtil.parseTableId(
-                    "`orders from 2023`", Optional.of("default_dataset"), Optional.of("default-project"));
+        BigQueryUtil.parseTableId(
+            "`orders from 2023`", Optional.of("default_dataset"), Optional.of("default-project"));
     assertThat(tableId)
-            .isEqualTo(TableId.of("default-project", "default_dataset", "orders from 2023"));
+        .isEqualTo(TableId.of("default-project", "default_dataset", "orders from 2023"));
   }
 
   @Test

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryUtilTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryUtilTest.java
@@ -150,31 +150,27 @@ public class BigQueryUtilTest {
   }
 
   @Test
-  public void testParseTableIdWithSpaces() {
-    // 1. Unqualified table name with spaces, relying on default dataset and project
-    TableId tableId1 =
-            BigQueryUtil.parseTableId(
-                    "my cool table", Optional.of("default_dataset"), Optional.of("default-project"));
-    assertThat(tableId1)
-            .isEqualTo(TableId.of("default-project", "default_dataset", "my cool table"));
+  public void testParseFullyQualifiedTableWithSpaces() {
+    TableId tableId = BigQueryUtil.parseTableId("my-project.my_dataset.a table with spaces");
+    assertThat(tableId).isEqualTo(TableId.of("my-project", "my_dataset", "a table with spaces"));
+  }
 
-    // 2. Partially qualified table name with spaces
-    TableId tableId2 =
+  @Test
+  public void testParseAmbiguousTableWithSpaces() {
+    TableId tableId =
             BigQueryUtil.parseTableId(
-                    "my_dataset.my other table", Optional.empty(), Optional.of("default-project"));
-    assertThat(tableId2).isEqualTo(TableId.of("default-project", "my_dataset", "my other table"));
+                    "orders from 2023", Optional.of("default_dataset"), Optional.of("default-project"));
+    assertThat(tableId)
+            .isEqualTo(TableId.of("default-project", "default_dataset", "orders from 2023"));
+  }
 
-    // 3. Fully qualified table name with spaces
-    TableId tableId3 = BigQueryUtil.parseTableId("my-project.my_dataset.a table with spaces");
-    assertThat(tableId3).isEqualTo(TableId.of("my-project", "my_dataset", "a table with spaces"));
-
-    // 4. Fully qualified table with spaces, ignoring provided defaults
-    TableId tableId4 =
+  @Test
+  public void testParseAmbiguousTableWithBackticks(){
+    TableId tableId =
             BigQueryUtil.parseTableId(
-                    "my-project.my_dataset.a table with spaces",
-                    Optional.of("other_dataset"),
-                    Optional.of("other-project"));
-    assertThat(tableId4).isEqualTo(TableId.of("my-project", "my_dataset", "a table with spaces"));
+                    "`orders from 2023`", Optional.of("default_dataset"), Optional.of("default-project"));
+    assertThat(tableId)
+            .isEqualTo(TableId.of("default-project", "default_dataset", "orders from 2023"));
   }
 
   @Test

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -144,9 +144,11 @@ public class SparkBigQueryConfig
   private static final String CONF_PREFIX = "spark.datasource.bigquery.";
   private static final int DEFAULT_BIGQUERY_CLIENT_CONNECT_TIMEOUT = 60 * 1000;
   private static final int DEFAULT_BIGQUERY_CLIENT_READ_TIMEOUT = 60 * 1000;
-  private static final Pattern QUICK_LOWERCASE_QUERY_PATTERN = Pattern.compile("(?i)^\\s*(select|with|\\()\\b[\\s\\S]*");
+  private static final Pattern QUICK_LOWERCASE_QUERY_PATTERN =
+      Pattern.compile("(?i)^\\s*(select|with|\\()\\b[\\s\\S]*");
   private static final Pattern HAS_WHITESPACE_PATTERN = Pattern.compile("\\s");
-  private static final Pattern SQL_KEYWORD_PATTERN = Pattern.compile("(?i)\\b(select|from|where|join|group by|order by|union all)\\b");
+  private static final Pattern SQL_KEYWORD_PATTERN =
+      Pattern.compile("(?i)\\b(select|from|where|join|group by|order by|union all)\\b");
   // Both MIN values correspond to the lower possible value that will actually make the code work.
   // 0 or less would make code hang or other bad side effects.
   public static final int MIN_BUFFERED_RESPONSES_PER_STREAM = 1;
@@ -743,8 +745,8 @@ public class SparkBigQueryConfig
     }
 
     // Might be a query with a leading comment, OR could be a table name with spaces.
-    return HAS_WHITESPACE_PATTERN.matcher(potentialQuery).find() &&
-              SQL_KEYWORD_PATTERN.matcher(potentialQuery).find();
+    return HAS_WHITESPACE_PATTERN.matcher(potentialQuery).find()
+        && SQL_KEYWORD_PATTERN.matcher(potentialQuery).find();
   }
 
   private static void validateDateFormat(

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -146,7 +146,7 @@ public class SparkBigQueryConfig
   private static final int DEFAULT_BIGQUERY_CLIENT_READ_TIMEOUT = 60 * 1000;
   private static final Pattern QUICK_LOWERCASE_QUERY_PATTERN = Pattern.compile("(?i)^\\s*(select|with|\\()\\b[\\s\\S]*");
   private static final Pattern HAS_WHITESPACE_PATTERN = Pattern.compile("\\s");
-  private static final Pattern SQL_KEYWORD_PATTERN =       Pattern.compile("(?i)\\b(select|from|where|join|group by|order by|union all)\\b");
+  private static final Pattern SQL_KEYWORD_PATTERN = Pattern.compile("(?i)\\b(select|from|where|join|group by|order by|union all)\\b");
   // Both MIN values correspond to the lower possible value that will actually make the code work.
   // 0 or less would make code hang or other bad side effects.
   public static final int MIN_BUFFERED_RESPONSES_PER_STREAM = 1;
@@ -731,6 +731,11 @@ public class SparkBigQueryConfig
       return false;
     }
     String potentialQuery = tableParamStr.trim();
+
+    // If the string is quoted with backticks, it is recognized as a table identifier, not a query.
+    if (potentialQuery.startsWith("`") && potentialQuery.endsWith("`")) {
+      return false;
+    }
 
     // Check for common query-starting keyword.
     if (QUICK_LOWERCASE_QUERY_PATTERN.matcher(potentialQuery).matches()) {

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -144,9 +144,9 @@ public class SparkBigQueryConfig
   private static final String CONF_PREFIX = "spark.datasource.bigquery.";
   private static final int DEFAULT_BIGQUERY_CLIENT_CONNECT_TIMEOUT = 60 * 1000;
   private static final int DEFAULT_BIGQUERY_CLIENT_READ_TIMEOUT = 60 * 1000;
-  private static final Pattern LOWERCASE_QUERY_PATTERN =
-      Pattern.compile("^(select|with)\\b[\\s\\S]*");
+  private static final Pattern QUICK_LOWERCASE_QUERY_PATTERN = Pattern.compile("(?i)^\\s*(select|with|\\()\\b[\\s\\S]*");
   private static final Pattern HAS_WHITESPACE_PATTERN = Pattern.compile("\\s");
+  private static final Pattern SQL_KEYWORD_PATTERN =       Pattern.compile("(?i)\\b(select|from|where|join|group by|order by|union all)\\b");
   // Both MIN values correspond to the lower possible value that will actually make the code work.
   // 0 or less would make code hang or other bad side effects.
   public static final int MIN_BUFFERED_RESPONSES_PER_STREAM = 1;
@@ -727,11 +727,19 @@ public class SparkBigQueryConfig
 
   @VisibleForTesting
   static boolean isQuery(String tableParamStr) {
-    // A potential query will start with (select|with) or contain a whitespace in between. This
-    // assumes good intentions. Queries like "/**/select'asdf'" although valid won't pass this test.
-    String potentialQuery = tableParamStr.toLowerCase().trim();
-    return LOWERCASE_QUERY_PATTERN.matcher(potentialQuery).matches()
-        || HAS_WHITESPACE_PATTERN.matcher(potentialQuery).find();
+    if (tableParamStr == null || tableParamStr.trim().isEmpty()) {
+      return false;
+    }
+    String potentialQuery = tableParamStr.trim();
+
+    // Check for common query-starting keyword.
+    if (QUICK_LOWERCASE_QUERY_PATTERN.matcher(potentialQuery).matches()) {
+      return true;
+    }
+
+    // Might be a query with a leading comment, OR could be a table name with spaces.
+    return HAS_WHITESPACE_PATTERN.matcher(potentialQuery).find() &&
+              SQL_KEYWORD_PATTERN.matcher(potentialQuery).find();
   }
 
   private static void validateDateFormat(

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -491,13 +491,17 @@ public class SparkBigQueryConfigTest {
     assertThat(SparkBigQueryConfig.isQuery("where")).isFalse();
     assertThat(SparkBigQueryConfig.isQuery("dataset.from")).isFalse();
 
-    // Positive cases: These are all valid queries.
     assertThat(SparkBigQueryConfig.isQuery("select * from `dataset.my table`")).isTrue();
     assertThat(SparkBigQueryConfig.isQuery("select field from `project.dataset.my table` where id > 10")).isTrue();
     assertThat(SparkBigQueryConfig.isQuery("WITH subset AS (SELECT * FROM `dataset.my table`)\nSELECT * FROM subset")).isTrue();
 
     assertThat(SparkBigQueryConfig.isQuery("/* Query for marketing */ SELECT * FROM my_table")).isTrue();
     assertThat(SparkBigQueryConfig.isQuery("\n-- Query for marketing\nSELECT * FROM my_table")).isTrue();
+
+    assertThat(SparkBigQueryConfig.isQuery("orders from 2023")).isTrue();
+    assertThat(SparkBigQueryConfig.isQuery("`orders from 2023`")).isFalse();
+    assertThat(SparkBigQueryConfig.isQuery("`my_project.my_dataset.sales group by product`"))
+            .isFalse();
   }
 
   @Test

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -492,16 +492,24 @@ public class SparkBigQueryConfigTest {
     assertThat(SparkBigQueryConfig.isQuery("dataset.from")).isFalse();
 
     assertThat(SparkBigQueryConfig.isQuery("select * from `dataset.my table`")).isTrue();
-    assertThat(SparkBigQueryConfig.isQuery("select field from `project.dataset.my table` where id > 10")).isTrue();
-    assertThat(SparkBigQueryConfig.isQuery("WITH subset AS (SELECT * FROM `dataset.my table`)\nSELECT * FROM subset")).isTrue();
+    assertThat(
+            SparkBigQueryConfig.isQuery(
+                "select field from `project.dataset.my table` where id > 10"))
+        .isTrue();
+    assertThat(
+            SparkBigQueryConfig.isQuery(
+                "WITH subset AS (SELECT * FROM `dataset.my table`)\nSELECT * FROM subset"))
+        .isTrue();
 
-    assertThat(SparkBigQueryConfig.isQuery("/* Query for marketing */ SELECT * FROM my_table")).isTrue();
-    assertThat(SparkBigQueryConfig.isQuery("\n-- Query for marketing\nSELECT * FROM my_table")).isTrue();
+    assertThat(SparkBigQueryConfig.isQuery("/* Query for marketing */ SELECT * FROM my_table"))
+        .isTrue();
+    assertThat(SparkBigQueryConfig.isQuery("\n-- Query for marketing\nSELECT * FROM my_table"))
+        .isTrue();
 
     assertThat(SparkBigQueryConfig.isQuery("orders from 2023")).isTrue();
     assertThat(SparkBigQueryConfig.isQuery("`orders from 2023`")).isFalse();
     assertThat(SparkBigQueryConfig.isQuery("`my_project.my_dataset.sales group by product`"))
-            .isFalse();
+        .isFalse();
   }
 
   @Test

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/ReadIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/ReadIntegrationTestBase.java
@@ -611,36 +611,33 @@ public class ReadIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
   public void testReadFromTableWithSpacesInName() {
     String tableNameWithSpaces = testTable + " with spaces";
 
-    String tableIdForBqSql = String.format("`%s`.`%s`.`%s`",
-            TestConstants.PROJECT_ID,
-            testDataset.toString(),
-            tableNameWithSpaces);
+    String tableIdForBqSql =
+        String.format(
+            "`%s`.`%s`.`%s`",
+            TestConstants.PROJECT_ID, testDataset.toString(), tableNameWithSpaces);
     try {
-      IntegrationTestUtils.runQuery(String.format(
-              "CREATE TABLE %s (id INT64, data STRING) AS " +
-                      "SELECT * FROM UNNEST([(1, 'foo'), (2, 'bar'), (3, 'baz')])",
+      IntegrationTestUtils.runQuery(
+          String.format(
+              "CREATE TABLE %s (id INT64, data STRING) AS "
+                  + "SELECT * FROM UNNEST([(1, 'foo'), (2, 'bar'), (3, 'baz')])",
               tableIdForBqSql));
 
-      String tableIdForConnector = String.format("%s:%s.%s",
-              TestConstants.PROJECT_ID,
-              testDataset.toString(),
-              tableNameWithSpaces);
+      String tableIdForConnector =
+          String.format(
+              "%s:%s.%s", TestConstants.PROJECT_ID, testDataset.toString(), tableNameWithSpaces);
 
-      Dataset<Row> df = spark.read()
-              .format("bigquery")
-              .load(tableIdForConnector);
+      Dataset<Row> df = spark.read().format("bigquery").load(tableIdForConnector);
 
-      StructType expectedSchema = new StructType()
+      StructType expectedSchema =
+          new StructType()
               .add("id", DataTypes.LongType, true)
               .add("data", DataTypes.StringType, true);
 
       assertThat(df.schema()).isEqualTo(expectedSchema);
       assertThat(df.count()).isEqualTo(3);
 
-      Dataset<Row> filteredDf = spark.read()
-              .format("bigquery")
-              .option("filter", "id > 1")
-              .load(tableIdForConnector);
+      Dataset<Row> filteredDf =
+          spark.read().format("bigquery").option("filter", "id > 1").load(tableIdForConnector);
 
       assertThat(filteredDf.count()).isEqualTo(2);
 

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/ReadIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/ReadIntegrationTestBase.java
@@ -607,6 +607,52 @@ public class ReadIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
     assertThat(snapshotRows).isEqualTo(allTypesRows);
   }
 
+  @Test
+  public void testReadFromTableWithSpacesInName() {
+    String tableNameWithSpaces = testTable + " with spaces";
+
+    String tableIdForBqSql = String.format("`%s`.`%s`.`%s`",
+            TestConstants.PROJECT_ID,
+            testDataset.toString(),
+            tableNameWithSpaces);
+    try {
+      IntegrationTestUtils.runQuery(String.format(
+              "CREATE TABLE %s (id INT64, data STRING) AS " +
+                      "SELECT * FROM UNNEST([(1, 'foo'), (2, 'bar'), (3, 'baz')])",
+              tableIdForBqSql));
+
+      String tableIdForConnector = String.format("%s:%s.%s",
+              TestConstants.PROJECT_ID,
+              testDataset.toString(),
+              tableNameWithSpaces);
+
+      Dataset<Row> df = spark.read()
+              .format("bigquery")
+              .load(tableIdForConnector);
+
+      StructType expectedSchema = new StructType()
+              .add("id", DataTypes.LongType, true)
+              .add("data", DataTypes.StringType, true);
+
+      assertThat(df.schema()).isEqualTo(expectedSchema);
+      assertThat(df.count()).isEqualTo(3);
+
+      Dataset<Row> filteredDf = spark.read()
+              .format("bigquery")
+              .option("filter", "id > 1")
+              .load(tableIdForConnector);
+
+      assertThat(filteredDf.count()).isEqualTo(2);
+
+      List<Row> rows = filteredDf.sort("id").collectAsList();
+      assertThat(rows.get(0).getLong(0)).isEqualTo(2);
+      assertThat(rows.get(0).getString(1)).isEqualTo("bar");
+
+    } finally {
+      IntegrationTestUtils.runQuery(String.format("DROP TABLE IF EXISTS %s", tableIdForBqSql));
+    }
+  }
+
   /**
    * Setting the CreateReadSession timeout to 1000 seconds, which should create the read session
    * since the timeout is more and data is less

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/ReadIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/ReadIntegrationTestBase.java
@@ -624,7 +624,7 @@ public class ReadIntegrationTestBase extends SparkBigQueryIntegrationTestBase {
 
       String tableIdForConnector =
           String.format(
-              "%s:%s.%s", TestConstants.PROJECT_ID, testDataset.toString(), tableNameWithSpaces);
+              "%s.%s.%s", TestConstants.PROJECT_ID, testDataset.toString(), tableNameWithSpaces);
 
       Dataset<Row> df = spark.read().format("bigquery").load(tableIdForConnector);
 


### PR DESCRIPTION
This PR enables reading from BigQuery tables with spaces in their names by updating the table parsing logic and improving the isQuery function. It also introduces support for backticked identifiers for ambiguous table names that contain SQL keywords (e.g., orders from 2023), ensuring they are always correctly identified as table names. 