### PR TITLE
docs: Document schema preservation behavior on SaveMode.Overwrite (#1456)

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -375,7 +375,7 @@ df.writeStream \
 
 #### Schema Behavior on Overwrite
 
-When using `SaveMode.Overwrite` (`.mode("overwrite")`), the connector **preserves the existing table's schema**. 
+When using `SaveMode.Overwrite` (`.mode("overwrite")`), the connector **preserves the existing table's schema**.
 The data is truncated, but column types, descriptions, and policy tags are retained.
 
 ```
@@ -386,7 +386,7 @@ df.write \
   .save("dataset.table")
 ```
 
-**Important:** If your DataFrame has a different schema than the existing table (e.g., changing a column from 
+**Important:** If your DataFrame has a different schema than the existing table (e.g., changing a column from
 `INTEGER` to `DOUBLE`), the write will fail with a type mismatch error. To change the schema, either:
 - Drop the table before overwriting
 - Use BigQuery DDL to alter the table schema first


### PR DESCRIPTION
## Description

This PR addresses the issue [#1456](https://github.com/GoogleCloudDataproc/spark-bigquery-connector/issues/1456)

Documents the schema preservation behaviour when using `SaveMode.Overwrite`, which was updated somewhere between 0.22.2 and 0.41.0 versions.

## Changes

- Added "Schema Behaviour on Overwrite" section to README-template.md
- Explains that the existing table schema is preserved during overwrites
- Documents workarounds for intentional schema changes

## Why

Users upgrading from versions prior to 0.41.0 encounter unexpected failures when overwriting tables with different column types. This documentation helps users understand the expected behaviour and provides workarounds.