### PR TITLE
Update openlineage-spark to 1.37.0 and enable Spark40OpenLineageIntegrationTest

### DIFF
--- a/spark-bigquery-dsv2/spark-4.0-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark40OpenLineageIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-4.0-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark40OpenLineageIntegrationTest.java
@@ -15,7 +15,4 @@
  */
 package com.google.cloud.spark.bigquery.integration;
 
-import org.junit.Ignore;
-
-@Ignore("OL DatabricksEventFilter throws exception in spark 4")
 public class Spark40OpenLineageIntegrationTest extends OpenLineageIntegrationTestBase {}

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -56,7 +56,7 @@
         <guava.version>33.4.8-jre</guava.version>
         <jackson.version>2.19.2</jackson.version>
         <netty.version>4.1.123.Final</netty.version>
-        <openlineage-spark.version>1.36.0</openlineage-spark.version>
+        <openlineage-spark.version>1.37.0</openlineage-spark.version>
         <paranamer.version>2.8.3</paranamer.version>
         <!-- Don't upgrade protobuf until bigquerystorage is compatible with 4.x version of proto.
         Ref : https://github.com/protocolbuffers/protobuf/issues/16452-->


### PR DESCRIPTION
As openlineage-spark update comes with a handful of fixes related to Spark 4 support