### PR TITLE
Doc Improvement: refresh CONTRIBUTING + add Spark 4.x to README compatibility matrices

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * Issue #1476: Fixed BigQuery MERGE statement ambiguity on overwrite when table columns are named `target` or `source`.
 * PR #1475: Don't reference `this` in anonymous WriterCommitMessageContext object.
+* PR #1473: Added `enableArrowTimestampRebase` option (default `true`) to control the Julian-to-Gregorian rebase in the Arrow reader path. Set to `false` to avoid the 2-day shift on pre-Gregorian timestamps. Fixes #1389.
 
 ## 0.44.1 - 2026-03-25
 * BigQuery API has been upgraded to version 2.60.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Next
 
 * Issue #1476: Fixed BigQuery MERGE statement ambiguity on overwrite when table columns are named `target` or `source`.
+* PR #1475: Don't reference `this` in anonymous WriterCommitMessageContext object.
 
 ## 0.44.1 - 2026-03-25
 * BigQuery API has been upgraded to version 2.60.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,9 @@
 * PR #1376: `materializationDataset` is now optional to read from views or queries.
 * PR #1380: Fixed ImpersonatedCredentials serialization
 * PR #1381: Added the option to set custom credentials scopes
+* PR #1400: Fixed issue #1379 by preventing indirect `SaveMode.Append` writes from updating table
+  metadata and requiring the `bigquery.tables.setCategory` permission; also fixed a redundant load
+  during dynamic partition overwrite.
 * PR #1411: Added Support for [SparkSession#executeCommand](https://archive.apache.org/dist/spark/docs/3.0.0/api/java/org/apache/spark/sql/SparkSession.html#executeCommand-java.lang.String-java.lang.String-scala.collection.immutable.Map-)
 * Issue #1421: Fix ArrowInputPartitionContext serialization issue. Thanks @mrjoe7 !
 * BigQuery API has been upgraded to version 2.54.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,10 +102,10 @@ Plus, defined in `spark-bigquery-parent/pom.xml`:
 * `integration` — enables `*IntegrationTest` classes via Failsafe.
 * `acceptance` — enables `*AcceptanceTest` classes via Failsafe.
 
-Example: to compile **just** the Scala 2.12 connector run
+Example: To compile **just** the Scala 2.12 connector, run
 `./mvnw install -Pdsv1_2.12`.
 
-**Important:** if no profile is selected, only the always-built common
+**Important:** If no profile is selected, only the always-built common
 artifacts are produced.
 
 ### JDK requirements

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,12 +33,6 @@ The connector is built using the Maven wrapper (`./mvnw`). The repository
 publishes several connector jars sharing a common core, organized along three
 axes: API generation (DSv1 / DSv2), Spark version, and Scala version.
 
-> **Source of truth for the test commands CI runs:**
-> [`cloudbuild/presubmit.sh`](cloudbuild/presubmit.sh) (presubmit: init, unit
-> tests, integration tests sharded per profile) and
-> [`cloudbuild/nightly.sh`](cloudbuild/nightly.sh) (nightly: above plus
-> acceptance tests). If the examples below ever drift, those scripts win.
-
 ### Modules
 
 Always built (no profile required):
@@ -116,8 +110,16 @@ artifacts are produced.
 
 ### JDK requirements
 
