### PR TITLE
Added Support for Change Data Capture (CDC)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+* PR #1494: Added Support for Change Data Capture (CDC)
+
 ## 0.44.2 - 2026-05-20
 
 * Issue #1389: Fixed Timestamp Conversion from Julian to Gregorian conversion

--- a/README-template.md
+++ b/README-template.md
@@ -402,6 +402,27 @@ This behavior was introduced between version 0.22.0 and 0.41.0 to prevent accide
 
 **Note:** This behavior applies to both the `indirect` (default) and `direct` write methods.
 
+#### Change Data Capture (CDC) write
+
+The connector supports writing data to BigQuery tables using Change Data Capture (CDC). CDC allows applying row-level updates (`UPSERT`) and deletes (`DELETE`) directly from a Spark DataFrame based on the `_CHANGE_TYPE` and `_CHANGE_SEQUENCE_NUMBER` pseudo-columns (case-insensitive). CDC writes require using the direct write method with `writeAtLeastOnce` enabled, target table pre-existence with a primary key, and `SaveMode.Append` (`.mode("append")`). Partition decorators are not supported alongside CDC writes.
+
+```python
+# Create a DataFrame containing CDC columns
+data = [
+    (1, "Alice", "UPSERT", 1),
+    (2, "Bob", "DELETE", 2)
+]
+df = spark.createDataFrame(data, ["id", "name", "_CHANGE_TYPE", "_CHANGE_SEQUENCE_NUMBER"])
+
+# Write to BigQuery using direct write method with writeAtLeastOnce enabled
+df.write \
+  .format("bigquery") \
+  .mode("append") \
+  .option("writeMethod", "direct") \
+  .option("writeAtLeastOnce", "true") \
+  .save("dataset.table")
+```
+
 ### Running SQL on BigQuery
 
 The connector supports Spark's [SparkSession#executeCommand](https://archive.apache.org/dist/spark/docs/3.0.0/api/java/org/apache/spark/sql/SparkSession.html#executeCommand-java.lang.String-java.lang.String-scala.collection.immutable.Map-)

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
@@ -75,6 +75,7 @@ import java.util.TreeMap;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.IntFunction;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -574,12 +575,10 @@ public class BigQueryUtil {
       return ComparisonResult.differentNoDescription();
     }
 
-    java.util.List<Field> filteredSourceFields =
+    List<Field> filteredSourceFields =
         sourceFieldList.stream()
-            .filter(
-                f ->
-                    !CDC_PSEUDO_COLUMNS.contains(f.getName().toUpperCase(java.util.Locale.ENGLISH)))
-            .collect(java.util.stream.Collectors.toList());
+            .filter(f -> !isCdcPseudoColumn(f))
+            .collect(Collectors.toList());
 
     // cannot write of the source has more fields than the destination table.
     if (filteredSourceFields.size() > destinationFieldList.size()) {
@@ -1192,5 +1191,4 @@ public class BigQueryUtil {
   public static boolean isCdcPseudoColumn(Field field) {
     return BigQueryUtil.CDC_PSEUDO_COLUMNS.contains(field.getName().toUpperCase(Locale.ENGLISH));
   }
-
 }

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
@@ -88,6 +88,8 @@ public class BigQueryUtil {
   public static final int DEFAULT_NUMERIC_SCALE = 9;
   public static final int DEFAULT_BIG_NUMERIC_PRECISION = 76;
   public static final int DEFAULT_BIG_NUMERIC_SCALE = 38;
+  public static final ImmutableSet<String> CDC_PSEUDO_COLUMNS =
+      ImmutableSet.of("_CHANGE_TYPE", "_CHANGE_SEQUENCE_NUMBER");
   private static final int NO_VALUE = -1;
   private static final long BIGQUERY_INTEGER_MIN_VALUE = Long.MIN_VALUE;
   static final ImmutableSet<String> INTERNAL_ERROR_MESSAGES =
@@ -572,18 +574,26 @@ public class BigQueryUtil {
       return ComparisonResult.differentNoDescription();
     }
 
+    java.util.List<Field> filteredSourceFields =
+        sourceFieldList.stream()
+            .filter(
+                f ->
+                    !CDC_PSEUDO_COLUMNS.contains(f.getName().toUpperCase(java.util.Locale.ENGLISH)))
+            .collect(java.util.stream.Collectors.toList());
+
     // cannot write of the source has more fields than the destination table.
-    if (sourceFieldList.size() > destinationFieldList.size()) {
+    if (filteredSourceFields.size() > destinationFieldList.size()) {
       return ComparisonResult.differentWithDescription(
           ImmutableList.of(
               "Number of source fields: "
-                  + sourceFieldList.size()
+                  + filteredSourceFields.size()
                   + " is larger than number of destination fields: "
                   + destinationFieldList.size()));
     }
 
     Map<String, Field> sourceFieldsMap =
-        sourceFieldList.stream().collect(Collectors.toMap(Field::getName, Function.identity()));
+        filteredSourceFields.stream()
+            .collect(Collectors.toMap(Field::getName, Function.identity()));
     Map<String, Field> destinationFieldsMap =
         destinationFieldList.stream()
             .collect(Collectors.toMap(Field::getName, Function.identity()));

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
@@ -75,7 +75,6 @@ import java.util.TreeMap;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.IntFunction;
-import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -576,9 +575,7 @@ public class BigQueryUtil {
     }
 
     List<Field> filteredSourceFields =
-        sourceFieldList.stream()
-            .filter(f -> !isCdcPseudoColumn(f))
-            .collect(Collectors.toList());
+        sourceFieldList.stream().filter(f -> !isCdcPseudoColumn(f)).collect(Collectors.toList());
 
     // cannot write of the source has more fields than the destination table.
     if (filteredSourceFields.size() > destinationFieldList.size()) {

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
@@ -574,22 +574,18 @@ public class BigQueryUtil {
       return ComparisonResult.differentNoDescription();
     }
 
-    List<Field> filteredSourceFields =
-        sourceFieldList.stream().filter(f -> !isCdcPseudoColumn(f)).collect(Collectors.toList());
-
     // cannot write of the source has more fields than the destination table.
-    if (filteredSourceFields.size() > destinationFieldList.size()) {
+    if (sourceFieldList.size() > destinationFieldList.size()) {
       return ComparisonResult.differentWithDescription(
           ImmutableList.of(
               "Number of source fields: "
-                  + filteredSourceFields.size()
+                  + sourceFieldList.size()
                   + " is larger than number of destination fields: "
                   + destinationFieldList.size()));
     }
 
     Map<String, Field> sourceFieldsMap =
-        filteredSourceFields.stream()
-            .collect(Collectors.toMap(Field::getName, Function.identity()));
+        sourceFieldList.stream().collect(Collectors.toMap(Field::getName, Function.identity()));
     Map<String, Field> destinationFieldsMap =
         destinationFieldList.stream()
             .collect(Collectors.toMap(Field::getName, Function.identity()));

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
@@ -1188,4 +1188,9 @@ public class BigQueryUtil {
     }
     return String.valueOf(fieldValue.getValue());
   }
+
+  public static boolean isCdcPseudoColumn(Field field) {
+    return BigQueryUtil.CDC_PSEUDO_COLUMNS.contains(field.getName().toUpperCase(Locale.ENGLISH));
+  }
+
 }

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryUtil.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryUtil.java
@@ -34,6 +34,7 @@ import java.io.UncheckedIOException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -51,6 +52,7 @@ import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
 
 /** Spark related utilities */
 public class SparkBigQueryUtil {
@@ -321,5 +323,9 @@ public class SparkBigQueryUtil {
                     "dataproc_job_uuid",
                     BigQueryUtil.sanitizeLabelValue(tag.substring(tag.lastIndexOf('_') + 1))));
     return labels.build();
+  }
+
+  public static boolean isCdcPseudoColumn(StructField field) {
+    return BigQueryUtil.CDC_PSEUDO_COLUMNS.contains(field.name().toUpperCase(Locale.ENGLISH));
   }
 }

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryUtil.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/SparkBigQueryUtil.java
@@ -31,6 +31,8 @@ import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.sql.Date;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
@@ -217,7 +219,7 @@ public class SparkBigQueryUtil {
     }
 
     // need to return timestamp in epoch microseconds
-    java.sql.Timestamp timestamp = (java.sql.Timestamp) sparkValue;
+    Timestamp timestamp = (Timestamp) sparkValue;
     long epochMillis = timestamp.getTime();
     int micros = (timestamp.getNanos() / 1000) % 1000;
     return epochMillis * 1000 + micros;
@@ -233,7 +235,7 @@ public class SparkBigQueryUtil {
       return Math.toIntExact(localDate.toEpochDay());
     }
 
-    java.sql.Date sparkDate = (java.sql.Date) sparkValue;
+    Date sparkDate = (Date) sparkValue;
     return (int) sparkDate.toLocalDate().toEpochDay();
   }
 

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/CreatableRelationProviderHelper.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/CreatableRelationProviderHelper.java
@@ -22,9 +22,11 @@ import com.google.cloud.bigquery.connector.common.BigQueryUtil;
 import com.google.cloud.spark.bigquery.DataSourceVersion;
 import com.google.cloud.spark.bigquery.InjectorBuilder;
 import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
