### PR TITLE
adding dataproc labels to bigquery jobs

### DIFF
--- a/spark-bigquery-connector-common/pom.xml
+++ b/spark-bigquery-connector-common/pom.xml
@@ -82,6 +82,11 @@
             <artifactId>arrow-vector</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.4.3</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-dataproc</artifactId>
             <scope>test</scope>
@@ -89,6 +94,12 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-netty</artifactId>
+            <version>5.15.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spark-bigquery-connector-common/pom.xml
+++ b/spark-bigquery-connector-common/pom.xml
@@ -82,11 +82,6 @@
             <artifactId>arrow-vector</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents.client5</groupId>
-            <artifactId>httpclient5</artifactId>
-            <version>5.4.3</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-dataproc</artifactId>
             <scope>test</scope>

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -636,9 +636,9 @@ public class SparkBigQueryConfig
 
     config.bigQueryJobLabels =
         ImmutableMap.<String, String>builder()
-            .putAll(parseBigQueryLabels(globalOptions, options, BIGQUERY_JOB_LABEL_PREFIX))
             .putAll(GCPLabelUtils.getSparkLabels(originalGlobalOptions))
-            .build();
+            .putAll(parseBigQueryLabels(globalOptions, options, BIGQUERY_JOB_LABEL_PREFIX))
+            .buildKeepingLast();
 
     config.bigQueryTableLabels =
         parseBigQueryLabels(globalOptions, options, BIGQUERY_TABLE_LABEL_PREFIX);

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryConfig.java
@@ -54,6 +54,7 @@ import com.google.cloud.bigquery.connector.common.ReadSessionCreatorConfigBuilde
 import com.google.cloud.bigquery.storage.v1.ArrowSerializationOptions.CompressionCodec;
 import com.google.cloud.bigquery.storage.v1.DataFormat;
 import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions.ResponseCompressionCodec;
+import com.google.cloud.spark.bigquery.util.GCPLabelUtils;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
@@ -634,7 +635,11 @@ public class SparkBigQueryConfig
             });
 
     config.bigQueryJobLabels =
