### PR TITLE
feat: Add reservation option for BigQuery jobs

### DIFF
--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryConfig.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryConfig.java
@@ -53,6 +53,7 @@ public class BigQueryClientFactoryConfig implements BigQueryConfig {
   private final int channelPoolSize;
   private final Optional<Integer> flowControlWindowBytes;
   private final QueryJobConfiguration.Priority queryJobPriority;
+  private final Optional<String> reservation;
   private final long bigQueryJobTimeoutInMinutes;
 
   BigQueryClientFactoryConfig(BigQueryConfig bigQueryConfig, long bigQueryJobTimeoutInMinutes) {
@@ -85,6 +86,7 @@ public class BigQueryClientFactoryConfig implements BigQueryConfig {
     this.channelPoolSize = bigQueryConfig.getChannelPoolSize();
     this.flowControlWindowBytes = bigQueryConfig.getFlowControlWindowBytes();
     this.queryJobPriority = bigQueryConfig.getQueryJobPriority();
+    this.reservation = bigQueryConfig.getReservation();
     this.bigQueryJobTimeoutInMinutes = bigQueryJobTimeoutInMinutes;
   }
 
@@ -216,6 +218,11 @@ public class BigQueryClientFactoryConfig implements BigQueryConfig {
   @Override
   public Priority getQueryJobPriority() {
     return queryJobPriority;
+  }
+
+  @Override
+  public Optional<String> getReservation() {
+    return reservation;
   }
 
   public long getBigQueryJobTimeoutInMinutes() {

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientModule.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClientModule.java
@@ -136,6 +136,7 @@ public class BigQueryClientModule implements com.google.inject.Module {
         destinationTableCache,
         bigQueryJobLabels,
         config.getQueryJobPriority(),
+        config.getReservation(),
         Optional.of(jobCompletionListener),
         config.getBigQueryJobTimeoutInMinutes());
   }

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfig.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryConfig.java
@@ -78,6 +78,8 @@ public interface BigQueryConfig {
 
   Priority getQueryJobPriority();
 
+  Optional<String> getReservation();
+
   long getBigQueryJobTimeoutInMinutes();
 
   Optional<ImmutableList<String>> getCredentialsScopes();

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryClientFactoryTest.java
@@ -645,6 +645,11 @@ public class BigQueryClientFactoryTest {
     }
 
     @Override
+    public Optional<String> getReservation() {
+      return Optional.empty();
+    }
+
+    @Override
     public Optional<Long> getCreateReadSessionTimeoutInSeconds() {
       return Optional.empty();
     }

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -248,6 +248,7 @@ public class SparkBigQueryConfig
   private Map<String, String> bigQueryTableLabels = Collections.emptyMap();
   private com.google.common.base.Optional<Long> createReadSessionTimeoutInSeconds;
   private QueryJobConfiguration.Priority queryJobPriority = DEFAULT_JOB_PRIORITY;
+  private com.google.common.base.Optional<String> reservation = empty();
 
   private com.google.common.base.Optional<String> destinationTableKmsKeyName = empty();
 
@@ -647,6 +648,8 @@ public class SparkBigQueryConfig
             .transform(String::toUpperCase)
             .transform(Priority::valueOf)
             .or(DEFAULT_JOB_PRIORITY);
+
+    config.reservation = getAnyOption(globalOptions, options, "reservation");
 
     config.destinationTableKmsKeyName =
         getAnyOption(globalOptions, options, "destinationTableKmsKeyName");
@@ -1100,6 +1103,10 @@ public class SparkBigQueryConfig
   @Override
   public Priority getQueryJobPriority() {
     return queryJobPriority;
+  }
+
+  public Optional<String> getReservation() {
+    return reservation.toJavaUtil();
   }
 
   @Override

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/SparkBigQueryConfigTest.java
@@ -137,6 +137,31 @@ public class SparkBigQueryConfigTest {
   }
 
   @Test
+  public void testReservation() {
+    Configuration hadoopConfiguration = new Configuration();
+    DataSourceOptions options =
+        new DataSourceOptions(
+            ImmutableMap.<String, String>builder()
+                .put("table", "test_t")
+                .put("dataset", "test_d")
+                .put("project", "test_p")
+                .put("reservation", "my_reservation")
+                .build());
+    SparkBigQueryConfig config =
+        SparkBigQueryConfig.from(
+            options.asMap(),
+            defaultGlobalOptions,
+            hadoopConfiguration,
+            ImmutableMap.of(),
+            DEFAULT_PARALLELISM,
+            new SQLConf(),
+            SPARK_VERSION,
+            Optional.empty(), /* tableIsMandatory */
+            true);
+    assertThat(config.getReservation()).isEqualTo(Optional.of("my_reservation"));
+  }
+
+  @Test
   public void testConfigFromOptions() {
     Configuration hadoopConfiguration = new Configuration();
     DataSourceOptions options =

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/IntegrationTestUtils.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/IntegrationTestUtils.java
@@ -31,6 +31,7 @@ import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TableResult;
 import com.google.cloud.bigquery.ViewDefinition;
 import com.google.cloud.bigquery.connector.common.BigQueryClient;
+import com.google.cloud.bigquery.connector.common.BigQueryJobCompletionListener;
 import com.google.cloud.spark.bigquery.SchemaConverters;
 import com.google.cloud.spark.bigquery.SchemaConvertersConfiguration;
 import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
@@ -66,6 +67,7 @@ public class IntegrationTestUtils {
         ImmutableMap.of(),
         SparkBigQueryConfig.DEFAULT_JOB_PRIORITY,
         Optional.empty(),
+        Optional.<BigQueryJobCompletionListener>empty(),
         6 * 60);
   }
 

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -47,7 +47,7 @@
         <arrow.spark4.version>18.3.0</arrow.spark4.version>
         <gax.version>2.63.1</gax.version>
         <google-auth.version>1.33.1</google-auth.version>
-        <google-cloud-bigquery.version>2.48.1</google-cloud-bigquery.version>
+        <google-cloud-bigquery.version>2.53.0</google-cloud-bigquery.version>
         <google-cloud-bigquerystorage.version>3.11.4</google-cloud-bigquerystorage.version>
         <google-cloud-dataproc.version>4.56.0</google-cloud-dataproc.version>
         <google-cloud-storage.version>2.49.0</google-cloud-storage.version>


### PR DESCRIPTION
Adds ability to specify the reservation that will be used when creating BigQuery jobs submitted by the connector ([BQ docs](https://cloud.google.com/bigquery/docs/reservations-assignments#reservation)).

Updates google-cloud-bigquery to the latest 2.53.0 (the reservation JobConfig field was added in [2.50.0](https://github.com/googleapis/java-bigquery/releases/tag/v2.50.0)).