+import com.google.cloud.spark.bigquery.SparkBigQueryUtil;
 import com.google.cloud.spark.bigquery.write.context.BigQueryDataSourceWriterModule;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Injector;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.spark.sql.*;
@@ -123,6 +125,13 @@ public class CreatableRelationProviderHelper {
   private BigQueryInsertableRelationBase createBigQueryInsertableRelationInternal(
       StructType schema, SaveMode saveMode, Injector injector) {
     SparkBigQueryConfig config = injector.getInstance(SparkBigQueryConfig.class);
+    if (Arrays.stream(schema.fields()).anyMatch(SparkBigQueryUtil::isCdcPseudoColumn)) {
+      if (config.getWriteMethod() != SparkBigQueryConfig.WriteMethod.DIRECT
+          || !config.isWriteAtLeastOnce()) {
+        throw new IllegalArgumentException(
+            "CDC is only supported when writeMethod is DIRECT and writeAtLeastOnce is true.");
+      }
+    }
     BigQueryClient bigQueryClient = injector.getInstance(BigQueryClient.class);
     SQLContext sqlContext = injector.getInstance(SparkSession.class).sqlContext();
 

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
@@ -18,9 +18,9 @@ package com.google.cloud.spark.bigquery.write.context;
 import static com.google.cloud.spark.bigquery.ProtobufUtils.toProtoSchema;
 
 import com.google.api.gax.retrying.RetrySettings;
-import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardTableDefinition;
 import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.connector.common.BigQueryClient;
@@ -89,9 +89,7 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
   private final SparkContext sparkContext;
 
   private static StructType normalizeCdcColumns(StructType schema) {
-    boolean hasCdc =
-        Arrays.stream(schema.fields())
-            .anyMatch(SparkBigQueryUtil::isCdcPseudoColumn);
+    boolean hasCdc = Arrays.stream(schema.fields()).anyMatch(SparkBigQueryUtil::isCdcPseudoColumn);
     if (!hasCdc) {
       return schema;
     }
@@ -105,19 +103,18 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
                   }
                   return f;
                 })
