### PR TITLE
Don't reference this in anonymous WriterCommitMessageContext object

### DIFF
--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/DataSourceWriterContextPartitionHandler.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/DataSourceWriterContextPartitionHandler.java
@@ -71,17 +71,18 @@ public class DataSourceWriterContextPartitionHandler
             epoch,
             e);
         dataWriterContext.abort();
-        return ImmutableList.<WriterCommitMessageContext>of(writerCommitMessageWithError(e)).iterator();
+        return ImmutableList.<WriterCommitMessageContext>of(writerCommitMessageWithError(e))
+            .iterator();
       }
     }
   }
 
   private static WriterCommitMessageContext writerCommitMessageWithError(Exception e) {
     return new WriterCommitMessageContext() {
-        @Override
-        public Optional<Exception> getError() {
-          return Optional.of(e);
-        }
-      };
-    }
+      @Override
+      public Optional<Exception> getError() {
+        return Optional.of(e);
+      }
+    };
+  }
 }

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/DataSourceWriterContextPartitionHandler.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/DataSourceWriterContextPartitionHandler.java
@@ -71,15 +71,17 @@ public class DataSourceWriterContextPartitionHandler
             epoch,
             e);
         dataWriterContext.abort();
-        WriterCommitMessageContext writerCommitMessage =
-            new WriterCommitMessageContext() {
-              @Override
-              public Optional<Exception> getError() {
-                return Optional.of(e);
-              }
-            };
-        return ImmutableList.<WriterCommitMessageContext>of(writerCommitMessage).iterator();
+        return ImmutableList.<WriterCommitMessageContext>of(writerCommitMessageWithError(e)).iterator();
       }
     }
   }
+
+  private static WriterCommitMessageContext writerCommitMessageWithError(Exception e) {
+    return new WriterCommitMessageContext() {
+        @Override
+        public Optional<Exception> getError() {
+          return Optional.of(e);
+        }
+      };
+    }
 }


### PR DESCRIPTION
Bigquery connector wraps exceptions adding a reference to `this` in the anonymous class returned with an error. `this` references an `com.google.cloud.spark.bigquery.repackaged.com.google.common.collect.ImmutableMap` through a chain of refs. Kryo fails to deserialize this class and this makes every exception critical and not retriable:   
```
org.apache.spark.scheduler.TaskResultGetter - Exception while getting task result
com.esotericsoftware.kryo.KryoException: java.lang.UnsupportedOperationException
Serialization trace:
headers (com.google.cloud.spark.bigquery.repackaged.com.google.api.gax.rpc.AutoValue_FixedHeaderProvider)
headerProvider (com.google.cloud.bigquery.connector.common.BigQueryClientFactory)
writeClientFactory (com.google.cloud.spark.bigquery.write.context.BigQueryDirectDataWriterContextFactory)
dataWriterContextFactory (com.google.cloud.spark.bigquery.write.DataSourceWriterContextPartitionHandler)
this$0 (com.google.cloud.spark.bigquery.write.DataSourceWriterContextPartitionHandler$1)
```

As `com.google.common.collect.*` are added as repackaged, they are not covered by `de.javakaffee.kryoserializers.guava.ImmutableMapSerializer`.

This PR moves object creation into static method so that it no longer references `this`.

I have a follow-up question, is it necessary to repackage dependencies? This can lead to other similar issues.