-The build targets Java 8 bytecode (`maven.compiler.release=8`), but the test
-matrix runs on **two JDKs**:
+The connector itself is compiled to Java 8 bytecode
+(`maven.compiler.release=8`). At runtime, the JDK you need depends on which
+Spark version your connector targets:
+
+* Connectors for Spark 3.1 – 3.5: Java 8 supported (Java 11 / 17 also work
+  where the underlying Spark distribution supports them).
+* Connectors for Spark 4.0 / 4.1: **Java 17 required**, matching Spark 4.x's
+  own JDK requirement.
+
+The CI test matrix uses both JDKs:
 
 * **Java 17** — initial install, all unit tests, and integration tests for
   Spark 3.3, 3.4, 3.5, 4.0, and 4.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,84 +29,144 @@ Guidelines](https://opensource.google.com/conduct/).
 
 ## Building and Testing the Connector
 
-The connector is built using the Maven wrapper. The project contains several
-connectors, sharing some of the code among them. The connectors are:
-* spark-bigquery_2.11 - a Scala 2.11 based connector, targeting Spark 2.3 and
-  2.4 using Scala 2.11.
-* spark-bigquery_2.12 - a Scala 2.12 based connector, targeting Spark 2.4 and
-  3.x using Scala 2.12.
-* spark-2.4-bigquery - a Java only connector, targeting Spark 2.4 (of all
-  Scala versions), using the new DataSource APIs.
-* spark-3.1-bigquery - a Java only connector, targeting Spark 3.1 (of all
-  Scala versions), using the new DataSource APIs. Still under development.
+The connector is built using the Maven wrapper (`./mvnw`). The repository
+publishes several connector jars sharing a common core, organized along three
+axes: API generation (DSv1 / DSv2), Spark version, and Scala version.
 
-The project's artifacts are:
+> **Source of truth for the test commands CI runs:**
+> [`cloudbuild/presubmit.sh`](cloudbuild/presubmit.sh) (presubmit: init, unit
+> tests, integration tests sharded per profile) and
+> [`cloudbuild/nightly.sh`](cloudbuild/nightly.sh) (nightly: above plus
+> acceptance tests). If the examples below ever drift, those scripts win.
 
-* `spark-bigquery-parent` - The parent POM for all artifacts. Common settings
-  and artifact version should be defined here.
-* `bigquery-connector-common` - Utility classes for working with the BigQuery
-  APIs. This artifact has no dependency on Spark. This artifact can potentially
-  be used by non-spark connectors
-* `spark-bigquery-connector-common`- Common utilites and logic  shared among
-  all connectors (Scala and Java alike). Whenever possible, new code should be
-  in this artifact
-* `spark-bigquery-dsv1/spark-bigquery-dsv1-parent` - Common settings for the
-  Scala based DataSource V1 implementation.
-* `spark-bigquery-dsv1/spark-bigquery-dsv1-spark3-support` - As some of the APIs
-  used by the connector have changed between Spark 2.x and 3.x, they are wrapped
-  in a neutral interface with wrappers for the two implementations. Unlike the
-  other dsv1 artifacts, this project depends on Spark 3 for this reason.
-* `spark-bigquery-dsv1/spark-bigquery_2.11` and
-  `spark-bigquery-dsv1/spark-bigquery_2.12` - The implementation of the Scala
-  based connectors. Both connectors share the same code via a symbolic link, so
-  a change in one of them will automatically affect the other.
-* `spark-bigquery-dsv1/spark-bigquery-with-dependencies-parent` - Common
-  settings for the shaded artifacts.
-* `spark-bigquery-dsv1/spark-bigquery-with-dependencies_2.11` and
-  `spark-bigquery-dsv1/spark-bigquery-with-dependencies_2.12` - The shaded
-  distributable of the connector, containing all the dependencies.
-* `spark-bigquery-dsv2/spark-bigquery-dsv2-parent` - Common settings for the
-  Java only DataSource V2 implementations.
-* `spark-bigquery-dsv2/spark-2.4-bigquery` - A Java only DataSource V2
-  connector implementing the Spark 2.4 APIs.
-* `spark-bigquery-dsv2/spark-3.1-bigquery` - A Java only DataSource V2
-  connector implementing the Spark 3.1 APIs. Under development.
-* `spark-bigquery-python-lib` - The python support library, adding BigQuery
-  types not supported by Spark.
+### Modules
 
-As building and running all the connectors is a lengthy process, the project is
-split into several [profiles](https://maven.apache.org/guides/introduction/introduction-to-profiles.html),
-each building only a subset of the project's artifacts. The profiles are:
+Always built (no profile required):
 
-* `dsv1` - Running both Scala/DSv1 connectors.
-* `dsv1_2.11` - Running just the Scala 2.11 connector.
-* `dsv1_2.12` - Running just the Scala 2.12 connector.
-* `dsv2` - Running both Java/DSv2 connectors.
-* `dsv2_2.4` - Running just the Java Spark 2.4 connector.
-* `dsv2_3.1` - Running just the Java Spark 3.1 connector.
-* `all` - Running all the connectors.
+* `spark-bigquery-parent` — parent POM with shared versions, plugin config, and
+  the `integration` / `acceptance` profile definitions.
+* `bigquery-connector-common` — pure BigQuery API utilities, no Spark
+  dependency. Reusable by non-Spark callers.
+* `spark-bigquery-connector-common` — Spark-aware logic shared between DSv1 and
+  DSv2. Whenever possible, **new shared code should land here.**
+* `spark-bigquery-tests` — shared integration-test fixtures.
+* `spark-bigquery-scala-212-support` — Scala 2.12 compatibility shims.
+* `spark-bigquery-python-lib` — Python helpers for BigQuery types not native
+  to Spark.
 
-Example: In order to compile **just** the Scala 2.12 connector run
+DSv1 (Scala) connectors under `spark-bigquery-dsv1/`:
+
+* `spark-bigquery-dsv1-parent`, `spark-bigquery-dsv1-spark2-support`,
+  `spark-bigquery-dsv1-spark3-support` — sub-parent and Spark-version API
+  shims.
+* `spark-bigquery_2.12`, `spark-bigquery_2.13` — Scala 2.12 and 2.13
+  connectors. The two modules keep **near-duplicate** `src/main` and
+  `src/test` trees (only the per-Scala-version provider differs). Apply
+  non-Scala-specific changes to both. Only the shared build configuration
+  under `src/build` is symlinked, pointing each module at
+  `spark-bigquery-dsv1/src/build/`.
+* `spark-bigquery-with-dependencies_2.12`,
+  `spark-bigquery-with-dependencies_2.13` — the shaded distributable jars
+  bundling all dependencies.
+
+DSv2 (Java) connectors under `spark-bigquery-dsv2/`:
+
+* `spark-bigquery-dsv2-parent`, `spark-bigquery-dsv2-common`,
+  `spark-bigquery-metrics` — shared infrastructure.
+* `spark-3.1-bigquery`, `spark-3.2-bigquery`, `spark-3.3-bigquery`,
+  `spark-3.4-bigquery`, `spark-3.5-bigquery`, `spark-4.0-bigquery`,
+  `spark-4.1-bigquery` — the per-Spark-version connector jars, each backed by
+  a `*-bigquery-lib` module reused by the next-version connector.
+
+Pushdown variants under `spark-bigquery-pushdown/` add query pushdown support
+per Spark+Scala combination. They are built separately and are **not** driven
+by the root `dsv1*` / `dsv2*` profiles.
+
+Other:
+
+* `coverage` — Jacoco aggregator, activated by `-Pcoverage`.
+* `examples`, `scripts` — sample code and helper scripts (not Maven modules).
+
+A few legacy modules remain on disk (`spark-bigquery_2.11`,
+`spark-bigquery-with-dependencies_2.11`, `spark-2.4-bigquery`) but are no
+longer in the CI matrix.
+
+### Profiles
+
+Because building every connector is lengthy, the project uses
+[Maven profiles](https://maven.apache.org/guides/introduction/introduction-to-profiles.html)
+to scope the build. The profiles defined in the root POM are:
+
+* `dsv1_2.12`, `dsv1_2.13` — one Scala variant of the DSv1 connector.
+* `dsv2_3.1`, `dsv2_3.2`, `dsv2_3.3`, `dsv2_3.4`, `dsv2_3.5`, `dsv2_4.0`,
+  `dsv2_4.1` — one Spark version of the DSv2 connector.
+* `dsv1`, `dsv2`, `all` — aggregates for the whole DSv1 / DSv2 / both worlds.
+* `coverage` — adds the `coverage/` aggregator for Jacoco reports.
+
+Plus, defined in `spark-bigquery-parent/pom.xml`:
+
+* `integration` — enables `*IntegrationTest` classes via Failsafe.
+* `acceptance` — enables `*AcceptanceTest` classes via Failsafe.
+
+Example: to compile **just** the Scala 2.12 connector run
 `./mvnw install -Pdsv1_2.12`.
 
-**Note**: Need java 1.8 and make sure **/usr/libexec/java_home** set to java 1.8 before building any module.
+**Important:** if no profile is selected, only the always-built common
+artifacts are produced.
 
-**Important**: If no profile is selected, then only the common artifacts are run.
+### JDK requirements
 
-The integration and acceptance tests are disabled by default. In order to run it please add the
-following profiles to the run:
-* Integration tests - `./mvnw failsafe:integration-test -Pdsv1_2.11,integration`
-* Acceptance tests - `./mvnw verify -Pdsv2_2.4,acceptance`
+The build targets Java 8 bytecode (`maven.compiler.release=8`), but the test
+matrix runs on **two JDKs**:
 
-In order to run the integration tests make sure that your GCP user has the proper accounts for creating and deleting
-datasets and tables in your test project in BigQuery. It will also need the permissions to upload files to the test
-bucket in GCS as well as delete them.
+* **Java 17** — initial install, all unit tests, and integration tests for
+  Spark 3.3, 3.4, 3.5, 4.0, and 4.1.
+* **Java 8** — integration tests for `dsv1_2.12`, `dsv1_2.13`, `dsv2_3.1`,
+  and `dsv2_3.2`.
 
-Setting the following environment variables is required to run the integration tests:
-* `GOOGLE_APPLICATION_CREDENTIALS` - the full path to a credentials JSON, either a service account or the result of a
-  `gcloud auth login` run
-* `GOOGLE_CLOUD_PROJECT` - The Google cloud platform project used to test the connector
-* `TEMPORARY_GCS_BUCKET` - The GCS bucked used to test writing to BigQuery during the integration tests
-* `ACCEPTANCE_TEST_BUCKET` - The GCS bucked used to test writing to BigQuery during the acceptance tests
-* `SERVERLESS_NETWORK_URI` - The network used by the serverless batches during the acceptance tests
-* `BIGLAKE_CONNECTION_ID` - The connection ID to create a BigLake table using a Cloud Resource connection
+CI generates `toolchains.xml` automatically via
+`./mvnw toolchains:generate-jdk-toolchains-xml`. Locally, install both JDKs
+and either generate the toolchains file the same way or set `JAVA_HOME` per
+command. See `cloudbuild/presubmit.sh` for the exact mapping of stage to JDK.
+
+### Running tests
+
+Integration and acceptance tests are disabled by default. To run them locally:
+
+```bash
+# Unit tests for one connector flavor
+./mvnw test -Pcoverage,dsv2_3.5
+
+# Integration tests for one connector flavor
+./mvnw failsafe:integration-test failsafe:verify -Pintegration,dsv2_3.5
+
+# Acceptance tests for one connector flavor
+./mvnw failsafe:integration-test failsafe:verify -Pacceptance,dsv2_3.5
+```
+
+To reproduce the full CI presubmit, follow the sequence in
+`cloudbuild/presubmit.sh`. (DSv1 + DSv2 + all integration profiles, with the
+correct JDK per stage.)
+
+### GCP setup for integration / acceptance tests
+
+The test-runner GCP user needs permissions to create and delete BigQuery
+datasets and tables in the test project, and to read, write, and delete
+objects in the test buckets in GCS.
+
+The following environment variables are required to run integration tests:
+
+* `GOOGLE_APPLICATION_CREDENTIALS` — full path to a credentials JSON, either a
+  service account or the result of a `gcloud auth login` run.
+* `GOOGLE_CLOUD_PROJECT` — Google Cloud project used to test the connector.
+* `TEMPORARY_GCS_BUCKET` — GCS bucket for staging writes during integration
+  tests.
+* `BIGLAKE_CONNECTION_ID` — Cloud Resource connection ID used by BigLake table
+  tests.
+* `BIGQUERY_KMS_KEY_NAME` — KMS key used by encrypted-table tests.
+
+Acceptance tests additionally require:
+
+* `ACCEPTANCE_TEST_BUCKET` — GCS bucket reserved for acceptance scenarios.
+* `SERVERLESS_NETWORK_URI` — VPC network used by the serverless Dataproc
+  batches.

--- a/README-template.md
+++ b/README-template.md
@@ -82,7 +82,7 @@ The final two connectors are Scala based connectors, please use the jar relevant
 below.
 
 ### Connector to Spark Compatibility Matrix
-| Connector \ Spark                     | 2.3     | 2.4     | 3.0     | 3.1     | 3.2     | 3.3     |3.4      | 3.5     | 4.0     | 4.1     |
+| Connector \ Spark                     | 2.3     | 2.4     | 3.0     | 3.1     | 3.2     | 3.3     | 3.4     | 3.5     | 4.0     | 4.1     |
 |---------------------------------------|---------|---------|---------|---------|---------|---------|---------|---------|---------|---------|
 | spark-4.1-bigquery                    |         |         |         |         |         |         |         |         |         | &check; |
 | spark-4.0-bigquery                    |         |         |         |         |         |         |         |         | &check; |         |

--- a/README-template.md
+++ b/README-template.md
@@ -82,30 +82,39 @@ The final two connectors are Scala based connectors, please use the jar relevant
 below.
 
 ### Connector to Spark Compatibility Matrix
-| Connector \ Spark                     | 2.3     | 2.4     | 3.0     | 3.1     | 3.2     | 3.3     |3.4      | 3.5     |
-|---------------------------------------|---------|---------|---------|---------|---------|---------|---------|---------|
-| spark-3.5-bigquery                    |         |         |         |         |         |         |         | &check; |
-| spark-3.4-bigquery                    |         |         |         |         |         |         | &check; | &check; |
-| spark-3.3-bigquery                    |         |         |         |         |         | &check; | &check; | &check; |
-| spark-3.2-bigquery                    |         |         |         |         | &check; | &check; | &check; | &check; |
-| spark-3.1-bigquery                    |         |         |         | &check; | &check; | &check; | &check; | &check; |
-| spark-2.4-bigquery                    |         | &check; |         |         |         |         |         |         |
-| spark-bigquery-with-dependencies_2.13 |         |         |         |         | &check; | &check; | &check; | &check; |
-| spark-bigquery-with-dependencies_2.12 |         | &check; | &check; | &check; | &check; | &check; | &check; | &check; |
-| spark-bigquery-with-dependencies_2.11 | &check; | &check; |         |         |         |         |         |         |
+| Connector \ Spark                     | 2.3     | 2.4     | 3.0     | 3.1     | 3.2     | 3.3     |3.4      | 3.5     | 4.0     | 4.1     |
+|---------------------------------------|---------|---------|---------|---------|---------|---------|---------|---------|---------|---------|
+| spark-4.1-bigquery                    |         |         |         |         |         |         |         |         |         | &check; |
+| spark-4.0-bigquery                    |         |         |         |         |         |         |         |         | &check; |         |
+| spark-3.5-bigquery                    |         |         |         |         |         |         |         | &check; |         |         |
+| spark-3.4-bigquery                    |         |         |         |         |         |         | &check; | &check; |         |         |
+| spark-3.3-bigquery                    |         |         |         |         |         | &check; | &check; | &check; |         |         |
+| spark-3.2-bigquery                    |         |         |         |         | &check; | &check; | &check; | &check; |         |         |
+| spark-3.1-bigquery                    |         |         |         | &check; | &check; | &check; | &check; | &check; |         |         |
+| spark-2.4-bigquery                    |         | &check; |         |         |         |         |         |         |         |         |
+| spark-bigquery-with-dependencies_2.13 |         |         |         |         | &check; | &check; | &check; | &check; |         |         |
+| spark-bigquery-with-dependencies_2.12 |         | &check; | &check; | &check; | &check; | &check; | &check; | &check; |         |         |
+| spark-bigquery-with-dependencies_2.11 | &check; | &check; |         |         |         |         |         |         |         |         |
 
 ### Connector to Dataproc Image Compatibility Matrix
-| Connector \ Dataproc Image            | 1.3     | 1.4     | 1.5     | 2.0     | 2.1     | 2.2     | Serverless<br>Image 1.0 | Serverless<br>Image 2.0 | Serverless<br>Image 2.1 | Serverless<br>Image 2.2 |
-|---------------------------------------|---------|---------|---------|---------|---------|---------|-------------------------|-------------------------|-------------------------|-------------------------|
-| spark-3.5-bigquery                    |         |         |         |         |         | &check; |                         |                         |                         | &check;                 |
-| spark-3.4-bigquery                    |         |         |         |         |         | &check; |                         |                         | &check;                 | &check;                 |
-| spark-3.3-bigquery                    |         |         |         |         | &check; | &check; | &check;                 | &check;                 | &check;                 | &check;                 |
-| spark-3.2-bigquery                    |         |         |         |         | &check; | &check; | &check;                 | &check;                 | &check;                 | &check;                 |
-| spark-3.1-bigquery                    |         |         |         | &check; | &check; | &check; | &check;                 | &check;                 | &check;                 | &check;                 |
-| spark-2.4-bigquery                    |         | &check; | &check; |         |         |         |                         |                         |                         |                         |
-| spark-bigquery-with-dependencies_2.13 |         |         |         |         |         |         |                         | &check;                 | &check;                 | &check;                 |
-| spark-bigquery-with-dependencies_2.12 |         |         | &check; | &check; | &check; | &check; | &check;                 |                         |                         |                         |
-| spark-bigquery-with-dependencies_2.11 | &check; | &check; |         |         |         |         |                         |                         |                         |                         |
+| Connector \ Dataproc Image            | 1.3     | 1.4     | 1.5     | 2.0     | 2.1     | 2.2     | 3.0     | Serverless<br>Image 1.0 | Serverless<br>Image 2.0 | Serverless<br>Image 2.1 | Serverless<br>Image 2.2 | Serverless<br>Image 3.0 |
+|---------------------------------------|---------|---------|---------|---------|---------|---------|---------|-------------------------|-------------------------|-------------------------|-------------------------|-------------------------|
+| spark-4.1-bigquery                    |         |         |         |         |         |         |         |                         |                         |                         |                         |                         |
+| spark-4.0-bigquery                    |         |         |         |         |         |         | &check; |                         |                         |                         |                         | &check;                 |
+| spark-3.5-bigquery                    |         |         |         |         |         | &check; |         |                         |                         |                         | &check;                 |                         |
+| spark-3.4-bigquery                    |         |         |         |         |         | &check; |         |                         |                         | &check;                 | &check;                 |                         |
+| spark-3.3-bigquery                    |         |         |         |         | &check; | &check; |         | &check;                 | &check;                 | &check;                 | &check;                 |                         |
+| spark-3.2-bigquery                    |         |         |         |         | &check; | &check; |         | &check;                 | &check;                 | &check;                 | &check;                 |                         |
+| spark-3.1-bigquery                    |         |         |         | &check; | &check; | &check; |         | &check;                 | &check;                 | &check;                 | &check;                 |                         |
+| spark-2.4-bigquery                    |         | &check; | &check; |         |         |         |         |                         |                         |                         |                         |                         |
+| spark-bigquery-with-dependencies_2.13 |         |         |         |         |         |         |         |                         | &check;                 | &check;                 | &check;                 |                         |
+| spark-bigquery-with-dependencies_2.12 |         |         | &check; | &check; | &check; | &check; |         | &check;                 |                         |                         |                         |                         |
+| spark-bigquery-with-dependencies_2.11 | &check; | &check; |         |         |         |         |         |                         |                         |                         |                         |                         |
+
+Dataproc Image 3.0 (Spark 4.0) and Serverless Image 3.0 (Spark 4.0) are
+currently in preview; see the
+[Dataproc release notes](https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-version-clusters)
+for the latest image-version status.
 
 ### Maven / Ivy Package Usage
 The connector is also available from the

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The final two connectors are Scala based connectors, please use the jar relevant
 below.
 
 ### Connector to Spark Compatibility Matrix
-| Connector \ Spark                     | 2.3     | 2.4     | 3.0     | 3.1     | 3.2     | 3.3     |3.4      | 3.5     | 4.0     | 4.1     |
+| Connector \ Spark                     | 2.3     | 2.4     | 3.0     | 3.1     | 3.2     | 3.3     | 3.4     | 3.5     | 4.0     | 4.1     |
 |---------------------------------------|---------|---------|---------|---------|---------|---------|---------|---------|---------|---------|
 | spark-4.1-bigquery                    |         |         |         |         |         |         |         |         |         | &check; |
 | spark-4.0-bigquery                    |         |         |         |         |         |         |         |         | &check; |         |

--- a/README.md
+++ b/README.md
@@ -76,30 +76,39 @@ The final two connectors are Scala based connectors, please use the jar relevant
 below.
 
 ### Connector to Spark Compatibility Matrix
-| Connector \ Spark                     | 2.3     | 2.4     | 3.0     | 3.1     | 3.2     | 3.3     |3.4      | 3.5     |
-|---------------------------------------|---------|---------|---------|---------|---------|---------|---------|---------|
-| spark-3.5-bigquery                    |         |         |         |         |         |         |         | &check; |
-| spark-3.4-bigquery                    |         |         |         |         |         |         | &check; | &check; |
-| spark-3.3-bigquery                    |         |         |         |         |         | &check; | &check; | &check; |
-| spark-3.2-bigquery                    |         |         |         |         | &check; | &check; | &check; | &check; |
-| spark-3.1-bigquery                    |         |         |         | &check; | &check; | &check; | &check; | &check; |
-| spark-2.4-bigquery                    |         | &check; |         |         |         |         |         |         |
-| spark-bigquery-with-dependencies_2.13 |         |         |         |         | &check; | &check; | &check; | &check; |
-| spark-bigquery-with-dependencies_2.12 |         | &check; | &check; | &check; | &check; | &check; | &check; | &check; |
-| spark-bigquery-with-dependencies_2.11 | &check; | &check; |         |         |         |         |         |         |
+| Connector \ Spark                     | 2.3     | 2.4     | 3.0     | 3.1     | 3.2     | 3.3     |3.4      | 3.5     | 4.0     | 4.1     |
+|---------------------------------------|---------|---------|---------|---------|---------|---------|---------|---------|---------|---------|
+| spark-4.1-bigquery                    |         |         |         |         |         |         |         |         |         | &check; |
+| spark-4.0-bigquery                    |         |         |         |         |         |         |         |         | &check; |         |
+| spark-3.5-bigquery                    |         |         |         |         |         |         |         | &check; |         |         |
+| spark-3.4-bigquery                    |         |         |         |         |         |         | &check; | &check; |         |         |
+| spark-3.3-bigquery                    |         |         |         |         |         | &check; | &check; | &check; |         |         |
+| spark-3.2-bigquery                    |         |         |         |         | &check; | &check; | &check; | &check; |         |         |
+| spark-3.1-bigquery                    |         |         |         | &check; | &check; | &check; | &check; | &check; |         |         |
+| spark-2.4-bigquery                    |         | &check; |         |         |         |         |         |         |         |         |
+| spark-bigquery-with-dependencies_2.13 |         |         |         |         | &check; | &check; | &check; | &check; |         |         |
+| spark-bigquery-with-dependencies_2.12 |         | &check; | &check; | &check; | &check; | &check; | &check; | &check; |         |         |
+| spark-bigquery-with-dependencies_2.11 | &check; | &check; |         |         |         |         |         |         |         |         |
 
 ### Connector to Dataproc Image Compatibility Matrix
-| Connector \ Dataproc Image            | 1.3     | 1.4     | 1.5     | 2.0     | 2.1     | 2.2     | Serverless<br>Image 1.0 | Serverless<br>Image 2.0 | Serverless<br>Image 2.1 | Serverless<br>Image 2.2 |
-|---------------------------------------|---------|---------|---------|---------|---------|---------|-------------------------|-------------------------|-------------------------|-------------------------|
-| spark-3.5-bigquery                    |         |         |         |         |         | &check; |                         |                         |                         | &check;                 |
-| spark-3.4-bigquery                    |         |         |         |         |         | &check; |                         |                         | &check;                 | &check;                 |
-| spark-3.3-bigquery                    |         |         |         |         | &check; | &check; | &check;                 | &check;                 | &check;                 | &check;                 |
-| spark-3.2-bigquery                    |         |         |         |         | &check; | &check; | &check;                 | &check;                 | &check;                 | &check;                 |
-| spark-3.1-bigquery                    |         |         |         | &check; | &check; | &check; | &check;                 | &check;                 | &check;                 | &check;                 |
-| spark-2.4-bigquery                    |         | &check; | &check; |         |         |         |                         |                         |                         |                         |
-| spark-bigquery-with-dependencies_2.13 |         |         |         |         |         |         |                         | &check;                 | &check;                 | &check;                 |
-| spark-bigquery-with-dependencies_2.12 |         |         | &check; | &check; | &check; | &check; | &check;                 |                         |                         |                         |
-| spark-bigquery-with-dependencies_2.11 | &check; | &check; |         |         |         |         |                         |                         |                         |                         |
+| Connector \ Dataproc Image            | 1.3     | 1.4     | 1.5     | 2.0     | 2.1     | 2.2     | 3.0     | Serverless<br>Image 1.0 | Serverless<br>Image 2.0 | Serverless<br>Image 2.1 | Serverless<br>Image 2.2 | Serverless<br>Image 3.0 |
+|---------------------------------------|---------|---------|---------|---------|---------|---------|---------|-------------------------|-------------------------|-------------------------|-------------------------|-------------------------|
+| spark-4.1-bigquery                    |         |         |         |         |         |         |         |                         |                         |                         |                         |                         |
+| spark-4.0-bigquery                    |         |         |         |         |         |         | &check; |                         |                         |                         |                         | &check;                 |
+| spark-3.5-bigquery                    |         |         |         |         |         | &check; |         |                         |                         |                         | &check;                 |                         |
+| spark-3.4-bigquery                    |         |         |         |         |         | &check; |         |                         |                         | &check;                 | &check;                 |                         |
+| spark-3.3-bigquery                    |         |         |         |         | &check; | &check; |         | &check;                 | &check;                 | &check;                 | &check;                 |                         |
+| spark-3.2-bigquery                    |         |         |         |         | &check; | &check; |         | &check;                 | &check;                 | &check;                 | &check;                 |                         |
+| spark-3.1-bigquery                    |         |         |         | &check; | &check; | &check; |         | &check;                 | &check;                 | &check;                 | &check;                 |                         |
+| spark-2.4-bigquery                    |         | &check; | &check; |         |         |         |         |                         |                         |                         |                         |                         |
+| spark-bigquery-with-dependencies_2.13 |         |         |         |         |         |         |         |                         | &check;                 | &check;                 | &check;                 |                         |
+| spark-bigquery-with-dependencies_2.12 |         |         | &check; | &check; | &check; | &check; |         | &check;                 |                         |                         |                         |                         |
+| spark-bigquery-with-dependencies_2.11 | &check; | &check; |         |         |         |         |         |                         |                         |                         |                         |                         |
+
+Dataproc Image 3.0 (Spark 4.0) and Serverless Image 3.0 (Spark 4.0) are
+currently in preview; see the
+[Dataproc release notes](https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-version-clusters)
+for the latest image-version status.
 
 ### Maven / Ivy Package Usage
 The connector is also available from the


### PR DESCRIPTION
- Refresh `CONTRIBUTING.md` to match the current modules, Maven profiles, CI matrix, and JDK 8 / 11 / 17 toolchains.
- Add Spark 4.0 / 4.1 and cluster/serverless 3.0 compatibility entries to `README.md` and `README-template.md`.
- Update cluster image 3.0 for its GA Spark 4.1 runtime and link to the current cluster/serverless lifecycle pages so support status does not go stale.
- Restore the implemented `parentProject` option documentation and remove the non-functional `billingProject` entry. Fixes #1503.
- Backfill the omitted 0.43.0 release note for PR #1400 / issue #1379.

The branch has been merged with current `master`; upstream release notes are preserved.
