### PR TITLE
Fix the logging for pushdown filters

### DIFF
--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreator.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreator.java
@@ -16,7 +16,7 @@
 package com.google.cloud.bigquery.connector.common;
 
 import static com.google.cloud.bigquery.connector.common.BigQueryErrorCode.UNSUPPORTED;
-import static com.google.cloud.bigquery.connector.common.BigQueryUtil.friendlyTableName;
+import com.google.cloud.bigquery.connector.common.BigQueryUtil;
 import static java.lang.String.format;
 
 import com.google.cloud.bigquery.TableDefinition;
@@ -101,7 +101,7 @@ public class ReadSessionCreator {
             + "|selectedFields=[{}],"
             + "|filter=[{}]"
             + "|snapshotTimeMillis[{}]",
-        friendlyTableName(table),
+        BigQueryUtil.friendlyTableName(table),
         String.join(",", selectedFields),
         filter.orElse("None"),
         config.getSnapshotTimeMillis().isPresent()

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreator.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreator.java
@@ -16,7 +16,6 @@
 package com.google.cloud.bigquery.connector.common;
 
 import static com.google.cloud.bigquery.connector.common.BigQueryErrorCode.UNSUPPORTED;
-import com.google.cloud.bigquery.connector.common.BigQueryUtil;
 import static java.lang.String.format;
 
 import com.google.cloud.bigquery.TableDefinition;

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreator.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/ReadSessionCreator.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigquery.connector.common;
 
 import static com.google.cloud.bigquery.connector.common.BigQueryErrorCode.UNSUPPORTED;
+import static com.google.cloud.bigquery.connector.common.BigQueryUtil.friendlyTableName;
 import static java.lang.String.format;
 
 import com.google.cloud.bigquery.TableDefinition;
@@ -100,7 +101,7 @@ public class ReadSessionCreator {
             + "|selectedFields=[{}],"
             + "|filter=[{}]"
             + "|snapshotTimeMillis[{}]",
-        actualTable.getFriendlyName(),
+        friendlyTableName(table),
         String.join(",", selectedFields),
         filter.orElse("None"),
         config.getSnapshotTimeMillis().isPresent()

--- a/spark-bigquery-dsv2/spark-3.1-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark31BigQueryScanBuilder.java
+++ b/spark-bigquery-dsv2/spark-3.1-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark31BigQueryScanBuilder.java
@@ -96,8 +96,8 @@ public class Spark31BigQueryScanBuilder
   @Override
   public String description() {
     return String.format(
-        "Reading table [%s], Read session Id : %s ",
-        ctx.getFullTableName(), ctx.getReadSessionId());
+        "Reading table [%s], filters [%s], Read session Id : %s ",
+        ctx.getFullTableName(), getPushdownFilters().orElse(""), ctx.getReadSessionId());
   }
 
   @Override


### PR DESCRIPTION
Fix the call to get friendly name. Since BQ does not create a friendly name for a table when we use a builder to create a table, we need to use the big query util to get the friendly table name.