-            .toArray(org.apache.spark.sql.types.StructField[]::new);
+            .toArray(StructField[]::new);
     return new StructType(fields);
   }
 
   private boolean hasCdcColumns(Schema bigQuerySchema) {
-    return bigQuerySchema.getFields().stream()
-        .anyMatch(BigQueryUtil::isCdcPseudoColumn);
+    return bigQuerySchema.getFields().stream().anyMatch(BigQueryUtil::isCdcPseudoColumn);
   }
 
   private boolean hasPrimaryKey(TableInfo tableInfo) {
     try {
-      if (tableInfo.getDefinition() instanceof com.google.cloud.bigquery.StandardTableDefinition) {
-        com.google.cloud.bigquery.StandardTableDefinition stdDef = tableInfo.getDefinition();
+      if (tableInfo.getDefinition() instanceof StandardTableDefinition) {
+        StandardTableDefinition stdDef = (StandardTableDefinition) tableInfo.getDefinition();
         return stdDef.getTableConstraints() != null
             && stdDef.getTableConstraints().getPrimaryKey() != null;
       }

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
@@ -18,6 +18,7 @@ package com.google.cloud.spark.bigquery.write.context;
 import static com.google.cloud.spark.bigquery.ProtobufUtils.toProtoSchema;
 
 import com.google.api.gax.retrying.RetrySettings;
+import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.Schema;
 import com.google.cloud.bigquery.TableId;
@@ -41,9 +42,11 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
+import java.util.Locale;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,22 +87,27 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
   private WritingMode writingMode = WritingMode.ALL_ELSE;
   private final SparkContext sparkContext;
 
+  private static boolean isCdcPseudoColumn(StructField field) {
+    return BigQueryUtil.CDC_PSEUDO_COLUMNS.contains(field.name().toUpperCase(Locale.ENGLISH));
+  }
+
+  private static boolean isCdcPseudoColumn(Field field) {
+    return BigQueryUtil.CDC_PSEUDO_COLUMNS.contains(field.getName().toUpperCase(Locale.ENGLISH));
+  }
+
   private static StructType normalizeCdcColumns(StructType schema) {
     boolean hasCdc =
         Arrays.stream(schema.fields())
-            .anyMatch(
-                f ->
-                    BigQueryUtil.CDC_PSEUDO_COLUMNS.contains(
-                        f.name().toUpperCase(java.util.Locale.ENGLISH)));
+            .anyMatch(BigQueryDirectDataSourceWriterContext::isCdcPseudoColumn);
     if (!hasCdc) {
       return schema;
     }
-    org.apache.spark.sql.types.StructField[] fields =
+    StructField[] fields =
         Arrays.stream(schema.fields())
             .map(
                 f -> {
-                  String nameUpper = f.name().toUpperCase(java.util.Locale.ENGLISH);
-                  if (BigQueryUtil.CDC_PSEUDO_COLUMNS.contains(nameUpper)) {
+                  String nameUpper = f.name().toUpperCase(Locale.ENGLISH);
+                  if (isCdcPseudoColumn(f)) {
                     return f.copy(nameUpper, f.dataType(), f.nullable(), f.metadata());
                   }
                   return f;
@@ -110,10 +118,7 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
 
   private boolean hasCdcColumns(Schema bigQuerySchema) {
     return bigQuerySchema.getFields().stream()
-        .anyMatch(
-            f ->
-                BigQueryUtil.CDC_PSEUDO_COLUMNS.contains(
-                    f.getName().toUpperCase(java.util.Locale.ENGLISH)));
+        .anyMatch(BigQueryDirectDataSourceWriterContext::isCdcPseudoColumn);
   }
 
   private boolean hasPrimaryKey(TableInfo tableInfo) {

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
@@ -36,6 +36,7 @@ import com.google.cloud.spark.bigquery.PartitionOverwriteMode;
 import com.google.cloud.spark.bigquery.SchemaConverters;
 import com.google.cloud.spark.bigquery.SchemaConvertersConfiguration;
 import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
+import com.google.cloud.spark.bigquery.SparkBigQueryUtil;
 import com.google.cloud.spark.bigquery.metrics.SparkBigQueryConnectorMetricsUtils;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
@@ -87,18 +88,10 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
   private WritingMode writingMode = WritingMode.ALL_ELSE;
   private final SparkContext sparkContext;
 
-  private static boolean isCdcPseudoColumn(StructField field) {
-    return BigQueryUtil.CDC_PSEUDO_COLUMNS.contains(field.name().toUpperCase(Locale.ENGLISH));
-  }
-
-  private static boolean isCdcPseudoColumn(Field field) {
-    return BigQueryUtil.CDC_PSEUDO_COLUMNS.contains(field.getName().toUpperCase(Locale.ENGLISH));
-  }
-
   private static StructType normalizeCdcColumns(StructType schema) {
     boolean hasCdc =
         Arrays.stream(schema.fields())
-            .anyMatch(BigQueryDirectDataSourceWriterContext::isCdcPseudoColumn);
+            .anyMatch(SparkBigQueryUtil::isCdcPseudoColumn);
     if (!hasCdc) {
       return schema;
     }
@@ -107,7 +100,7 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
             .map(
                 f -> {
                   String nameUpper = f.name().toUpperCase(Locale.ENGLISH);
-                  if (isCdcPseudoColumn(f)) {
+                  if (SparkBigQueryUtil.isCdcPseudoColumn(f)) {
                     return f.copy(nameUpper, f.dataType(), f.nullable(), f.metadata());
                   }
                   return f;
@@ -118,7 +111,7 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
 
   private boolean hasCdcColumns(Schema bigQuerySchema) {
     return bigQuerySchema.getFields().stream()
-        .anyMatch(BigQueryDirectDataSourceWriterContext::isCdcPseudoColumn);
+        .anyMatch(BigQueryUtil::isCdcPseudoColumn);
   }
 
   private boolean hasPrimaryKey(TableInfo tableInfo) {

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
@@ -161,6 +161,10 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
         SchemaConverters.from(this.schemaConvertersConfiguration)
             .toBigQuerySchema(this.sparkSchema);
     if (hasCdcColumns(bigQuerySchema)) {
+      if (bigQuerySchema.getFields().get("_CHANGE_TYPE") == null) {
+        throw new IllegalArgumentException(
+            "CDC writes require the _CHANGE_TYPE column to be present in the schema.");
+      }
       if (saveMode != SaveMode.Append) {
         throw new IllegalArgumentException("CDC can only be used with SaveMode.Append");
       }

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
@@ -169,12 +169,12 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
         SchemaConverters.from(this.schemaConvertersConfiguration)
             .toBigQuerySchema(this.sparkSchema);
     if (hasCdcColumns(bigQuerySchema)) {
+      if (saveMode != SaveMode.Append) {
+        throw new IllegalArgumentException("CDC can only be used with SaveMode.Append");
+      }
       if (!writeAtLeastOnce) {
         throw new IllegalArgumentException(
             "CDC is only supported when writeMethod is DIRECT and writeAtLeastOnce is true.");
-      }
-      if (saveMode != SaveMode.Append) {
-        throw new IllegalArgumentException("CDC can only be used with SaveMode.Append");
       }
       if (destinationTableId.getTable().contains("$")) {
         throw new IllegalArgumentException(

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
@@ -99,7 +99,7 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
                 f -> {
                   String nameUpper = f.name().toUpperCase(Locale.ENGLISH);
                   if (SparkBigQueryUtil.isCdcPseudoColumn(f)) {
-                    return f.copy(nameUpper, f.dataType(), f.nullable(), f.metadata());
+                    return new StructField(nameUpper, f.dataType(), f.nullable(), f.metadata());
                   }
                   return f;
                 })
@@ -112,7 +112,7 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
   }
 
   private boolean hasPrimaryKey(TableInfo tableInfo) {
-    if (!(tableInfo.getDefinition() instanceof StandardTableDefinition)) {
+    if (tableInfo == null || !(tableInfo.getDefinition() instanceof StandardTableDefinition)) {
       return false;
     }
     try {

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
@@ -44,6 +44,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.Locale;
+import java.util.stream.Collectors;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -208,9 +209,17 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
     if (bigQueryClient.tableExists(destinationTableId)) {
       TableInfo destinationTable = bigQueryClient.getTable(destinationTableId);
       Schema tableSchema = destinationTable.getDefinition().getSchema();
+      Schema sourceSchemaForValidation = bigQuerySchema;
+      if (hasCdcColumns(bigQuerySchema)) {
+        sourceSchemaForValidation =
+            Schema.of(
+                bigQuerySchema.getFields().stream()
+                    .filter(f -> !BigQueryUtil.isCdcPseudoColumn(f))
+                    .collect(Collectors.toList()));
+      }
       ComparisonResult schemaWritableResult =
           BigQueryUtil.schemaWritable(
-              bigQuerySchema, // sourceSchema
+              sourceSchemaForValidation, // sourceSchema
               tableSchema, // destinationSchema
               false, // regardFieldOrder
               enableModeCheckForSchemaFields);

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
@@ -112,12 +112,13 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
   }
 
   private boolean hasPrimaryKey(TableInfo tableInfo) {
+    if (!(tableInfo.getDefinition() instanceof StandardTableDefinition)) {
+      return false;
+    }
     try {
-      if (tableInfo.getDefinition() instanceof StandardTableDefinition) {
-        StandardTableDefinition stdDef = (StandardTableDefinition) tableInfo.getDefinition();
-        return stdDef.getTableConstraints() != null
-            && stdDef.getTableConstraints().getPrimaryKey() != null;
-      }
+      StandardTableDefinition stdDef = (StandardTableDefinition) tableInfo.getDefinition();
+      return stdDef.getTableConstraints() != null
+          && stdDef.getTableConstraints().getPrimaryKey() != null;
     } catch (NoSuchMethodError | Exception e) {
       // Fallback if google-cloud-bigquery version doesn't support getTableConstraints or throws
     }

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
@@ -84,6 +84,51 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
   private WritingMode writingMode = WritingMode.ALL_ELSE;
   private final SparkContext sparkContext;
 
+  private static StructType normalizeCdcColumns(StructType schema) {
+    boolean hasCdc =
+        Arrays.stream(schema.fields())
+            .anyMatch(
+                f ->
+                    BigQueryUtil.CDC_PSEUDO_COLUMNS.contains(
+                        f.name().toUpperCase(java.util.Locale.ENGLISH)));
+    if (!hasCdc) {
+      return schema;
+    }
+    org.apache.spark.sql.types.StructField[] fields =
+        Arrays.stream(schema.fields())
+            .map(
+                f -> {
+                  String nameUpper = f.name().toUpperCase(java.util.Locale.ENGLISH);
+                  if (BigQueryUtil.CDC_PSEUDO_COLUMNS.contains(nameUpper)) {
+                    return f.copy(nameUpper, f.dataType(), f.nullable(), f.metadata());
+                  }
+                  return f;
+                })
+            .toArray(org.apache.spark.sql.types.StructField[]::new);
+    return new StructType(fields);
+  }
+
+  private boolean hasCdcColumns(Schema bigQuerySchema) {
+    return bigQuerySchema.getFields().stream()
+        .anyMatch(
+            f ->
+                BigQueryUtil.CDC_PSEUDO_COLUMNS.contains(
+                    f.getName().toUpperCase(java.util.Locale.ENGLISH)));
+  }
+
+  private boolean hasPrimaryKey(TableInfo tableInfo) {
+    try {
+      if (tableInfo.getDefinition() instanceof com.google.cloud.bigquery.StandardTableDefinition) {
+        com.google.cloud.bigquery.StandardTableDefinition stdDef = tableInfo.getDefinition();
+        return stdDef.getTableConstraints() != null
+            && stdDef.getTableConstraints().getPrimaryKey() != null;
+      }
+    } catch (NoSuchMethodError | Exception e) {
+      // Fallback if google-cloud-bigquery version doesn't support getTableConstraints or throws
+    }
+    return true; // Default to true if unable to check
+  }
+
   public BigQueryDirectDataSourceWriterContext(
       BigQueryClient bigQueryClient,
       BigQueryClientFactory bigQueryWriteClientFactory,
@@ -106,7 +151,7 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
     this.writeClientFactory = bigQueryWriteClientFactory;
     this.destinationTableId = destinationTableId;
     this.writeUUID = writeUUID;
-    this.sparkSchema = sparkSchema;
+    this.sparkSchema = normalizeCdcColumns(sparkSchema);
     this.bigqueryDataWriterHelperRetrySettings = bigqueryDataWriterHelperRetrySettings;
     this.traceId = traceId;
     this.enableModeCheckForSchemaFields = enableModeCheckForSchemaFields;
@@ -116,9 +161,23 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
     this.writeAtLeastOnce = writeAtLeastOnce;
     this.sparkContext = sparkContext;
     Schema bigQuerySchema =
-        SchemaConverters.from(this.schemaConvertersConfiguration).toBigQuerySchema(sparkSchema);
+        SchemaConverters.from(this.schemaConvertersConfiguration)
+            .toBigQuerySchema(this.sparkSchema);
+    if (hasCdcColumns(bigQuerySchema)) {
+      if (!writeAtLeastOnce) {
+        throw new IllegalArgumentException(
+            "CDC is only supported when writeMethod is DIRECT and writeAtLeastOnce is true.");
+      }
+      if (saveMode != SaveMode.Append) {
+        throw new IllegalArgumentException("CDC can only be used with SaveMode.Append");
+      }
+      if (destinationTableId.getTable().contains("$")) {
+        throw new IllegalArgumentException(
+            "CDC cannot be used with a partition decorator ($). Write to the base table.");
+      }
+    }
     try {
-      this.protoSchema = toProtoSchema(sparkSchema);
+      this.protoSchema = toProtoSchema(this.sparkSchema);
     } catch (IllegalArgumentException e) {
       throw new BigQueryConnectorException.InvalidSchemaException(
           "Could not convert Spark schema to protobuf descriptor", e);
@@ -164,9 +223,18 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
           new BigQueryConnectorException.InvalidSchemaException(
               "Destination table's schema is not compatible with dataframe's schema. "
                   + schemaWritableResult.makeMessage()));
+      if (hasCdcColumns(bigQuerySchema)) {
+        if (!hasPrimaryKey(destinationTable)) {
+          throw new IllegalArgumentException("CDC requires a primary key on the destination table");
+        }
+      }
       switch (saveMode) {
         case Append:
           if (writeAtLeastOnce) {
+            if (hasCdcColumns(bigQuerySchema)) {
+              writingMode = WritingMode.ALL_ELSE;
+              return new BigQueryTable(destinationTable.getTableId(), false);
+            }
             writingMode = WritingMode.APPEND_AT_LEAST_ONCE;
             return new BigQueryTable(
                 bigQueryClient.createTempTable(destinationTableId, tableSchema).getTableId(), true);
@@ -184,6 +252,9 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
       }
       return new BigQueryTable(destinationTable.getTableId(), false);
     } else {
+      if (hasCdcColumns(bigQuerySchema)) {
+        throw new IllegalArgumentException("CDC can only be written to an existing table");
+      }
       return new BigQueryTable(
           bigQueryClient
               .createTable(

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
@@ -48,6 +48,7 @@ import java.util.stream.Collectors;
 import org.apache.spark.SparkContext;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.slf4j.Logger;
@@ -161,9 +162,16 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
         SchemaConverters.from(this.schemaConvertersConfiguration)
             .toBigQuerySchema(this.sparkSchema);
     if (hasCdcColumns(bigQuerySchema)) {
-      if (bigQuerySchema.getFields().get("_CHANGE_TYPE") == null) {
-        throw new IllegalArgumentException(
-            "CDC writes require the _CHANGE_TYPE column to be present in the schema.");
+      StructField changeTypeField =
+          Arrays.stream(this.sparkSchema.fields())
+              .filter(f -> f.name().equals("_CHANGE_TYPE"))
+              .findFirst()
+              .orElseThrow(
+                  () ->
+                      new IllegalArgumentException(
+                          "CDC writes require the _CHANGE_TYPE column to be present in the schema."));
+      if (!changeTypeField.dataType().equals(DataTypes.StringType)) {
+        throw new IllegalArgumentException("CDC _CHANGE_TYPE column must be of type String");
       }
       if (saveMode != SaveMode.Append) {
         throw new IllegalArgumentException("CDC can only be used with SaveMode.Append");

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataWriterContext.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.slf4j.Logger;
@@ -88,6 +89,9 @@ public class BigQueryDirectDataWriterContext implements DataWriterContext<Intern
     int changeTypeIdx = -1;
     for (int i = 0; i < sparkSchema.fields().length; i++) {
       if (sparkSchema.fields()[i].name().equalsIgnoreCase("_CHANGE_TYPE")) {
+        if (!sparkSchema.fields()[i].dataType().equals(DataTypes.StringType)) {
+          throw new IllegalArgumentException("CDC _CHANGE_TYPE column must be of type String");
+        }
         changeTypeIdx = i;
         break;
       }

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataWriterContext.java
@@ -109,20 +109,11 @@ public class BigQueryDirectDataWriterContext implements DataWriterContext<Intern
   @Override
   public void write(InternalRow record) throws IOException {
     if (changeTypeFieldIndex != -1) {
-      Object changeTypeObj = record.get(changeTypeFieldIndex, DataTypes.StringType);
-      if (changeTypeObj != null) {
-        if (changeTypeObj instanceof UTF8String) {
-          UTF8String changeTypeUtf8 = (UTF8String) changeTypeObj;
-          if (!changeTypeUtf8.equals(UPSERT) && !changeTypeUtf8.equals(DELETE)) {
-            throw new IllegalArgumentException(
-                "CDC _CHANGE_TYPE must be UPSERT or DELETE, but got: " + changeTypeUtf8);
-          }
-        } else {
-          String valStr = changeTypeObj.toString();
-          if (!valStr.equals("UPSERT") && !valStr.equals("DELETE")) {
-            throw new IllegalArgumentException(
-                "CDC _CHANGE_TYPE must be UPSERT or DELETE, but got: " + valStr);
-          }
+      UTF8String changeTypeUtf8 = record.getUTF8String(changeTypeFieldIndex);
+      if (changeTypeUtf8 != null) {
+        if (!changeTypeUtf8.equals(UPSERT) && !changeTypeUtf8.equals(DELETE)) {
+          throw new IllegalArgumentException(
+                  "CDC _CHANGE_TYPE must be UPSERT or DELETE, but got: " + changeTypeUtf8);
         }
       } else {
         throw new IllegalArgumentException("CDC _CHANGE_TYPE cannot be null");

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataWriterContext.java
@@ -104,10 +104,19 @@ public class BigQueryDirectDataWriterContext implements DataWriterContext<Intern
   @Override
   public void write(InternalRow record) throws IOException {
     if (changeTypeFieldIndex != -1) {
-      org.apache.spark.unsafe.types.UTF8String changeTypeVal =
-          record.getUTF8String(changeTypeFieldIndex);
-      if (changeTypeVal != null) {
-        String valStr = changeTypeVal.toString();
+      Object changeTypeObj =
+          record.get(changeTypeFieldIndex, org.apache.spark.sql.types.DataTypes.StringType);
+      if (changeTypeObj != null) {
+        String valStr;
+        if (changeTypeObj instanceof org.apache.spark.unsafe.types.UTF8String) {
+          valStr = ((org.apache.spark.unsafe.types.UTF8String) changeTypeObj).toString();
+        } else if (changeTypeObj instanceof String) {
+          valStr = (String) changeTypeObj;
+        } else {
+          throw new IllegalArgumentException(
+              "CDC _CHANGE_TYPE must be a String, but got class: "
+                  + changeTypeObj.getClass().getName());
+        }
         if (!valStr.equals("UPSERT") && !valStr.equals("DELETE")) {
           throw new IllegalArgumentException(
               "CDC _CHANGE_TYPE must be UPSERT or DELETE, but got: " + valStr);

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataWriterContext.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.spark.sql.catalyst.InternalRow;
-import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.slf4j.Logger;
@@ -113,7 +112,7 @@ public class BigQueryDirectDataWriterContext implements DataWriterContext<Intern
       if (changeTypeUtf8 != null) {
         if (!changeTypeUtf8.equals(UPSERT) && !changeTypeUtf8.equals(DELETE)) {
           throw new IllegalArgumentException(
-                  "CDC _CHANGE_TYPE must be UPSERT or DELETE, but got: " + changeTypeUtf8);
+              "CDC _CHANGE_TYPE must be UPSERT or DELETE, but got: " + changeTypeUtf8);
         }
       } else {
         throw new IllegalArgumentException("CDC _CHANGE_TYPE cannot be null");

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataWriterContext.java
@@ -35,10 +35,14 @@ import java.util.Map;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BigQueryDirectDataWriterContext implements DataWriterContext<InternalRow> {
+  private static final UTF8String UPSERT = UTF8String.fromString("UPSERT");
+  private static final UTF8String DELETE = UTF8String.fromString("DELETE");
+
   final Logger logger = LoggerFactory.getLogger(BigQueryDirectDataWriterContext.class);
 
   private final int partitionId;
@@ -84,7 +88,7 @@ public class BigQueryDirectDataWriterContext implements DataWriterContext<Intern
 
     int changeTypeIdx = -1;
     for (int i = 0; i < sparkSchema.fields().length; i++) {
-      if (sparkSchema.fields()[i].name().equals("_CHANGE_TYPE")) {
+      if (sparkSchema.fields()[i].name().equalsIgnoreCase("_CHANGE_TYPE")) {
         changeTypeIdx = i;
         break;
       }
@@ -107,10 +111,18 @@ public class BigQueryDirectDataWriterContext implements DataWriterContext<Intern
     if (changeTypeFieldIndex != -1) {
       Object changeTypeObj = record.get(changeTypeFieldIndex, DataTypes.StringType);
       if (changeTypeObj != null) {
-        String valStr = changeTypeObj.toString();
-        if (!valStr.equals("UPSERT") && !valStr.equals("DELETE")) {
-          throw new IllegalArgumentException(
-              "CDC _CHANGE_TYPE must be UPSERT or DELETE, but got: " + valStr);
+        if (changeTypeObj instanceof UTF8String) {
+          UTF8String changeTypeUtf8 = (UTF8String) changeTypeObj;
+          if (!changeTypeUtf8.equals(UPSERT) && !changeTypeUtf8.equals(DELETE)) {
+            throw new IllegalArgumentException(
+                "CDC _CHANGE_TYPE must be UPSERT or DELETE, but got: " + changeTypeUtf8);
+          }
+        } else {
+          String valStr = changeTypeObj.toString();
+          if (!valStr.equals("UPSERT") && !valStr.equals("DELETE")) {
+            throw new IllegalArgumentException(
+                "CDC _CHANGE_TYPE must be UPSERT or DELETE, but got: " + valStr);
+          }
         }
       } else {
         throw new IllegalArgumentException("CDC _CHANGE_TYPE cannot be null");

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataWriterContext.java
@@ -48,6 +48,7 @@ public class BigQueryDirectDataWriterContext implements DataWriterContext<Intern
   private final Descriptors.Descriptor schemaDescriptor;
   private final Map<Integer, ProtobufSchemaFieldCacheEntry> fieldIndexToEntryMap;
   private final DynamicMessage.Builder messageBuilder;
+  private final int changeTypeFieldIndex;
 
   /**
    * A helper object to assist the BigQueryDataWriter with all the writing: essentially does all the
@@ -80,6 +81,15 @@ public class BigQueryDirectDataWriterContext implements DataWriterContext<Intern
     this.fieldIndexToEntryMap = new HashMap<>();
     this.messageBuilder = DynamicMessage.newBuilder(this.schemaDescriptor);
 
+    int changeTypeIdx = -1;
+    for (int i = 0; i < sparkSchema.fields().length; i++) {
+      if (sparkSchema.fields()[i].name().equals("_CHANGE_TYPE")) {
+        changeTypeIdx = i;
+        break;
+      }
+    }
+    this.changeTypeFieldIndex = changeTypeIdx;
+
     this.writerHelper =
         new BigQueryDirectDataWriterHelper(
             writeClientFactory,
@@ -93,6 +103,19 @@ public class BigQueryDirectDataWriterContext implements DataWriterContext<Intern
 
   @Override
   public void write(InternalRow record) throws IOException {
+    if (changeTypeFieldIndex != -1) {
+      org.apache.spark.unsafe.types.UTF8String changeTypeVal =
+          record.getUTF8String(changeTypeFieldIndex);
+      if (changeTypeVal != null) {
+        String valStr = changeTypeVal.toString();
+        if (!valStr.equals("UPSERT") && !valStr.equals("DELETE")) {
+          throw new IllegalArgumentException(
+              "CDC _CHANGE_TYPE must be UPSERT or DELETE, but got: " + valStr);
+        }
+      } else {
+        throw new IllegalArgumentException("CDC _CHANGE_TYPE cannot be null");
+      }
+    }
     ByteString message =
         buildSingleRowMessage(
                 sparkSchema,

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataWriterContext.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.unsafe.types.UTF8String;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -108,16 +107,7 @@ public class BigQueryDirectDataWriterContext implements DataWriterContext<Intern
     if (changeTypeFieldIndex != -1) {
       Object changeTypeObj = record.get(changeTypeFieldIndex, DataTypes.StringType);
       if (changeTypeObj != null) {
-        String valStr;
-        if (changeTypeObj instanceof UTF8String) {
-          valStr = ((UTF8String) changeTypeObj).toString();
-        } else if (changeTypeObj instanceof String) {
-          valStr = (String) changeTypeObj;
-        } else {
-          throw new IllegalArgumentException(
-              "CDC _CHANGE_TYPE must be a String, but got class: "
-                  + changeTypeObj.getClass().getName());
-        }
+        String valStr = changeTypeObj.toString();
         if (!valStr.equals("UPSERT") && !valStr.equals("DELETE")) {
           throw new IllegalArgumentException(
               "CDC _CHANGE_TYPE must be UPSERT or DELETE, but got: " + valStr);

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataWriterContext.java
@@ -33,7 +33,9 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.UTF8String;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,12 +106,11 @@ public class BigQueryDirectDataWriterContext implements DataWriterContext<Intern
   @Override
   public void write(InternalRow record) throws IOException {
     if (changeTypeFieldIndex != -1) {
-      Object changeTypeObj =
-          record.get(changeTypeFieldIndex, org.apache.spark.sql.types.DataTypes.StringType);
+      Object changeTypeObj = record.get(changeTypeFieldIndex, DataTypes.StringType);
       if (changeTypeObj != null) {
         String valStr;
-        if (changeTypeObj instanceof org.apache.spark.unsafe.types.UTF8String) {
-          valStr = ((org.apache.spark.unsafe.types.UTF8String) changeTypeObj).toString();
+        if (changeTypeObj instanceof UTF8String) {
+          valStr = ((UTF8String) changeTypeObj).toString();
         } else if (changeTypeObj instanceof String) {
           valStr = (String) changeTypeObj;
         } else {

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataWriterContext.java
@@ -112,8 +112,12 @@ public class BigQueryDirectDataWriterContext implements DataWriterContext<Intern
   @Override
   public void write(InternalRow record) throws IOException {
     if (changeTypeFieldIndex != -1) {
-      UTF8String changeTypeUtf8 = record.getUTF8String(changeTypeFieldIndex);
-      if (changeTypeUtf8 != null) {
+      Object changeTypeVal = record.get(changeTypeFieldIndex, DataTypes.StringType);
+      if (changeTypeVal != null) {
+        UTF8String changeTypeUtf8 =
+            changeTypeVal instanceof UTF8String
+                ? (UTF8String) changeTypeVal
+                : UTF8String.fromString(changeTypeVal.toString());
         if (!changeTypeUtf8.equals(UPSERT) && !changeTypeUtf8.equals(DELETE)) {
           throw new IllegalArgumentException(
               "CDC _CHANGE_TYPE must be UPSERT or DELETE, but got: " + changeTypeUtf8);

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryIndirectDataSourceWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryIndirectDataSourceWriterContext.java
@@ -35,8 +35,10 @@ import com.google.cloud.spark.bigquery.write.BigQueryWriteHelper;
 import com.google.cloud.spark.bigquery.write.IntermediateDataCleaner;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.beam.sdk.io.hadoop.SerializableConfiguration;
@@ -95,11 +97,8 @@ public class BigQueryIndirectDataSourceWriterContext implements DataSourceWriter
     this.intermediateDataCleaner = intermediateDataCleaner;
     this.writeDisposition = SparkBigQueryUtil.saveModeToWriteDisposition(saveMode);
     this.sparkContext = sparkContext;
-    if (java.util.Arrays.stream(sparkSchema.fields())
-        .anyMatch(
-            f ->
-                com.google.cloud.bigquery.connector.common.BigQueryUtil.CDC_PSEUDO_COLUMNS.contains(
-                    f.name().toUpperCase(java.util.Locale.ENGLISH)))) {
+    if (Arrays.stream(sparkSchema.fields())
+        .anyMatch(SparkBigQueryUtil::isCdcPseudoColumn)) {
       throw new IllegalArgumentException(
           "CDC is only supported when writeMethod is DIRECT and writeAtLeastOnce is true.");
     }

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryIndirectDataSourceWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryIndirectDataSourceWriterContext.java
@@ -38,7 +38,6 @@ import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.beam.sdk.io.hadoop.SerializableConfiguration;
@@ -97,8 +96,7 @@ public class BigQueryIndirectDataSourceWriterContext implements DataSourceWriter
     this.intermediateDataCleaner = intermediateDataCleaner;
     this.writeDisposition = SparkBigQueryUtil.saveModeToWriteDisposition(saveMode);
     this.sparkContext = sparkContext;
-    if (Arrays.stream(sparkSchema.fields())
-        .anyMatch(SparkBigQueryUtil::isCdcPseudoColumn)) {
+    if (Arrays.stream(sparkSchema.fields()).anyMatch(SparkBigQueryUtil::isCdcPseudoColumn)) {
       throw new IllegalArgumentException(
           "CDC is only supported when writeMethod is DIRECT and writeAtLeastOnce is true.");
     }

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryIndirectDataSourceWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryIndirectDataSourceWriterContext.java
@@ -95,6 +95,14 @@ public class BigQueryIndirectDataSourceWriterContext implements DataSourceWriter
     this.intermediateDataCleaner = intermediateDataCleaner;
     this.writeDisposition = SparkBigQueryUtil.saveModeToWriteDisposition(saveMode);
     this.sparkContext = sparkContext;
+    if (java.util.Arrays.stream(sparkSchema.fields())
+        .anyMatch(
+            f ->
+                com.google.cloud.bigquery.connector.common.BigQueryUtil.CDC_PSEUDO_COLUMNS.contains(
+                    f.name().toUpperCase(java.util.Locale.ENGLISH)))) {
+      throw new IllegalArgumentException(
+          "CDC is only supported when writeMethod is DIRECT and writeAtLeastOnce is true.");
+    }
   }
 
   @Override

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -2843,7 +2843,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   public void testCdcAppend() throws Exception {
     assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
 
-    String destTableName = testDataset + "." + "cdc_test_" + System.nanoTime();
+    String destTableName = testDataset + "." + testTable;
     String ddl =
         String.format(
             "CREATE TABLE %s (id INT64, name STRING, PRIMARY KEY(id) NOT ENFORCED)", destTableName);
@@ -2868,7 +2868,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
         .option("writeAtLeastOnce", "true")
         .save(destTableName);
 
-    int numOfRows = testTableNumberOfRows(destTableName.split("\\.")[1]);
+    int numOfRows = testTableNumberOfRows(testTable);
     assertThat(numOfRows).isEqualTo(2);
 
     // Send a DELETE for one of the rows
@@ -2881,7 +2881,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
         .option("writeAtLeastOnce", "true")
         .save(destTableName);
 
-    numOfRows = testTableNumberOfRows(destTableName.split("\\.")[1]);
+    numOfRows = testTableNumberOfRows(testTable);
     assertThat(numOfRows).isEqualTo(1);
   }
 
@@ -2889,7 +2889,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   public void testCdcFailsWhenIndirectWriteMethod() {
     assumeThat(writeMethod, equalTo(WriteMethod.INDIRECT));
 
-    String destTableName = testDataset + "." + "cdc_indirect_test_" + System.nanoTime();
+    String destTableName = testDataset + "." + testTable;
     StructType schema =
         new StructType().add("id", DataTypes.LongType).add("_CHANGE_TYPE", DataTypes.StringType);
     Dataset<Row> df =
@@ -2925,8 +2925,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   public void testCdcFailsWhenDirectButNotAtLeastOnce() {
     assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
 
-    String destTableName =
-        testDataset + "." + "cdc_direct_not_at_least_once_test_" + System.nanoTime();
+    String destTableName = testDataset + "." + testTable;
     StructType schema =
         new StructType().add("id", DataTypes.LongType).add("_CHANGE_TYPE", DataTypes.StringType);
     Dataset<Row> df =
@@ -2962,7 +2961,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   public void testCdcFailsWhenTableDoesNotExist() {
     assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
 
-    String destTableName = testDataset + "." + "cdc_no_table_test_" + System.nanoTime();
+    String destTableName = testDataset + "." + testTable;
     StructType schema =
         new StructType().add("id", DataTypes.LongType).add("_CHANGE_TYPE", DataTypes.StringType);
     Dataset<Row> df =
@@ -2996,7 +2995,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   public void testCdcFailsWithPartitionDecorator() throws Exception {
     assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
 
-    String baseTableName = testDataset + "." + "cdc_partition_decorator_test_" + System.nanoTime();
+    String baseTableName = testDataset + "." + testTable;
     String ddl =
         String.format(
             "CREATE TABLE %s (id INT64, name STRING, partition_date DATE, PRIMARY KEY(id) NOT ENFORCED) PARTITION BY partition_date",
@@ -3046,7 +3045,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   public void testCdcFailsWithInvalidChangeType() throws Exception {
     assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
 
-    String destTableName = testDataset + "." + "cdc_invalid_value_test_" + System.nanoTime();
+    String destTableName = testDataset + "." + testTable;
     String ddl =
         String.format(
             "CREATE TABLE %s (id INT64, name STRING, PRIMARY KEY(id) NOT ENFORCED)", destTableName);
@@ -3090,7 +3089,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   public void testCdcFailsWithOverwrite() throws Exception {
     assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
 
-    String destTableName = testDataset + "." + "cdc_overwrite_test_" + System.nanoTime();
+    String destTableName = testDataset + "." + testTable;
     String ddl =
         String.format(
             "CREATE TABLE %s (id INT64, name STRING, PRIMARY KEY(id) NOT ENFORCED)", destTableName);

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -2895,9 +2895,9 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
     Dataset<Row> df =
         spark.createDataFrame(Collections.singletonList(RowFactory.create(1L, "UPSERT")), schema);
 
-    IllegalArgumentException e =
+    Exception e =
         assertThrows(
-            IllegalArgumentException.class,
+            Exception.class,
             () -> {
               df.write()
                   .format("bigquery")
@@ -2906,8 +2906,19 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
                   .option("temporaryGcsBucket", TestConstants.TEMPORARY_GCS_BUCKET)
                   .save(destTableName);
             });
-    assertThat(e.getMessage())
-        .contains("CDC is only supported when writeMethod is DIRECT and writeAtLeastOnce is true");
+    boolean found = false;
+    Throwable t = e;
+    while (t != null) {
+      if (t instanceof IllegalArgumentException
+          && t.getMessage()
+              .contains(
+                  "CDC is only supported when writeMethod is DIRECT and writeAtLeastOnce is true")) {
+        found = true;
+        break;
+      }
+      t = t.getCause();
+    }
+    assertThat(found).isTrue();
   }
 
   @Test
@@ -2921,9 +2932,9 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
     Dataset<Row> df =
         spark.createDataFrame(Collections.singletonList(RowFactory.create(1L, "UPSERT")), schema);
 
-    IllegalArgumentException e =
+    Exception e =
         assertThrows(
-            IllegalArgumentException.class,
+            Exception.class,
             () -> {
               df.write()
                   .format("bigquery")
@@ -2932,8 +2943,19 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
                   .option("writeAtLeastOnce", "false")
                   .save(destTableName);
             });
-    assertThat(e.getMessage())
-        .contains("CDC is only supported when writeMethod is DIRECT and writeAtLeastOnce is true");
+    boolean found = false;
+    Throwable t = e;
+    while (t != null) {
+      if (t instanceof IllegalArgumentException
+          && t.getMessage()
+              .contains(
+                  "CDC is only supported when writeMethod is DIRECT and writeAtLeastOnce is true")) {
+        found = true;
+        break;
+      }
+      t = t.getCause();
+    }
+    assertThat(found).isTrue();
   }
 
   @Test
@@ -2946,9 +2968,9 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
     Dataset<Row> df =
         spark.createDataFrame(Collections.singletonList(RowFactory.create(1L, "UPSERT")), schema);
 
-    IllegalArgumentException e =
+    Exception e =
         assertThrows(
-            IllegalArgumentException.class,
+            Exception.class,
             () -> {
               df.write()
                   .format("bigquery")
@@ -2957,7 +2979,17 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
                   .option("writeAtLeastOnce", "true")
                   .save(destTableName);
             });
-    assertThat(e.getMessage()).contains("CDC can only be written to an existing table");
+    boolean found = false;
+    Throwable t = e;
+    while (t != null) {
+      if (t instanceof IllegalArgumentException
+          && t.getMessage().contains("CDC can only be written to an existing table")) {
+        found = true;
+        break;
+      }
+      t = t.getCause();
+    }
+    assertThat(found).isTrue();
   }
 
   @Test
@@ -2967,18 +2999,26 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
     String baseTableName = testDataset + "." + "cdc_partition_decorator_test_" + System.nanoTime();
     String ddl =
         String.format(
-            "CREATE TABLE %s (id INT64, name STRING, PRIMARY KEY(id) NOT ENFORCED)", baseTableName);
+            "CREATE TABLE %s (id INT64, name STRING, partition_date DATE, PRIMARY KEY(id) NOT ENFORCED) PARTITION BY partition_date",
+            baseTableName);
     IntegrationTestUtils.runQuery(ddl);
 
     String destTableName = baseTableName + "$20230101";
     StructType schema =
-        new StructType().add("id", DataTypes.LongType).add("_CHANGE_TYPE", DataTypes.StringType);
+        new StructType()
+            .add("id", DataTypes.LongType)
+            .add("name", DataTypes.StringType)
+            .add("partition_date", DataTypes.DateType)
+            .add("_CHANGE_TYPE", DataTypes.StringType);
     Dataset<Row> df =
-        spark.createDataFrame(Collections.singletonList(RowFactory.create(1L, "UPSERT")), schema);
+        spark.createDataFrame(
+            Collections.singletonList(
+                RowFactory.create(1L, "foo", java.sql.Date.valueOf("2023-01-01"), "UPSERT")),
+            schema);
 
-    IllegalArgumentException e =
+    Exception e =
         assertThrows(
-            IllegalArgumentException.class,
+            Exception.class,
             () -> {
               df.write()
                   .format("bigquery")
@@ -2987,8 +3027,19 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
                   .option("writeAtLeastOnce", "true")
                   .save(destTableName);
             });
-    assertThat(e.getMessage())
-        .contains("CDC cannot be used with a partition decorator ($). Write to the base table.");
+    boolean found = false;
+    Throwable t = e;
+    while (t != null) {
+      if (t instanceof IllegalArgumentException
+          && t.getMessage()
+              .contains(
+                  "CDC cannot be used with a partition decorator ($). Write to the base table.")) {
+        found = true;
+        break;
+      }
+      t = t.getCause();
+    }
+    assertThat(found).isTrue();
   }
 
   @Test
@@ -3050,9 +3101,9 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
     Dataset<Row> df =
         spark.createDataFrame(Collections.singletonList(RowFactory.create(1L, "UPSERT")), schema);
 
-    IllegalArgumentException e =
+    Exception e =
         assertThrows(
-            IllegalArgumentException.class,
+            Exception.class,
             () -> {
               df.write()
                   .format("bigquery")
@@ -3061,6 +3112,16 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
                   .option("writeAtLeastOnce", "true")
                   .save(destTableName);
             });
-    assertThat(e.getMessage()).contains("CDC can only be used with SaveMode.Append");
+    boolean found = false;
+    Throwable t = e;
+    while (t != null) {
+      if (t instanceof IllegalArgumentException
+          && t.getMessage().contains("CDC can only be used with SaveMode.Append")) {
+        found = true;
+        break;
+      }
+      t = t.getCause();
+    }
+    assertThat(found).isTrue();
   }
 }

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -2838,4 +2838,229 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
   static <T> Predicate<T> not(Predicate<T> predicate) {
     return predicate.negate();
   }
+
+  @Test
+  public void testCdcAppend() throws Exception {
+    assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
+
+    String destTableName = testDataset + "." + "cdc_test_" + System.nanoTime();
+    String ddl =
+        String.format(
+            "CREATE TABLE %s (id INT64, name STRING, PRIMARY KEY(id) NOT ENFORCED)", destTableName);
+    IntegrationTestUtils.runQuery(ddl);
+
+    // Using lowercase `_change_type` to test Phase 2 case-mapping under the hood
+    StructType schema =
+        new StructType()
+            .add("id", DataTypes.LongType)
+            .add("name", DataTypes.StringType)
+            .add("_change_type", DataTypes.StringType);
+
+    List<Row> rows =
+        Arrays.asList(
+            RowFactory.create(1L, "foo", "UPSERT"), RowFactory.create(2L, "bar", "UPSERT"));
+    Dataset<Row> df = spark.createDataFrame(rows, schema);
+
+    df.write()
+        .format("bigquery")
+        .mode(SaveMode.Append)
+        .option("writeMethod", "direct")
+        .option("writeAtLeastOnce", "true")
+        .save(destTableName);
+
+    int numOfRows = testTableNumberOfRows(destTableName.split("\\.")[1]);
+    assertThat(numOfRows).isEqualTo(2);
+
+    // Send a DELETE for one of the rows
+    List<Row> rows2 = Arrays.asList(RowFactory.create(1L, "foo", "DELETE"));
+    Dataset<Row> df2 = spark.createDataFrame(rows2, schema);
+    df2.write()
+        .format("bigquery")
+        .mode(SaveMode.Append)
+        .option("writeMethod", "direct")
+        .option("writeAtLeastOnce", "true")
+        .save(destTableName);
+
+    numOfRows = testTableNumberOfRows(destTableName.split("\\.")[1]);
+    assertThat(numOfRows).isEqualTo(1);
+  }
+
+  @Test
+  public void testCdcFailsWhenIndirectWriteMethod() {
+    assumeThat(writeMethod, equalTo(WriteMethod.INDIRECT));
+
+    String destTableName = testDataset + "." + "cdc_indirect_test_" + System.nanoTime();
+    StructType schema =
+        new StructType().add("id", DataTypes.LongType).add("_CHANGE_TYPE", DataTypes.StringType);
+    Dataset<Row> df =
+        spark.createDataFrame(Collections.singletonList(RowFactory.create(1L, "UPSERT")), schema);
+
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              df.write()
+                  .format("bigquery")
+                  .mode(SaveMode.Append)
+                  .option("writeMethod", "indirect")
+                  .option("temporaryGcsBucket", TestConstants.TEMPORARY_GCS_BUCKET)
+                  .save(destTableName);
+            });
+    assertThat(e.getMessage())
+        .contains("CDC is only supported when writeMethod is DIRECT and writeAtLeastOnce is true");
+  }
+
+  @Test
+  public void testCdcFailsWhenDirectButNotAtLeastOnce() {
+    assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
+
+    String destTableName =
+        testDataset + "." + "cdc_direct_not_at_least_once_test_" + System.nanoTime();
+    StructType schema =
+        new StructType().add("id", DataTypes.LongType).add("_CHANGE_TYPE", DataTypes.StringType);
+    Dataset<Row> df =
+        spark.createDataFrame(Collections.singletonList(RowFactory.create(1L, "UPSERT")), schema);
+
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              df.write()
+                  .format("bigquery")
+                  .mode(SaveMode.Append)
+                  .option("writeMethod", "direct")
+                  .option("writeAtLeastOnce", "false")
+                  .save(destTableName);
+            });
+    assertThat(e.getMessage())
+        .contains("CDC is only supported when writeMethod is DIRECT and writeAtLeastOnce is true");
+  }
+
+  @Test
+  public void testCdcFailsWhenTableDoesNotExist() {
+    assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
+
+    String destTableName = testDataset + "." + "cdc_no_table_test_" + System.nanoTime();
+    StructType schema =
+        new StructType().add("id", DataTypes.LongType).add("_CHANGE_TYPE", DataTypes.StringType);
+    Dataset<Row> df =
+        spark.createDataFrame(Collections.singletonList(RowFactory.create(1L, "UPSERT")), schema);
+
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              df.write()
+                  .format("bigquery")
+                  .mode(SaveMode.Append)
+                  .option("writeMethod", "direct")
+                  .option("writeAtLeastOnce", "true")
+                  .save(destTableName);
+            });
+    assertThat(e.getMessage()).contains("CDC can only be written to an existing table");
+  }
+
+  @Test
+  public void testCdcFailsWithPartitionDecorator() throws Exception {
+    assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
+
+    String baseTableName = testDataset + "." + "cdc_partition_decorator_test_" + System.nanoTime();
+    String ddl =
+        String.format(
+            "CREATE TABLE %s (id INT64, name STRING, PRIMARY KEY(id) NOT ENFORCED)", baseTableName);
+    IntegrationTestUtils.runQuery(ddl);
+
+    String destTableName = baseTableName + "$20230101";
+    StructType schema =
+        new StructType().add("id", DataTypes.LongType).add("_CHANGE_TYPE", DataTypes.StringType);
+    Dataset<Row> df =
+        spark.createDataFrame(Collections.singletonList(RowFactory.create(1L, "UPSERT")), schema);
+
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              df.write()
+                  .format("bigquery")
+                  .mode(SaveMode.Append)
+                  .option("writeMethod", "direct")
+                  .option("writeAtLeastOnce", "true")
+                  .save(destTableName);
+            });
+    assertThat(e.getMessage())
+        .contains("CDC cannot be used with a partition decorator ($). Write to the base table.");
+  }
+
+  @Test
+  public void testCdcFailsWithInvalidChangeType() throws Exception {
+    assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
+
+    String destTableName = testDataset + "." + "cdc_invalid_value_test_" + System.nanoTime();
+    String ddl =
+        String.format(
+            "CREATE TABLE %s (id INT64, name STRING, PRIMARY KEY(id) NOT ENFORCED)", destTableName);
+    IntegrationTestUtils.runQuery(ddl);
+
+    StructType schema =
+        new StructType()
+            .add("id", DataTypes.LongType)
+            .add("name", DataTypes.StringType)
+            .add("_CHANGE_TYPE", DataTypes.StringType);
+    Dataset<Row> df =
+        spark.createDataFrame(
+            Collections.singletonList(RowFactory.create(1L, "foo", "INSERT")), schema);
+
+    Exception e =
+        assertThrows(
+            Exception.class,
+            () -> {
+              df.write()
+                  .format("bigquery")
+                  .mode(SaveMode.Append)
+                  .option("writeMethod", "direct")
+                  .option("writeAtLeastOnce", "true")
+                  .save(destTableName);
+            });
+
+    boolean found = false;
+    Throwable t = e;
+    while (t != null) {
+      if (t instanceof IllegalArgumentException
+          && t.getMessage().contains("CDC _CHANGE_TYPE must be UPSERT or DELETE")) {
+        found = true;
+        break;
+      }
+      t = t.getCause();
+    }
+    assertThat(found).isTrue();
+  }
+
+  @Test
+  public void testCdcFailsWithOverwrite() throws Exception {
+    assumeThat(writeMethod, equalTo(WriteMethod.DIRECT));
+
+    String destTableName = testDataset + "." + "cdc_overwrite_test_" + System.nanoTime();
+    String ddl =
+        String.format(
+            "CREATE TABLE %s (id INT64, name STRING, PRIMARY KEY(id) NOT ENFORCED)", destTableName);
+    IntegrationTestUtils.runQuery(ddl);
+
+    StructType schema =
+        new StructType().add("id", DataTypes.LongType).add("_CHANGE_TYPE", DataTypes.StringType);
+    Dataset<Row> df =
+        spark.createDataFrame(Collections.singletonList(RowFactory.create(1L, "UPSERT")), schema);
+
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              df.write()
+                  .format("bigquery")
+                  .mode(SaveMode.Overwrite)
+                  .option("writeMethod", "direct")
+                  .option("writeAtLeastOnce", "true")
+                  .save(destTableName);
+            });
+    assertThat(e.getMessage()).contains("CDC can only be used with SaveMode.Append");
+  }
 }

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/WriteIntegrationTestBase.java
@@ -80,6 +80,7 @@ import org.apache.spark.ml.feature.MinMaxScaler;
 import org.apache.spark.ml.feature.MinMaxScalerModel;
 import org.apache.spark.ml.feature.VectorAssembler;
 import org.apache.spark.ml.linalg.SQLDataTypes;
+import org.apache.spark.ml.linalg.Vector;
 import org.apache.spark.package$;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoder;
@@ -2688,8 +2689,7 @@ abstract class WriteIntegrationTestBase extends SparkBigQueryIntegrationTestBase
     List<Row> values = result.collectAsList();
     assertThat(values).hasSize(3);
     Row row = values.get(0);
-    assertThat(row.get(row.fieldIndex("features")))
-        .isInstanceOf(org.apache.spark.ml.linalg.Vector.class);
+    assertThat(row.get(row.fieldIndex("features"))).isInstanceOf(Vector.class);
   }
 
   @Test


### PR DESCRIPTION
### Description
This PR implements support for Change Data Capture (CDC) writes into BigQuery using the DIRECT write method. Change Data Capture allows applying updates (`UPSERT`) and deletes (`DELETE`) directly from a Spark DataFrame based on the `_CHANGE_TYPE` and `_CHANGE_SEQUENCE_NUMBER` pseudo-columns.

### Implemented Features:
1. **Case-Insensitive Column Normalization:** Maps any casing of `_CHANGE_TYPE` and `_CHANGE_SEQUENCE_NUMBER` in the DataFrame schema to UPPERCASE before transmitting to BigQuery, as required by the Cloud CDC specifications.
2. **Strict Validations for CDC Writes:**
   - Enforces `SaveMode.Append` (other modes like `Overwrite` are rejected).
   - Enforces `writeMethod=DIRECT` and `writeAtLeastOnce=true`.
   - Rejects writes containing partition decorators (e.g. `table$partition`), forcing writes to the base table.
   - Rejects writes if the destination table does not exist or lacks a primary key.
3. **Client-Side Row-Level Validation:** Intercepts rows in the serializer loop and fails fast if the `_CHANGE_TYPE` column is null or contains an invalid value (anything other than `UPSERT` or `DELETE`).
4. **Indirect Write Rejection:** Rejects CDC writes immediately if the `INDIRECT` write method is chosen.
5. **Integration Tests:** Added a robust test suite in `WriteIntegrationTestBase` covering CDC success and fail-fast validation scenarios.
