### PR TITLE
Centralize and unify BigQuery Job telemetry and duration logging

### DIFF
--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
@@ -24,7 +24,6 @@ import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.bigquery.Bigquery;
 import com.google.auth.http.HttpCredentialsAdapter;
-import com.google.cloud.BaseServiceException;
 import com.google.cloud.RetryOption;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryException;
@@ -162,7 +161,7 @@ public class BigQueryClient {
    *
    * @param job The {@code Job} to keep track of.
    */
-  public JobInfo waitForJob(Job job) {
+  public JobInfo waitForJob(Job job, String operation) {
     try {
       Job completedJob =
           job.waitFor(
@@ -178,6 +177,7 @@ public class BigQueryClient {
         throw new IllegalStateException(
             String.format("Job aborted due to timeout  : %s minutes", bigQueryJobTimeoutInMinutes));
       }
+      logJobTelemetry(completedJob, operation);
       jobCompletionListener.ifPresent(jcl -> jcl.accept(completedJob));
       return completedJob;
     } catch (InterruptedException e) {
@@ -553,16 +553,12 @@ public class BigQueryClient {
     return bigQuery.update(table);
   }
 
-  public Job createAndWaitFor(JobConfiguration.Builder jobConfiguration) {
-    return createAndWaitFor(jobConfiguration.build());
-  }
-
-  public Job createAndWaitFor(JobConfiguration jobConfiguration) {
+  public Job createAndWaitFor(JobConfiguration jobConfiguration, String operation) {
     JobInfo jobInfo = JobInfo.of(jobConfiguration);
     Job job = bigQuery.create(jobInfo);
-    Job returnedJob = null;
 
     log.info("Submitted job {}. jobId: {}", jobConfiguration, job.getJobId());
+
     try {
       Job completedJob = job.waitFor();
       if (completedJob == null) {
@@ -576,6 +572,7 @@ public class BigQueryClient {
             String.format(
                 "Failed to run the job [%s], due to '%s'", completedJob.getStatus().getError()));
       }
+      logJobTelemetry(completedJob, operation);
       return completedJob;
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -583,6 +580,18 @@ public class BigQueryClient {
           BaseHttpServiceException.UNKNOWN_CODE,
           String.format("Failed to run the job [%s], task was interrupted", job),
           e);
+    }
+  }
+
+  private void logJobTelemetry(Job completedJob, String operation) {
+    JobStatistics stats = completedJob.getStatistics();
+    if (stats != null && stats.getStartTime() != null && stats.getEndTime() != null) {
+      long duration = stats.getEndTime() - stats.getStartTime();
+      JobConfiguration config = completedJob.getConfiguration();
+      JobConfiguration.Type type = config != null ? config.getType() : null;
+      JobId jobId = completedJob.getJobId();
+      String jobIdStr = jobId != null ? jobId.getJob() : "unknown";
+      log.info("BigQuery {} job {} ({}) completed in {}ms", type, jobIdStr, operation, duration);
     }
   }
 
@@ -955,7 +964,7 @@ public class BigQueryClient {
 
     Job finishedJob = null;
     try {
-      finishedJob = createAndWaitFor(jobConfiguration);
+      finishedJob = createAndWaitFor(jobConfiguration.build(), "Load Data from GCS to Table");
 
       if (finishedJob.getStatus().getError() != null) {
         throw new BigQueryException(
@@ -1218,7 +1227,8 @@ public class BigQueryClient {
       JobInfo jobInfo = JobInfo.of(queryJobConfigurationBuilder.build());
 
       log.info("running query [{}]", querySql);
-      JobInfo completedJobInfo = bigQueryClient.waitForJob(bigQueryClient.create(jobInfo));
+      JobInfo completedJobInfo =
+          bigQueryClient.waitForJob(bigQueryClient.create(jobInfo), "Materialize Query to Table");
       if (completedJobInfo.getStatus().getError() != null) {
         throw BigQueryUtil.convertToBigQueryException(completedJobInfo.getStatus().getError());
       }
@@ -1237,31 +1247,6 @@ public class BigQueryClient {
       // temp table was auto generated
       return bigQueryClient.getTable(
           ((QueryJobConfiguration) completedJobInfo.getConfiguration()).getDestinationTable());
-    }
-
-    Job waitForJob(Job job) {
-      try {
-        log.info(
-            "Job submitted : {}, {},  Job type : {}",
-            job.getJobId(),
-            job.getSelfLink(),
-            job.getConfiguration().getType());
-        Job completedJob = job.waitFor();
-        log.info(
-            "Job has finished {} creationTime : {}, startTime : {}, endTime : {} ",
-            completedJob.getJobId(),
-            completedJob.getStatistics().getCreationTime(),
-            completedJob.getStatistics().getStartTime(),
-            completedJob.getStatistics().getEndTime());
-        log.debug("Job has finished. {}", completedJob);
-        return completedJob;
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        throw new BigQueryException(
-            BaseServiceException.UNKNOWN_CODE,
-            String.format("Job %s has been interrupted", job.getJobId()),
-            e);
-      }
     }
   }
 

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryClient.java
@@ -161,7 +161,7 @@ public class BigQueryClient {
    *
    * @param job The {@code Job} to keep track of.
    */
-  public JobInfo waitForJob(Job job, String operation) {
+  public JobInfo waitForJob(Job job, JobOperation operation) {
     try {
       Job completedJob =
           job.waitFor(
@@ -553,7 +553,7 @@ public class BigQueryClient {
     return bigQuery.update(table);
   }
 
-  public Job createAndWaitFor(JobConfiguration jobConfiguration, String operation) {
+  public Job createAndWaitFor(JobConfiguration jobConfiguration, JobOperation operation) {
     JobInfo jobInfo = JobInfo.of(jobConfiguration);
     Job job = bigQuery.create(jobInfo);
 
@@ -583,7 +583,10 @@ public class BigQueryClient {
     }
   }
 
-  private void logJobTelemetry(Job completedJob, String operation) {
+  private void logJobTelemetry(Job completedJob, JobOperation operation) {
+    if (completedJob == null) {
+      return;
+    }
     JobStatistics stats = completedJob.getStatistics();
     if (stats != null && stats.getStartTime() != null && stats.getEndTime() != null) {
       long duration = stats.getEndTime() - stats.getStartTime();
@@ -591,7 +594,12 @@ public class BigQueryClient {
       JobConfiguration.Type type = config != null ? config.getType() : null;
       JobId jobId = completedJob.getJobId();
       String jobIdStr = jobId != null ? jobId.getJob() : "unknown";
-      log.info("BigQuery {} job {} ({}) completed in {}ms", type, jobIdStr, operation, duration);
+      log.info(
+          "BigQuery {} job {} ({}) completed in {}ms",
+          type,
+          jobIdStr,
+          operation.getDescription(),
+          duration);
     }
   }
 
@@ -964,7 +972,7 @@ public class BigQueryClient {
 
     Job finishedJob = null;
     try {
-      finishedJob = createAndWaitFor(jobConfiguration.build(), "Load Data from GCS to Table");
+      finishedJob = createAndWaitFor(jobConfiguration.build(), JobOperation.LOAD_DATA_FROM_GCS);
 
       if (finishedJob.getStatus().getError() != null) {
         throw new BigQueryException(
@@ -1228,7 +1236,7 @@ public class BigQueryClient {
 
       log.info("running query [{}]", querySql);
       JobInfo completedJobInfo =
-          bigQueryClient.waitForJob(bigQueryClient.create(jobInfo), "Materialize Query to Table");
+          bigQueryClient.waitForJob(bigQueryClient.create(jobInfo), JobOperation.MATERIALIZE_QUERY);
       if (completedJobInfo.getStatus().getError() != null) {
         throw BigQueryUtil.convertToBigQueryException(completedJobInfo.getStatus().getError());
       }

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/JobOperation.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/JobOperation.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigquery.connector.common;
+
+/**
+ * Enum representing different BigQuery job operations tracked by the connector. Used for telemetry
+ * and logging purposes.
+ */
+public enum JobOperation {
+  /** Operation for loading data from GCS to a BigQuery table. */
+  LOAD_DATA_FROM_GCS("Load Data from GCS to Table"),
+  /** Operation for materializing a query result into a BigQuery table. */
+  MATERIALIZE_QUERY("Materialize Query to Table"),
+  /** Operation for committing an overwrite transaction. */
+  OVERWRITE_TRANSACTION("Overwrite Transaction Commit"),
+  /** Operation for committing an append transaction. */
+  APPEND_TRANSACTION("Append Transaction Commit"),
+  /** Operation for committing a dynamic partition overwrite. */
+  DYNAMIC_PARTITION_OVERWRITE("Dynamic Partition Overwrite Commit");
+
+  private final String description;
+
+  JobOperation(String description) {
+    this.description = description;
+  }
+
+  /**
+   * Returns the user-friendly description of the job operation.
+   *
+   * @return the description of the operation
+   */
+  public String getDescription() {
+    return description;
+  }
+}

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/BigQueryWriteHelper.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/BigQueryWriteHelper.java
@@ -146,16 +146,10 @@ public class BigQueryWriteHelper {
                         config.getEnableModeCheckForSchemaFields())
                     .getTableId());
         loadDataToBigQuery();
-        long startTime = System.currentTimeMillis();
         Job queryJob =
             bigQueryClient.overwriteDestinationWithTemporaryDynamicPartitons(
                 temporaryTableId.get(), config.getTableId());
-        bigQueryClient.waitForJob(queryJob);
-        long duration = System.currentTimeMillis() - startTime;
-        logger.info(
-            "Overwrote destination with temporary dynamic partitions in {}ms. JobId: {}",
-            duration,
-            queryJob.getJobId().getJob());
+        bigQueryClient.waitForJob(queryJob, "Dynamic Partition Overwrite Commit");
       } else {
         loadDataToBigQuery();
       }

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/BigQueryWriteHelper.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/BigQueryWriteHelper.java
@@ -27,6 +27,7 @@ import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.connector.common.BigQueryClient;
 import com.google.cloud.bigquery.connector.common.BigQueryConnectorException;
 import com.google.cloud.bigquery.connector.common.BigQueryUtil;
+import com.google.cloud.bigquery.connector.common.JobOperation;
 import com.google.cloud.spark.bigquery.PartitionOverwriteMode;
 import com.google.cloud.spark.bigquery.SchemaConverters;
 import com.google.cloud.spark.bigquery.SchemaConvertersConfiguration;
@@ -149,7 +150,7 @@ public class BigQueryWriteHelper {
         Job queryJob =
             bigQueryClient.overwriteDestinationWithTemporaryDynamicPartitons(
                 temporaryTableId.get(), config.getTableId());
-        bigQueryClient.waitForJob(queryJob, "Dynamic Partition Overwrite Commit");
+        bigQueryClient.waitForJob(queryJob, JobOperation.DYNAMIC_PARTITION_OVERWRITE);
       } else {
         loadDataToBigQuery();
       }

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
@@ -28,6 +28,7 @@ import com.google.cloud.bigquery.connector.common.BigQueryClientFactory;
 import com.google.cloud.bigquery.connector.common.BigQueryConnectorException;
 import com.google.cloud.bigquery.connector.common.BigQueryUtil;
 import com.google.cloud.bigquery.connector.common.ComparisonResult;
+import com.google.cloud.bigquery.connector.common.JobOperation;
 import com.google.cloud.bigquery.storage.v1.BatchCommitWriteStreamsRequest;
 import com.google.cloud.bigquery.storage.v1.BatchCommitWriteStreamsResponse;
 import com.google.cloud.bigquery.storage.v1.BigQueryWriteClient;
@@ -356,8 +357,8 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
       bigQueryClient.waitForJob(
           queryJob,
           writingMode == WritingMode.OVERWRITE
-              ? "Overwrite Transaction Commit"
-              : "Append Transaction Commit");
+              ? JobOperation.OVERWRITE_TRANSACTION
+              : JobOperation.APPEND_TRANSACTION);
       Preconditions.checkState(
           bigQueryClient.deleteTable(tableToWrite.getTableId()),
           new BigQueryConnectorException(

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryDirectDataSourceWriterContext.java
@@ -343,11 +343,9 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
           batchCommitWriteStreamsResponse.getCommitTime());
     }
 
-    if (writingMode.equals(WritingMode.APPEND_AT_LEAST_ONCE)
-        || writingMode.equals(WritingMode.OVERWRITE)) {
-      long startTime = System.currentTimeMillis();
+    if (writingMode == WritingMode.APPEND_AT_LEAST_ONCE || writingMode == WritingMode.OVERWRITE) {
       Job queryJob =
-          (writingMode.equals(WritingMode.OVERWRITE))
+          (writingMode == WritingMode.OVERWRITE)
               ? overwriteMode == PartitionOverwriteMode.STATIC
                   ? bigQueryClient.overwriteDestinationWithTemporary(
                       tableToWrite.getTableId(), destinationTableId)
@@ -355,12 +353,11 @@ public class BigQueryDirectDataSourceWriterContext implements DataSourceWriterCo
                       tableToWrite.getTableId(), destinationTableId)
               : bigQueryClient.appendDestinationWithTemporary(
                   tableToWrite.getTableId(), destinationTableId);
-      bigQueryClient.waitForJob(queryJob);
-      long duration = System.currentTimeMillis() - startTime;
-      logger.info(
-          "Copied temporary table to destination in {}ms. JobId: {}",
-          duration,
-          queryJob.getJobId().getJob());
+      bigQueryClient.waitForJob(
+          queryJob,
+          writingMode == WritingMode.OVERWRITE
+              ? "Overwrite Transaction Commit"
+              : "Append Transaction Commit");
       Preconditions.checkState(
           bigQueryClient.deleteTable(tableToWrite.getTableId()),
           new BigQueryConnectorException(

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryIndirectDataSourceWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryIndirectDataSourceWriterContext.java
@@ -185,16 +185,10 @@ public class BigQueryIndirectDataSourceWriterContext implements DataSourceWriter
                         config.getTableId(), schema, config.getEnableModeCheckForSchemaFields())
                     .getTableId());
         loadDataToBigQuery(sourceUris, schema);
-        long startTime = System.currentTimeMillis();
         Job queryJob =
             bigQueryClient.overwriteDestinationWithTemporaryDynamicPartitons(
                 temporaryTableId.get(), config.getTableId());
-        bigQueryClient.waitForJob(queryJob);
-        long duration = System.currentTimeMillis() - startTime;
-        logger.info(
-            "Overwrote destination with temporary dynamic partitions in {}ms. JobId: {}",
-            duration,
-            queryJob.getJobId().getJob());
+        bigQueryClient.waitForJob(queryJob, "Dynamic Partition Overwrite Commit");
       } else {
         loadDataToBigQuery(sourceUris, schema);
       }
@@ -206,7 +200,6 @@ public class BigQueryIndirectDataSourceWriterContext implements DataSourceWriter
     } finally {
       cleanTemporaryGcsPathIfNeeded(epochId);
     }
-    logger.info("Data has been successfully loaded to BigQuery");
   }
 
   void loadDataToBigQuery(List<String> sourceUris, Schema schema) throws IOException {

--- a/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryIndirectDataSourceWriterContext.java
+++ b/spark-bigquery-connector-common/src/main/java/com/google/cloud/spark/bigquery/write/context/BigQueryIndirectDataSourceWriterContext.java
@@ -24,6 +24,7 @@ import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.connector.common.BigQueryClient;
 import com.google.cloud.bigquery.connector.common.BigQueryUtil;
+import com.google.cloud.bigquery.connector.common.JobOperation;
 import com.google.cloud.spark.bigquery.AvroSchemaConverter;
 import com.google.cloud.spark.bigquery.PartitionOverwriteMode;
 import com.google.cloud.spark.bigquery.SchemaConverters;
@@ -188,7 +189,7 @@ public class BigQueryIndirectDataSourceWriterContext implements DataSourceWriter
         Job queryJob =
             bigQueryClient.overwriteDestinationWithTemporaryDynamicPartitons(
                 temporaryTableId.get(), config.getTableId());
-        bigQueryClient.waitForJob(queryJob, "Dynamic Partition Overwrite Commit");
+        bigQueryClient.waitForJob(queryJob, JobOperation.DYNAMIC_PARTITION_OVERWRITE);
       } else {
         loadDataToBigQuery(sourceUris, schema);
       }


### PR DESCRIPTION
  ### Overview

This PR restructures how the Spark BigQuery Connector logs asynchronous job operations (Loads, Queries, Appends, Direct/Indirect Partitions). Previously, duration and completion logging was scattered, sometimes duplicated, or relied on localized client-side  System.currentTimeMillis()  implementations.

This change introduces a unified "choke point" by instrumenting the foundational wait wrappers in  BigQueryClient.java  to guarantee 100% coverage of all async operations while extracting exact cluster-side timing statistics.

  ### Key Changes
• Centralized Telemetry Injection: Modified the foundational  createAndWaitFor  and  waitForJob  methods in  BigQueryClient.java  to mandate a  String operation  identifier. Injected a  logJobTelemetry private method that polls the exact  completedJob.getStatistics().getStartTime()  &  getEndTime()  to log uniformly: BigQuery {type} job {jobId} ({operation}) completed in {duration}ms 
• Comprehensive Operation Tagging: Formally mapped all upwards callers to unambiguous strings:
      •  "Load Data from GCS to Table" 
      •  "Materialize Query to Table" 
      •  "Dynamic Partition Overwrite Commit" 
      •  "Overwrite Transaction Commit" 
      •  "Append Transaction Commit" 
      •  "Direct Query Execution" 
• Redundant Code Removal: Completely stripped the localized explicit  System.currentTimeMillis()  blocking logic that was previously implemented in the Writer Contexts since it is now natively superseded by the base wrapper.
• Stub Purging: Cleaned up the file architecture by purging completely unused legacy stubs, including the 1-arg  Job waitForJob(Job job)  and  Job createAndWaitFor(JobConfiguration.Builder) , alongside removing the now-unused  BaseServiceException  import.
