### PR TITLE
fix(auth): Handle ClassCastException in IdentityTokenSupplier

### DIFF
--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/IdentityTokenSupplier.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/IdentityTokenSupplier.java
@@ -29,7 +29,7 @@ public class IdentityTokenSupplier implements Serializable {
               .build();
 
       return Optional.ofNullable(idTokenCredentials.refreshAccessToken().getTokenValue());
-    } catch (IOException | IllegalArgumentException ex) {
+    } catch (IOException | RuntimeException ex) {
       log.info("Unable to obtain identity token");
       log.debug("Exception while fetching identity token", ex);
     }


### PR DESCRIPTION
### Description

This PR addresses a `ClassCastException` that occurs when using the Spark BigQuery connector with credential types that do not implement the `IdTokenProvider` interface, such as `AwsCredentials` used for AWS federated identity. It's fixing issue #1417.

To resolve this, the `try-catch` block in `fetchIdentityToken` has been expanded to catch `RuntimeException`. Since `ClassCastException` is a subclass of `RuntimeException`, this change ensures that the exception is caught correctly.

When the cast fails, the exception is logged, and the method returns an `Optional.empty()`, allowing the Spark job to proceed without the identity token. This makes the connector more robust and compatible with a wider range of authentication configurations.