-        parseBigQueryLabels(globalOptions, options, BIGQUERY_JOB_LABEL_PREFIX);
+        ImmutableMap.<String, String>builder()
+            .putAll(parseBigQueryLabels(globalOptions, options, BIGQUERY_JOB_LABEL_PREFIX))
+            .putAll(GCPLabelUtils.getSparkLabels(originalGlobalOptions))
+            .build();
+
     config.bigQueryTableLabels =
         parseBigQueryLabels(globalOptions, options, BIGQUERY_TABLE_LABEL_PREFIX);
 

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/util/GCPLabelUtils.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/util/GCPLabelUtils.java
@@ -1,0 +1,234 @@
+package com.google.cloud.spark.bigquery.util;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ParseException;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.util.Timeout;
+
+/** Util to extract values from GCP environment */
+public class GCPLabelUtils {
+
+  private static final String BASE_URI = "http://metadata.google.internal/computeMetadata/v1";
+  public static final String PROJECT_ID_ENDPOINT = "/project/project-id";
+  public static final String BATCH_ID_ENDPOINT = "/instance/attributes/dataproc-batch-id";
+  public static final String BATCH_UUID_ENDPOINT = "/instance/attributes/dataproc-batch-uuid";
+  public static final String SESSION_ID_ENDPOINT = "/instance/attributes/dataproc-session-id";
+  public static final String SESSION_UUID_ENDPOINT = "/instance/attributes/dataproc-session-uuid";
+  public static final String CLUSTER_UUID_ENDPOINT = "/instance/attributes/dataproc-cluster-uuid";
+  public static final String DATAPROC_REGION_ENDPOINT = "/instance/attributes/dataproc-region";
+  private static final String DATAPROC_CLASSPATH = "/usr/local/share/google/dataproc/lib";
+  private static final CloseableHttpClient HTTP_CLIENT;
+  public static final String SPARK_YARN_TAGS = "spark.yarn.tags";
+  public static final String SPARK_DRIVER_HOST = "spark.driver.host";
+  public static final String SPARK_APP_ID = "spark.app.id";
+  public static final String SPARK_APP_NAME = "spark.app.name";
+  public static final String GOOGLE_METADATA_API = "google.metadata.api.base-url";
+  public static final String SPARK_MASTER = "spark.master";
+  private static final String JOB_ID_PREFIX = "dataproc_job_";
+  private static final String JOB_UUID_PREFIX = "dataproc_uuid_";
+  private static final String METADATA_FLAVOUR = "Metadata-Flavor";
+  private static final String GOOGLE = "Google";
+  private static final String SPARK_DIST_CLASSPATH = "SPARK_DIST_CLASSPATH";
+
+  enum ResourceType {
+    CLUSTER,
+    BATCH,
+    INTERACTIVE,
+    UNKNOWN
+  }
+
+  static {
+    ConnectionConfig connectionConfig =
+        ConnectionConfig.custom()
+            .setConnectTimeout(Timeout.ofMilliseconds(100))
+            .setSocketTimeout(Timeout.ofMilliseconds(100))
+            .build();
+    PoolingHttpClientConnectionManager connMan =
+        PoolingHttpClientConnectionManagerBuilder.create()
+            .setDefaultConnectionConfig(connectionConfig)
+            .build();
+    RequestConfig config =
+        RequestConfig.custom().setConnectionRequestTimeout(Timeout.ofMilliseconds(100)).build();
+    HTTP_CLIENT =
+        HttpClients.custom().setDefaultRequestConfig(config).setConnectionManager(connMan).build();
+  }
+
+  static boolean isDataprocRuntime() {
+    String sparkDistClasspath = System.getenv(SPARK_DIST_CLASSPATH);
+    return (sparkDistClasspath != null && sparkDistClasspath.contains(DATAPROC_CLASSPATH));
+  }
+
+  public static Map<String, String> getSparkLabels(ImmutableMap<String, String> conf) {
+    Map<String, String> sparkLabels = new HashMap<>();
+    getSparkAppId(conf).ifPresent(p -> sparkLabels.put("appId", p));
+    getSparkAppName(conf).ifPresent(p -> sparkLabels.put("appName", p));
+    if (isDataprocRuntime()) {
+      sparkLabels.putAll(getGCPLabels(conf));
+    }
+    return sparkLabels;
+  }
+
+  static Map<String, String> getGCPLabels(ImmutableMap<String, String> conf) {
+    Map<String, String> gcpLabels = new HashMap<>();
+    ResourceType resource = identifyResource(conf);
+    switch (resource) {
+      case CLUSTER:
+        getClusterName(conf).ifPresent(p -> gcpLabels.put("cluster.name", p));
+        getClusterUUID(conf).ifPresent(p -> gcpLabels.put("cluster.uuid", p));
+        getDataprocJobID(conf).ifPresent(p -> gcpLabels.put("job.id", p));
+        getDataprocJobUUID(conf).ifPresent(p -> gcpLabels.put("job.uuid", p));
+        gcpLabels.put("job.type", "dataproc_job");
+        break;
+      case BATCH:
+        getDataprocBatchID(conf).ifPresent(p -> gcpLabels.put("spark.batch.id", p));
+        getDataprocBatchUUID(conf).ifPresent(p -> gcpLabels.put("spark.batch.uuid", p));
+        gcpLabels.put("job.type", "batch");
+        break;
+      case INTERACTIVE:
+        getDataprocSessionID(conf).ifPresent(p -> gcpLabels.put("spark.session.id", p));
+        getDataprocSessionUUID(conf).ifPresent(p -> gcpLabels.put("spark.session.uuid", p));
+        gcpLabels.put("job.type", "session");
+        break;
+      case UNKNOWN:
+        // do nothing
+        break;
+    }
+    getGCPProjectId(conf).ifPresent(p -> gcpLabels.put("projectId", p));
+    getDataprocRegion(conf).ifPresent(p -> gcpLabels.put("region", p));
+    return gcpLabels;
+  }
+
+  static ResourceType identifyResource(ImmutableMap<String, String> conf) {
+    if ("yarn".equals(conf.getOrDefault(SPARK_MASTER, ""))) return ResourceType.CLUSTER;
+    if (getDataprocBatchID(conf).isPresent()) return ResourceType.BATCH;
+    if (getDataprocSessionID(conf).isPresent()) return ResourceType.INTERACTIVE;
+
+    return ResourceType.UNKNOWN;
+  }
+
+  private static Optional<String> getDriverHost(ImmutableMap<String, String> conf) {
+    return Optional.ofNullable(conf.get(SPARK_DRIVER_HOST));
+  }
+
+  /* sample hostname:
+   * sample-cluster-m.us-central1-a.c.hadoop-cloud-dev.google.com.internal */
+  @VisibleForTesting
+  static Optional<String> getClusterName(ImmutableMap<String, String> conf) {
+    return getDriverHost(conf)
+        .map(host -> host.split("\\.")[0])
+        .map(s -> s.substring(0, s.lastIndexOf("-")));
+  }
+
+  @VisibleForTesting
+  static Optional<String> getDataprocRegion(ImmutableMap<String, String> conf) {
+    return fetchGCPMetadata(DATAPROC_REGION_ENDPOINT, conf);
+  }
+
+  @VisibleForTesting
+  static Optional<String> getDataprocJobID(ImmutableMap<String, String> conf) {
+    return getPropertyFromYarnTag(conf, JOB_ID_PREFIX);
+  }
+
+  @VisibleForTesting
+  static Optional<String> getDataprocJobUUID(ImmutableMap<String, String> conf) {
+    return getPropertyFromYarnTag(conf, JOB_UUID_PREFIX);
+  }
+
+  @VisibleForTesting
+  static Optional<String> getDataprocBatchID(ImmutableMap<String, String> conf) {
+    return fetchGCPMetadata(BATCH_ID_ENDPOINT, conf);
+  }
+
+  @VisibleForTesting
+  static Optional<String> getDataprocBatchUUID(ImmutableMap<String, String> conf) {
+    return fetchGCPMetadata(BATCH_UUID_ENDPOINT, conf);
+  }
+
+  @VisibleForTesting
+  static Optional<String> getDataprocSessionID(ImmutableMap<String, String> conf) {
+    return fetchGCPMetadata(SESSION_ID_ENDPOINT, conf);
+  }
+
+  @VisibleForTesting
+  private static Optional<String> getDataprocSessionUUID(ImmutableMap<String, String> conf) {
+    return fetchGCPMetadata(SESSION_UUID_ENDPOINT, conf);
+  }
+
+  @VisibleForTesting
+  static Optional<String> getGCPProjectId(ImmutableMap<String, String> conf) {
+    return fetchGCPMetadata(PROJECT_ID_ENDPOINT, conf)
+        .map(b -> b.substring(b.lastIndexOf('/') + 1));
+  }
+
+  @VisibleForTesting
+  static Optional<String> getSparkAppId(ImmutableMap<String, String> conf) {
+    return Optional.ofNullable(conf.get(SPARK_APP_ID));
+  }
+
+  @VisibleForTesting
+  static Optional<String> getSparkAppName(ImmutableMap<String, String> conf) {
+    return Optional.ofNullable(conf.get(SPARK_APP_NAME));
+  }
+
+  @VisibleForTesting
+  static Optional<String> getClusterUUID(ImmutableMap<String, String> conf) {
+    return fetchGCPMetadata(CLUSTER_UUID_ENDPOINT, conf);
+  }
+
+  @VisibleForTesting
+  static Optional<String> getPropertyFromYarnTag(
+      ImmutableMap<String, String> conf, String tagPrefix) {
+    String yarnTag = conf.get(SPARK_YARN_TAGS);
+    if (yarnTag == null) {
+      return Optional.empty();
+    }
+    return Arrays.stream(yarnTag.split(","))
+        .filter(tag -> tag.contains(tagPrefix))
+        .findFirst()
+        .map(tag -> tag.substring(tagPrefix.length()));
+  }
+
+  @VisibleForTesting
+  static Optional<String> fetchGCPMetadata(String httpEndpoint, ImmutableMap<String, String> conf) {
+    String baseUri = conf.getOrDefault(GOOGLE_METADATA_API, BASE_URI);
+    String httpURI = baseUri + httpEndpoint;
+    HttpGet httpGet = new HttpGet(httpURI);
+    httpGet.addHeader(METADATA_FLAVOUR, GOOGLE);
+    try {
+      return HTTP_CLIENT.execute(
+          httpGet,
+          response -> {
+            handleError(response);
+            return Optional.of(EntityUtils.toString(response.getEntity()));
+          });
+    } catch (IOException e) {
+      return Optional.empty();
+    }
+  }
+
+  private static void handleError(ClassicHttpResponse response) throws IOException, ParseException {
+    final int statusCode = response.getCode();
+    if (statusCode < 400 || statusCode >= 600) return;
+    String message =
+        String.format(
+            "code: %d, response: %s",
+            statusCode, EntityUtils.toString(response.getEntity(), UTF_8));
+    throw new IOException(message);
+  }
+}

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/util/GCPLabelUtils.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/util/GCPLabelUtils.java
@@ -81,8 +81,8 @@ public class GCPLabelUtils {
 
   private static Map<String, String> computeSparkLabels(ImmutableMap<String, String> conf) {
     Map<String, String> sparkLabels = new HashMap<>();
-    getSparkAppId(conf).ifPresent(p -> sparkLabels.put("appId", p));
-    getSparkAppName(conf).ifPresent(p -> sparkLabels.put("appName", p));
+    getSparkAppId(conf).ifPresent(p -> sparkLabels.put("app-id", p));
+    getSparkAppName(conf).ifPresent(p -> sparkLabels.put("app-name", p));
     if (isDataprocRuntime()) {
       sparkLabels.putAll(getGCPLabels(conf));
     }
@@ -92,7 +92,7 @@ public class GCPLabelUtils {
   static Map<String, String> getGCPLabels(ImmutableMap<String, String> conf) {
     try (CloseableHttpClient httpClient = createHttpClient()) {
       Map<String, String> gcpLabels = getResourceLabels(conf, httpClient);
-      getGCPProjectId(conf, httpClient).ifPresent(p -> gcpLabels.put("projectId", p));
+      getGCPProjectId(conf, httpClient).ifPresent(p -> gcpLabels.put("project-id", p));
       getDataprocRegion(conf, httpClient).ifPresent(p -> gcpLabels.put("region", p));
       return gcpLabels;
     } catch (IOException e) {
@@ -105,27 +105,27 @@ public class GCPLabelUtils {
       ImmutableMap<String, String> conf, CloseableHttpClient httpClient) {
     Map<String, String> resourceLabels = new HashMap<>();
     if ("yarn".equals(conf.getOrDefault(SPARK_MASTER, ""))) {
-      getClusterName(conf).ifPresent(p -> resourceLabels.put("cluster.name", p));
-      getClusterUUID(conf, httpClient).ifPresent(p -> resourceLabels.put("cluster.uuid", p));
-      getDataprocJobID(conf).ifPresent(p -> resourceLabels.put("job.id", p));
-      getDataprocJobUUID(conf).ifPresent(p -> resourceLabels.put("job.uuid", p));
-      resourceLabels.put("job.type", "dataproc_job");
+      getClusterName(conf).ifPresent(p -> resourceLabels.put("cluster-name", p));
+      getClusterUUID(conf, httpClient).ifPresent(p -> resourceLabels.put("cluster-uuid", p));
+      getDataprocJobID(conf).ifPresent(p -> resourceLabels.put("job-id", p));
+      getDataprocJobUUID(conf).ifPresent(p -> resourceLabels.put("job-uuid", p));
+      resourceLabels.put("job-type", "dataproc_job");
       return resourceLabels;
     }
     Optional<String> dataprocBatchID = getDataprocBatchID(conf, httpClient);
     if (dataprocBatchID.isPresent()) {
-      dataprocBatchID.ifPresent(p -> resourceLabels.put("spark.batch.id", p));
+      dataprocBatchID.ifPresent(p -> resourceLabels.put("spark-batch-id", p));
       getDataprocBatchUUID(conf, httpClient)
-          .ifPresent(p -> resourceLabels.put("spark.batch.uuid", p));
-      resourceLabels.put("job.type", "batch");
+          .ifPresent(p -> resourceLabels.put("spark-batch-uuid", p));
+      resourceLabels.put("job-type", "batch");
       return resourceLabels;
     }
     Optional<String> dataprocSessionID = getDataprocSessionID(conf, httpClient);
     if (dataprocSessionID.isPresent()) {
-      dataprocSessionID.ifPresent(p -> resourceLabels.put("spark.session.id", p));
+      dataprocSessionID.ifPresent(p -> resourceLabels.put("spark-session-id", p));
       getDataprocSessionUUID(conf, httpClient)
-          .ifPresent(p -> resourceLabels.put("spark.session.uuid", p));
-      resourceLabels.put("job.type", "session");
+          .ifPresent(p -> resourceLabels.put("spark-session-uuid", p));
+      resourceLabels.put("job-type", "session");
       return resourceLabels;
     }
     return resourceLabels;

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/util/GCPLabelUtils.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/util/GCPLabelUtils.java
@@ -122,7 +122,7 @@ public class GCPLabelUtils {
   static Optional<String> getClusterName(ImmutableMap<String, String> conf) {
     return getDriverHost(conf)
         .map(host -> host.split("\\.")[0])
-        .map(s -> s.substring(0, s.lastIndexOf("-")));
+        .map(s ->  s.contains("-") ? s.substring(0, s.lastIndexOf("-")) : s);
   }
 
   @VisibleForTesting

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/util/GCPLabelUtilsTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/util/GCPLabelUtilsTest.java
@@ -13,9 +13,6 @@ import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.Header;
 
 public class GCPLabelUtilsTest {
-  private ClientAndServer mockServer;
-  private String mockBaseUrl;
-
   public static final Header METADATA_HEADER = new Header("Metadata-Flavor", "Google");
   private static final String TEST_APP_NAME = "labels-test";
   private static final String TEST_APP_ID = "application_12345";
@@ -26,7 +23,6 @@ public class GCPLabelUtilsTest {
   private static final String TEST_SESSION_ID = "test-session";
   private static final String TEST_PROJECT_ID = "test-project";
   private static final String TEST_REGION = "us-central1";
-
   private static final ImmutableMap<String, String> EXPECTED_FACET_DATAPROC_CLUSTER =
       ImmutableMap.<String, String>builder()
           .put("job.uuid", TEST_RESOURCE_UUID)
@@ -55,6 +51,9 @@ public class GCPLabelUtilsTest {
           .put("job.type", "session")
           .put("region", TEST_REGION)
           .build();
+
+  private ClientAndServer mockServer;
+  private String mockBaseUrl;
 
   @Before
   public void setUp() {

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/util/GCPLabelUtilsTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/util/GCPLabelUtilsTest.java
@@ -25,30 +25,30 @@ public class GCPLabelUtilsTest {
   private static final String TEST_REGION = "us-central1";
   private static final ImmutableMap<String, String> EXPECTED_FACET_DATAPROC_CLUSTER =
       ImmutableMap.<String, String>builder()
-          .put("job.uuid", TEST_RESOURCE_UUID)
-          .put("job.id", TEST_JOB_ID)
-          .put("cluster.uuid", TEST_RESOURCE_UUID)
-          .put("cluster.name", TEST_CLUSTER_NAME)
-          .put("projectId", TEST_PROJECT_ID)
-          .put("job.type", "dataproc_job")
+          .put("job-uuid", TEST_RESOURCE_UUID)
+          .put("job-id", TEST_JOB_ID)
+          .put("cluster-uuid", TEST_RESOURCE_UUID)
+          .put("cluster-name", TEST_CLUSTER_NAME)
+          .put("project-id", TEST_PROJECT_ID)
+          .put("job-type", "dataproc_job")
           .put("region", TEST_REGION)
           .build();
 
   private static final ImmutableMap<String, String> EXPECTED_FACET_DATAPROC_BATCH =
       ImmutableMap.<String, String>builder()
-          .put("spark.batch.uuid", TEST_RESOURCE_UUID)
-          .put("spark.batch.id", TEST_BATCH_ID)
-          .put("projectId", TEST_PROJECT_ID)
-          .put("job.type", "batch")
+          .put("spark-batch-uuid", TEST_RESOURCE_UUID)
+          .put("spark-batch-id", TEST_BATCH_ID)
+          .put("project-id", TEST_PROJECT_ID)
+          .put("job-type", "batch")
           .put("region", TEST_REGION)
           .build();
 
   private static final ImmutableMap<String, String> EXPECTED_FACET_DATAPROC_SESSION =
       ImmutableMap.<String, String>builder()
-          .put("spark.session.uuid", TEST_RESOURCE_UUID)
-          .put("spark.session.id", TEST_SESSION_ID)
-          .put("projectId", TEST_PROJECT_ID)
-          .put("job.type", "session")
+          .put("spark-session-uuid", TEST_RESOURCE_UUID)
+          .put("spark-session-id", TEST_SESSION_ID)
+          .put("project-id", TEST_PROJECT_ID)
+          .put("job-type", "session")
           .put("region", TEST_REGION)
           .build();
 
@@ -78,8 +78,8 @@ public class GCPLabelUtilsTest {
     Map<String, String> labels = GCPLabelUtils.getSparkLabels(conf);
 
     assertEquals(2, labels.size());
-    assertEquals(TEST_APP_ID, labels.get("appId"));
-    assertEquals(TEST_APP_NAME, labels.get("appName"));
+    assertEquals(TEST_APP_ID, labels.get("app-id"));
+    assertEquals(TEST_APP_NAME, labels.get("app-name"));
   }
 
   @Test
@@ -102,8 +102,8 @@ public class GCPLabelUtilsTest {
     Map<String, String> labels2 = GCPLabelUtils.getSparkLabels(conf2);
 
     assertEquals(labels1.size(), labels2.size());
-    assertEquals(labels1.get("appId"), labels2.get("appId"));
-    assertEquals(labels1.get("appName"), labels2.get("appName"));
+    assertEquals(labels1.get("app-id"), labels2.get("app-id"));
+    assertEquals(labels1.get("app-name"), labels2.get("app-name"));
   }
 
   @Test

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/util/GCPLabelUtilsTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/util/GCPLabelUtilsTest.java
@@ -1,0 +1,192 @@
+package com.google.cloud.spark.bigquery.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.Header;
+
+public class GCPLabelUtilsTest {
+  private ClientAndServer mockServer;
+  private String mockBaseUrl;
+
+  public static final Header METADATA_HEADER = new Header("Metadata-Flavor", "Google");
+  private static final String TEST_APP_NAME = "labels-test";
+  private static final String TEST_APP_ID = "application_12345";
+  private static final String TEST_RESOURCE_UUID = "1q2w3e4r5t6y7u8i";
+  private static final String TEST_CLUSTER_NAME = "test-cluster";
+  private static final String TEST_JOB_ID = "test-job";
+  private static final String TEST_BATCH_ID = "test-batch";
+  private static final String TEST_SESSION_ID = "test-session";
+  private static final String TEST_PROJECT_ID = "test-project";
+  private static final String TEST_REGION = "us-central1";
+
+  private static final Map<String, Object> EXPECTED_FACET_DATAPROC_CLUSTER = new HashMap<>();
+  private static final Map<String, Object> EXPECTED_FACET_DATAPROC_BATCH = new HashMap<>();
+  private static final Map<String, Object> EXPECTED_FACET_DATAPROC_SESSION = new HashMap<>();
+
+  @Before
+  public void setUp() {
+    mockServer = ClientAndServer.startClientAndServer();
+    mockBaseUrl = "http://localhost:" + mockServer.getPort();
+  }
+
+  @After
+  public void tearDown() {
+    mockServer.stop();
+  }
+
+  @Test
+  public void testGetSparkLabelsOnlyAppInfo() {
+    ImmutableMap<String, String> conf =
+        ImmutableMap.of(
+            GCPLabelUtils.SPARK_APP_ID, TEST_APP_ID,
+            GCPLabelUtils.SPARK_APP_NAME, TEST_APP_NAME);
+
+    Map<String, String> labels = GCPLabelUtils.getSparkLabels(conf);
+
+    assertEquals(2, labels.size());
+    assertEquals(TEST_APP_ID, labels.get("appId"));
+    assertEquals(TEST_APP_NAME, labels.get("appName"));
+  }
+
+  @Test
+  public void testGetGCPLabelsClusterMode() {
+    // Setup mock server responses for cluster mode
+    setupMockServerForCluster();
+
+    ImmutableMap<String, String> conf =
+        ImmutableMap.<String, String>builder()
+            .put(GCPLabelUtils.SPARK_MASTER, "yarn")
+            .put(
+                GCPLabelUtils.SPARK_DRIVER_HOST,
+                TEST_CLUSTER_NAME + "-m.us-central1-a.c.hadoop-cloud-dev.google.com.internal")
+            .put(
+                GCPLabelUtils.SPARK_YARN_TAGS,
+                "dataproc_job_" + TEST_JOB_ID + ",dataproc_uuid_" + TEST_RESOURCE_UUID)
+            .put(GCPLabelUtils.SPARK_APP_ID, TEST_APP_ID)
+            .put(GCPLabelUtils.SPARK_APP_NAME, TEST_APP_NAME)
+            .put(GCPLabelUtils.GOOGLE_METADATA_API, mockBaseUrl)
+            .build();
+
+    Map<String, String> labels = GCPLabelUtils.getGCPLabels(conf);
+
+    // Verify all expected labels are present with correct values
+    assertResults(labels, EXPECTED_FACET_DATAPROC_CLUSTER);
+  }
+
+  @Test
+  public void testGetGCPLabelsBatchMode() {
+    // Setup mock server responses for batch mode
+    setupMockServerForBatch();
+
+    ImmutableMap<String, String> conf =
+        ImmutableMap.<String, String>builder()
+            .put(GCPLabelUtils.SPARK_APP_ID, TEST_APP_ID)
+            .put(GCPLabelUtils.SPARK_APP_NAME, TEST_APP_NAME)
+            .put(GCPLabelUtils.GOOGLE_METADATA_API, mockBaseUrl)
+            .build();
+
+    Map<String, String> labels = GCPLabelUtils.getGCPLabels(conf);
+
+    // Verify all expected labels are present with correct values
+    assertResults(labels, EXPECTED_FACET_DATAPROC_BATCH);
+  }
+
+  @Test
+  public void testGetGCPLabelsSessionMode() {
+    // Setup mock server responses for session mode
+    setupMockServerForSession();
+
+    ImmutableMap<String, String> conf =
+        ImmutableMap.<String, String>builder()
+            .put(GCPLabelUtils.SPARK_APP_ID, TEST_APP_ID)
+            .put(GCPLabelUtils.SPARK_APP_NAME, TEST_APP_NAME)
+            .put(GCPLabelUtils.GOOGLE_METADATA_API, mockBaseUrl)
+            .build();
+
+    Map<String, String> labels = GCPLabelUtils.getGCPLabels(conf);
+
+    // Verify all expected labels are present with correct values
+    assertResults(labels, EXPECTED_FACET_DATAPROC_SESSION);
+  }
+
+  private static void assertResults(
+      Map<String, String> labels, Map<String, Object> expectedFacetDataprocCluster) {
+    for (Map.Entry<String, Object> expected : expectedFacetDataprocCluster.entrySet()) {
+      assertEquals(
+          "Missing or incorrect value for key: " + expected.getKey(),
+          expected.getValue().toString(),
+          labels.get(expected.getKey()));
+    }
+  }
+
+  private void setupMockServerForCluster() {
+    setupMockServerBaseSetup();
+    return200ForEndpoint(GCPLabelUtils.CLUSTER_UUID_ENDPOINT, TEST_RESOURCE_UUID);
+  }
+
+  private void setupMockServerForBatch() {
+    setupMockServerBaseSetup();
+    return200ForEndpoint(GCPLabelUtils.BATCH_ID_ENDPOINT, TEST_BATCH_ID);
+    return200ForEndpoint(GCPLabelUtils.BATCH_UUID_ENDPOINT, TEST_RESOURCE_UUID);
+    return404ForEndpoint(GCPLabelUtils.SESSION_ID_ENDPOINT);
+    return404ForEndpoint(GCPLabelUtils.SESSION_UUID_ENDPOINT);
+  }
+
+  private void setupMockServerForSession() {
+    setupMockServerBaseSetup();
+    return200ForEndpoint(GCPLabelUtils.SESSION_ID_ENDPOINT, TEST_SESSION_ID);
+    return200ForEndpoint(GCPLabelUtils.SESSION_UUID_ENDPOINT, TEST_RESOURCE_UUID);
+    return200ForEndpoint(GCPLabelUtils.PROJECT_ID_ENDPOINT, "projects/456/" + TEST_PROJECT_ID);
+    return200ForEndpoint(GCPLabelUtils.DATAPROC_REGION_ENDPOINT, TEST_REGION);
+    return404ForEndpoint(GCPLabelUtils.BATCH_ID_ENDPOINT);
+    return404ForEndpoint(GCPLabelUtils.BATCH_UUID_ENDPOINT);
+  }
+
+  private void setupMockServerBaseSetup() {
+    return200ForEndpoint(GCPLabelUtils.PROJECT_ID_ENDPOINT, "projects/123456/" + TEST_PROJECT_ID);
+    return200ForEndpoint(GCPLabelUtils.DATAPROC_REGION_ENDPOINT, TEST_REGION);
+  }
+
+  private void return200ForEndpoint(String endpoint, String responseBody) {
+    mockServer
+        .when(request().withMethod("GET").withPath(endpoint).withHeader(METADATA_HEADER))
+        .respond(response().withBody(responseBody));
+  }
+
+  private void return404ForEndpoint(String endpoint) {
+    mockServer
+        .when(request().withMethod("GET").withPath(endpoint))
+        .respond(response().withStatusCode(404));
+  }
+
+  static {
+    EXPECTED_FACET_DATAPROC_CLUSTER.put("job.uuid", TEST_RESOURCE_UUID);
+    EXPECTED_FACET_DATAPROC_CLUSTER.put("job.id", TEST_JOB_ID);
+    EXPECTED_FACET_DATAPROC_CLUSTER.put("cluster.uuid", TEST_RESOURCE_UUID);
+    EXPECTED_FACET_DATAPROC_CLUSTER.put("cluster.name", TEST_CLUSTER_NAME);
+    EXPECTED_FACET_DATAPROC_CLUSTER.put("projectId", TEST_PROJECT_ID);
+    EXPECTED_FACET_DATAPROC_CLUSTER.put("job.type", "dataproc_job");
+    EXPECTED_FACET_DATAPROC_CLUSTER.put("region", TEST_REGION);
+
+    EXPECTED_FACET_DATAPROC_BATCH.put("spark.batch.uuid", TEST_RESOURCE_UUID);
+    EXPECTED_FACET_DATAPROC_BATCH.put("spark.batch.id", TEST_BATCH_ID);
+    EXPECTED_FACET_DATAPROC_BATCH.put("projectId", TEST_PROJECT_ID);
+    EXPECTED_FACET_DATAPROC_BATCH.put("job.type", "batch");
+    EXPECTED_FACET_DATAPROC_BATCH.put("region", TEST_REGION);
+
+    EXPECTED_FACET_DATAPROC_SESSION.put("spark.session.uuid", TEST_RESOURCE_UUID);
+    EXPECTED_FACET_DATAPROC_SESSION.put("spark.session.id", TEST_SESSION_ID);
+    EXPECTED_FACET_DATAPROC_SESSION.put("projectId", TEST_PROJECT_ID);
+    EXPECTED_FACET_DATAPROC_SESSION.put("job.type", "session");
+    EXPECTED_FACET_DATAPROC_SESSION.put("region", TEST_REGION);
+  }
+}


### PR DESCRIPTION
Adding labels containing information about Spark and GCP environment to BigQuery job will help link it's lineage information with Dataplex and make navigation easier for users. The code adds lables to BQ jobs containing information similar to what is collected by OpenLineage.