### PR TITLE
Preserve detailed row errors from failed direct writes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Next
 
 * PR #1494: Added Support for Change Data Capture (CDC)
+* Issue #1501: Preserved detailed row errors from failed direct writes
 
 ## 0.44.2 - 2026-05-20
 

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
@@ -67,7 +67,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -101,6 +100,12 @@ public class BigQueryUtil {
           "Received unexpected EOS on DATA frame from server");
 
   static final String READ_SESSION_EXPIRED_ERROR_MESSAGE = "session expired at";
+
+  private static final int MAX_APPEND_ROW_ERRORS_IN_MESSAGE = 100;
+  // Java serialization uses modified UTF-8 for strings; this also bounds standard UTF-8 logs.
+  private static final int MAX_APPEND_ROW_ERRORS_SECTION_BYTES = 64 * 1024;
+  private static final String APPEND_ROW_ERRORS_PREFIX = "row errors (append request indexes): ";
+  private static final String ROW_ERROR_TEXT_TRUNCATED_SUFFIX = " [row error text truncated]";
 
   private static final String TARGET_ALIAS =
       "__target_" + UUID.randomUUID().toString().replace("-", "");
@@ -184,10 +189,8 @@ public class BigQueryUtil {
       Map<Integer, String> rowErrors = appendSerializationError.getRowIndexToErrorMessage();
       message =
           format(
-              "%s; write stream: %s; row errors (append request indexes): %s",
-              message,
-              appendSerializationError.getStreamName(),
-              new TreeMap<>(rowErrors == null ? Collections.emptyMap() : rowErrors));
+              "%s; write stream: %s; %s",
+              message, appendSerializationError.getStreamName(), formatAppendRowErrors(rowErrors));
     }
     Status status;
     if (grpcException instanceof StatusException) {
@@ -209,6 +212,110 @@ public class BigQueryUtil {
     serializable.setStackTrace(grpcException.getStackTrace());
 
     return serializable;
+  }
+
+  private static String formatAppendRowErrors(@Nullable Map<Integer, String> rowErrors) {
+    if (rowErrors == null || rowErrors.isEmpty()) {
+      return APPEND_ROW_ERRORS_PREFIX + "{}";
+    }
+
+    TreeMap<Integer, String> lowestRowErrors = new TreeMap<>();
+    int totalRowErrorCount = 0;
+    for (Map.Entry<Integer, String> rowError : rowErrors.entrySet()) {
+      totalRowErrorCount++;
+      lowestRowErrors.put(rowError.getKey(), rowError.getValue());
+      if (lowestRowErrors.size() > MAX_APPEND_ROW_ERRORS_IN_MESSAGE) {
+        lowestRowErrors.pollLastEntry();
+      }
+    }
+
+    String maximumSuffix =
+        ROW_ERROR_TEXT_TRUNCATED_SUFFIX
+            + formatAdditionalRowErrorsOmittedSuffix(totalRowErrorCount);
+    int entriesByteLimit =
+        MAX_APPEND_ROW_ERRORS_SECTION_BYTES - modifiedUtf8Length(maximumSuffix) - 1;
+    StringBuilder formattedRowErrors = new StringBuilder(APPEND_ROW_ERRORS_PREFIX).append('{');
+    int formattedByteCount = modifiedUtf8Length(APPEND_ROW_ERRORS_PREFIX) + 1;
+    int formattedRowErrorCount = 0;
+    boolean rowErrorTextTruncated = false;
+
+    for (Map.Entry<Integer, String> rowError : lowestRowErrors.entrySet()) {
+      String separator = formattedRowErrorCount == 0 ? "" : ", ";
+      String rowErrorPrefix = separator + rowError.getKey() + "=";
+      int rowErrorPrefixByteCount = modifiedUtf8Length(rowErrorPrefix);
+      int remainingValueBytes = entriesByteLimit - formattedByteCount - rowErrorPrefixByteCount;
+      if (remainingValueBytes < 0) {
+        break;
+      }
+
+      formattedRowErrors.append(rowErrorPrefix);
+      formattedByteCount += rowErrorPrefixByteCount;
+      String rowErrorMessage = String.valueOf(rowError.getValue());
+      int originalLength = formattedRowErrors.length();
+      formattedByteCount +=
+          appendModifiedUtf8Prefix(formattedRowErrors, rowErrorMessage, remainingValueBytes);
+      formattedRowErrorCount++;
+      if (formattedRowErrors.length() - originalLength < rowErrorMessage.length()) {
+        rowErrorTextTruncated = true;
+        break;
+      }
+    }
+
+    formattedRowErrors.append('}');
+    if (rowErrorTextTruncated) {
+      formattedRowErrors.append(ROW_ERROR_TEXT_TRUNCATED_SUFFIX);
+    }
+    formattedRowErrors.append(
+        formatAdditionalRowErrorsOmittedSuffix(totalRowErrorCount - formattedRowErrorCount));
+    return formattedRowErrors.toString();
+  }
+
+  private static String formatAdditionalRowErrorsOmittedSuffix(int count) {
+    if (count == 0) {
+      return "";
+    }
+    return format(" [%d additional row error%s omitted]", count, count == 1 ? "" : "s");
+  }
+
+  private static int appendModifiedUtf8Prefix(
+      StringBuilder target, String value, int maximumBytes) {
+    int byteCount = 0;
+    int characterCount = 0;
+    while (characterCount < value.length()) {
+      char current = value.charAt(characterCount);
+      int currentCharacterCount =
+          Character.isHighSurrogate(current)
+                  && characterCount + 1 < value.length()
+                  && Character.isLowSurrogate(value.charAt(characterCount + 1))
+              ? 2
+              : 1;
+      int currentByteCount = modifiedUtf8Length(current);
+      if (currentCharacterCount == 2) {
+        currentByteCount += modifiedUtf8Length(value.charAt(characterCount + 1));
+      }
+      if (byteCount + currentByteCount > maximumBytes) {
+        break;
+      }
+      byteCount += currentByteCount;
+      characterCount += currentCharacterCount;
+    }
+    target.append(value, 0, characterCount);
+    return byteCount;
+  }
+
+  private static int modifiedUtf8Length(String value) {
+    int byteCount = 0;
+    for (int index = 0; index < value.length(); index++) {
+      byteCount += modifiedUtf8Length(value.charAt(index));
+    }
+    return byteCount;
+  }
+
+  private static int modifiedUtf8Length(char value) {
+    if (value >= 0x0001 && value <= 0x007f) {
+      return 1;
+    }
+    return value <= 0x07ff ? 2 : 3;
   }
 
   static BigQueryException convertToBigQueryException(BigQueryError error) {

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryUtil.java
@@ -43,6 +43,7 @@ import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TableResult;
 import com.google.cloud.bigquery.TimePartitioning;
+import com.google.cloud.bigquery.storage.v1.Exceptions.AppendSerializationError;
 import com.google.cloud.bigquery.storage.v1.ReadSession;
 import com.google.cloud.bigquery.storage.v1.ReadStream;
 import com.google.common.annotations.VisibleForTesting;
@@ -66,6 +67,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -177,6 +179,16 @@ public class BigQueryUtil {
   private static SerializableGrpcStatusException createSerializableGrpcStatusException(
       Throwable grpcException) {
     String message = grpcException.getMessage();
+    if (grpcException instanceof AppendSerializationError) {
+      AppendSerializationError appendSerializationError = (AppendSerializationError) grpcException;
+      Map<Integer, String> rowErrors = appendSerializationError.getRowIndexToErrorMessage();
+      message =
+          format(
+              "%s; write stream: %s; row errors (append request indexes): %s",
+              message,
+              appendSerializationError.getStreamName(),
+              new TreeMap<>(rowErrors == null ? Collections.emptyMap() : rowErrors));
+    }
     Status status;
     if (grpcException instanceof StatusException) {
       status = ((StatusException) grpcException).getStatus();

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryUtilTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryUtilTest.java
@@ -51,7 +51,12 @@ import com.google.cloud.bigquery.storage.v1.Exceptions.AppendSerializationError;
 import com.google.cloud.bigquery.storage.v1.ReadSession;
 import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions;
 import com.google.cloud.bigquery.storage.v1.ReadStream;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamConstants;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Arrays;
@@ -62,6 +67,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -75,6 +81,24 @@ public class BigQueryUtilTest {
       TableId.of("test.org:test-project", "test_dataset", "test_table");
   private static final String FULLY_QUALIFIED_TABLE =
       "test.org:test-project.test_dataset.test_table";
+
+  private static int serializedStringPayloadSize(String value) throws IOException {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(value);
+    }
+    byte[] serialized = bytes.toByteArray();
+    byte typeCode = serialized[2 * Short.BYTES];
+    int lengthBytes;
+    if (typeCode == ObjectStreamConstants.TC_STRING) {
+      lengthBytes = Short.BYTES;
+    } else if (typeCode == ObjectStreamConstants.TC_LONGSTRING) {
+      lengthBytes = Long.BYTES;
+    } else {
+      throw new AssertionError("Expected a serialized String type code");
+    }
+    return serialized.length - (2 * Short.BYTES) - 1 - lengthBytes;
+  }
 
   private static void checkFailureMessage(ComparisonResult result, String message) {
     assertThat(result.valuesAreEqual()).isFalse();
@@ -1590,26 +1614,88 @@ public class BigQueryUtilTest {
     assertThat(serializable.getStatusDescription()).isEqualTo(statusDescription);
     assertThat(serializable.getMessage()).contains("write stream: " + writeStream);
     assertThat(serializable.getMessage())
-        .contains("row errors (append request indexes): {0=first row failed, 2=second row failed}");
+        .endsWith("row errors (append request indexes): {0=first row failed, 2=second row failed}");
     assertThat(serializable.toString()).contains("first row failed");
+  }
+
+  @Test
+  public void testMakeSerializable_withMoreThanMaximumRowErrors() {
+    List<Integer> rowIndexes = IntStream.range(0, 102).boxed().collect(Collectors.toList());
+    Collections.shuffle(rowIndexes, new Random(1501L));
+    Map<Integer, String> rowErrors = new LinkedHashMap<>();
+    rowIndexes.forEach(index -> rowErrors.put(index, "row error " + index));
+    AppendSerializationError appendSerializationError =
+        new AppendSerializationError(
+            io.grpc.Status.Code.INVALID_ARGUMENT.value(),
+            "Errors found while processing rows",
+            "projects/test/datasets/test/tables/test/streams/test",
+            rowErrors);
+
+    Throwable result =
+        BigQueryUtil.verifySerialization(BigQueryUtil.makeSerializable(appendSerializationError));
+
+    String expectedRowErrors =
+        IntStream.range(0, 100)
+            .mapToObj(index -> index + "=row error " + index)
+            .collect(Collectors.joining(", ", "{", "}"));
+    assertThat(result.getMessage())
+        .endsWith(
+            "row errors (append request indexes): "
+                + expectedRowErrors
+                + " [2 additional row errors omitted]");
+    assertThat(result.getMessage()).doesNotContain("100=row error 100");
+    assertThat(result.getMessage()).doesNotContain("101=row error 101");
+  }
+
+  @Test
+  public void testMakeSerializable_withOversizedRowErrorMessage() throws IOException {
+    Map<Integer, String> rowErrors = new LinkedHashMap<>();
+    rowErrors.put(0, Strings.repeat("\uD83D\uDE80", 20 * 1024));
+    rowErrors.put(1, "second row failed");
+    AppendSerializationError appendSerializationError =
+        new AppendSerializationError(
+            io.grpc.Status.Code.INVALID_ARGUMENT.value(),
+            "Errors found while processing rows",
+            "projects/test/datasets/test/tables/test/streams/test",
+            rowErrors);
+
+    Throwable result =
+        BigQueryUtil.verifySerialization(BigQueryUtil.makeSerializable(appendSerializationError));
+
+    String rowErrorsPrefix = "row errors (append request indexes): ";
+    String message = result.getMessage();
+    String rowErrorsSection = message.substring(message.indexOf(rowErrorsPrefix));
+    int serializedPayloadSize = serializedStringPayloadSize(rowErrorsSection);
+    assertThat(serializedPayloadSize).isAtLeast(63 * 1024);
+    assertThat(serializedPayloadSize).isAtMost(64 * 1024);
+    assertThat(rowErrorsSection).startsWith(rowErrorsPrefix + "{0=");
+    assertThat(rowErrorsSection)
+        .endsWith("} [row error text truncated] [1 additional row error omitted]");
+    assertThat(rowErrorsSection).doesNotContain("1=second row failed");
+    assertThat(Character.isLowSurrogate(rowErrorsSection.charAt(rowErrorsSection.indexOf('}') - 1)))
+        .isTrue();
   }
 
   @Test
   public void testMakeSerializable_withAppendSerializationErrorWithoutRowErrors() {
     String statusDescription = "Errors found while processing rows";
-    AppendSerializationError appendSerializationError =
-        new AppendSerializationError(
-            io.grpc.Status.Code.INVALID_ARGUMENT.value(),
-            statusDescription,
-            "projects/test/datasets/test/tables/test/streams/test",
-            Collections.emptyMap());
+    List<Map<Integer, String>> noRowErrors =
+        Arrays.asList(null, Collections.<Integer, String>emptyMap());
+    for (Map<Integer, String> rowErrors : noRowErrors) {
+      AppendSerializationError appendSerializationError =
+          new AppendSerializationError(
+              io.grpc.Status.Code.INVALID_ARGUMENT.value(),
+              statusDescription,
+              "projects/test/datasets/test/tables/test/streams/test",
+              rowErrors);
 
-    Throwable result =
-        BigQueryUtil.verifySerialization(BigQueryUtil.makeSerializable(appendSerializationError));
+      Throwable result =
+          BigQueryUtil.verifySerialization(BigQueryUtil.makeSerializable(appendSerializationError));
 
-    assertThat(result).isInstanceOf(SerializableGrpcStatusException.class);
-    assertThat(result.getMessage())
-        .contains("write stream: " + appendSerializationError.getStreamName());
-    assertThat(result.getMessage()).contains("row errors (append request indexes): {}");
+      assertThat(result).isInstanceOf(SerializableGrpcStatusException.class);
+      assertThat(result.getMessage())
+          .contains("write stream: " + appendSerializationError.getStreamName());
+      assertThat(result.getMessage()).endsWith("row errors (append request indexes): {}");
+    }
   }
 }

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryUtilTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryUtilTest.java
@@ -47,6 +47,7 @@ import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TableResult;
 import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.bigquery.ViewDefinition;
+import com.google.cloud.bigquery.storage.v1.Exceptions.AppendSerializationError;
 import com.google.cloud.bigquery.storage.v1.ReadSession;
 import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions;
 import com.google.cloud.bigquery.storage.v1.ReadStream;
@@ -57,9 +58,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -1557,5 +1560,56 @@ public class BigQueryUtilTest {
 
     SerializableGrpcStatusException serializable = (SerializableGrpcStatusException) result;
     assertThat(serializable.getCauseMessage()).isEqualTo(rootCause.toString());
+  }
+
+  @Test
+  public void testMakeSerializable_withAppendSerializationError() {
+    String statusDescription = "Errors found while processing rows";
+    String writeStream = "projects/test/datasets/test/tables/test/streams/test";
+    Map<Integer, String> rowErrors = new LinkedHashMap<>();
+    rowErrors.put(2, "second row failed");
+    rowErrors.put(0, "first row failed");
+    AppendSerializationError appendSerializationError =
+        new AppendSerializationError(
+            io.grpc.Status.Code.INVALID_ARGUMENT.value(),
+            statusDescription,
+            writeStream,
+            rowErrors);
+    BigQueryConnectorException connectorException =
+        new BigQueryConnectorException(
+            "Execution Exception while retrieving AppendRowsResponse",
+            new ExecutionException(appendSerializationError));
+
+    Throwable result =
+        BigQueryUtil.verifySerialization(BigQueryUtil.makeSerializable(connectorException));
+
+    assertThat(result).isInstanceOf(SerializableGrpcStatusException.class);
+    assertThat(result.getCause()).isNull();
+    SerializableGrpcStatusException serializable = (SerializableGrpcStatusException) result;
+    assertThat(serializable.getStatusCode()).isEqualTo(io.grpc.Status.Code.INVALID_ARGUMENT);
+    assertThat(serializable.getStatusDescription()).isEqualTo(statusDescription);
+    assertThat(serializable.getMessage()).contains("write stream: " + writeStream);
+    assertThat(serializable.getMessage())
+        .contains("row errors (append request indexes): {0=first row failed, 2=second row failed}");
+    assertThat(serializable.toString()).contains("first row failed");
+  }
+
+  @Test
+  public void testMakeSerializable_withAppendSerializationErrorWithoutRowErrors() {
+    String statusDescription = "Errors found while processing rows";
+    AppendSerializationError appendSerializationError =
+        new AppendSerializationError(
+            io.grpc.Status.Code.INVALID_ARGUMENT.value(),
+            statusDescription,
+            "projects/test/datasets/test/tables/test/streams/test",
+            Collections.emptyMap());
+
+    Throwable result =
+        BigQueryUtil.verifySerialization(BigQueryUtil.makeSerializable(appendSerializationError));
+
+    assertThat(result).isInstanceOf(SerializableGrpcStatusException.class);
+    assertThat(result.getMessage())
+        .contains("write stream: " + appendSerializationError.getStreamName());
+    assertThat(result.getMessage()).contains("row errors (append request indexes): {}");
   }
 }

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/write/DataSourceWriterContextPartitionHandlerTest.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/write/DataSourceWriterContextPartitionHandlerTest.java
@@ -25,14 +25,21 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.cloud.bigquery.connector.common.BigQueryConnectorException;
+import com.google.cloud.bigquery.connector.common.BigQueryUtil;
+import com.google.cloud.bigquery.connector.common.SerializableGrpcStatusException;
+import com.google.cloud.bigquery.storage.v1.Exceptions.AppendSerializationError;
 import com.google.cloud.spark.bigquery.write.context.DataWriterContext;
 import com.google.cloud.spark.bigquery.write.context.DataWriterContextFactory;
 import com.google.cloud.spark.bigquery.write.context.WriterCommitMessageContext;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Streams;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -93,5 +100,37 @@ public class DataSourceWriterContextPartitionHandlerTest {
         Streams.stream(resultIterator).collect(Collectors.toList());
     assertThat(result).hasSize(1);
     assertThat(result.get(0).getError().isPresent()).isTrue();
+  }
+
+  @Test
+  public void testAppendSerializationErrorIsSerializableWithRowDetails() throws Exception {
+    String rowError = "partition date is outside the allowed bounds";
+    AppendSerializationError appendSerializationError =
+        new AppendSerializationError(
+            io.grpc.Status.Code.INVALID_ARGUMENT.value(),
+            "Errors found while processing rows",
+            "projects/test/datasets/test/tables/test/streams/test",
+            ImmutableMap.of(0, rowError));
+    BigQueryConnectorException connectorException =
+        new BigQueryConnectorException(
+            "Execution Exception while retrieving AppendRowsResponse",
+            new ExecutionException(appendSerializationError));
+    DataWriterContext dataWriterContext = mock(DataWriterContext.class);
+    when(dataWriterContext.commit()).thenThrow(connectorException);
+    DataWriterContextFactory dataWriterContextFactory = mock(DataWriterContextFactory.class);
+    when(dataWriterContextFactory.createDataWriterContext(any(Integer.class), anyLong(), anyLong()))
+        .thenReturn(dataWriterContext);
+    DataSourceWriterContextPartitionHandler handler =
+        new DataSourceWriterContextPartitionHandler(dataWriterContextFactory, EPOCH);
+
+    Iterator<WriterCommitMessageContext> resultIterator =
+        handler.call(0, Collections.<Row>emptyList().iterator());
+    WriterCommitMessageContext result = BigQueryUtil.verifySerialization(resultIterator.next());
+
+    verify(dataWriterContext).abort();
+    assertThat(resultIterator.hasNext()).isFalse();
+    assertThat(result.getError().isPresent()).isTrue();
+    assertThat(result.getError().get()).isInstanceOf(SerializableGrpcStatusException.class);
+    assertThat(result.getError().get().getMessage()).contains(rowError);
   }
 }


### PR DESCRIPTION
## Summary

- Preserve the write stream and per-row diagnostics from `AppendSerializationError`.
- Keep the serialized `SerializableGrpcStatusException` schema unchanged.
- Add regression coverage for exception serialization and the Spark partition-handler boundary.

## Root cause

`BigQueryUtil.makeSerializable()` converted `AppendSerializationError` into a generic serializable gRPC exception, discarding its stream name and row-indexed error messages.

## Testing

- Full `bigquery-connector-common` suite: 183 tests passed
- Full `spark-bigquery-connector-common` suite: 232 tests passed
- Spotless, Checkstyle, PMD, and `git diff --check` passed

Fixes #1501