### PR TITLE
Implement AccessTokenProvider to automatically refresh token for WIF

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -1460,6 +1460,15 @@ spark.conf.set("credentials", "<SERVICE_ACCOUNT_JSON_IN_BASE64>")
 // Per read/Write
 spark.read.format("bigquery").option("credentials", "<SERVICE_ACCOUNT_JSON_IN_BASE64>")
 ```
+* For Workload Identity Federation (WIF) or external account key files requiring dynamic token refresh across Spark executors, set `gcpAccessTokenProviderConfig` to the path of your credentials JSON file:
+```
+// Globally
+spark.conf.set("gcpAccessTokenProviderConfig", "</path/to/credentials.json>")
+// Per read/Write
+spark.read.format("bigquery").option("gcpAccessTokenProviderConfig", "</path/to/credentials.json>")
+```
+  When `gcpAccessTokenProviderConfig` is set, `gcpAccessTokenProvider` automatically defaults to `com.google.cloud.bigquery.connector.common.FileCredentialsAccessTokenProvider`. This ensures credentials are 100% serializable across Spark executors (preventing `NotSerializableException` in direct write mode) while dynamically refreshing OAuth tokens for jobs running longer than 1 hour.
+
 * In cases where the user has an internal service providing the Google AccessToken, a custom implementation
   can be done, creating only the AccessToken and providing its TTL. Token refresh will re-generate a new token. In order
   to use this, implement the

--- a/README.md
+++ b/README.md
@@ -1433,6 +1433,15 @@ spark.conf.set("credentials", "<SERVICE_ACCOUNT_JSON_IN_BASE64>")
 // Per read/Write
 spark.read.format("bigquery").option("credentials", "<SERVICE_ACCOUNT_JSON_IN_BASE64>")
 ```
+* For Workload Identity Federation (WIF) or external account key files requiring dynamic token refresh across Spark executors, set `gcpAccessTokenProviderConfig` to the path of your credentials JSON file:
+```
+// Globally
+spark.conf.set("gcpAccessTokenProviderConfig", "</path/to/credentials.json>")
+// Per read/Write
+spark.read.format("bigquery").option("gcpAccessTokenProviderConfig", "</path/to/credentials.json>")
+```
+  When `gcpAccessTokenProviderConfig` is set, `gcpAccessTokenProvider` automatically defaults to `com.google.cloud.bigquery.connector.common.FileCredentialsAccessTokenProvider`. This ensures credentials are 100% serializable across Spark executors (preventing `NotSerializableException` in direct write mode) while dynamically refreshing OAuth tokens for jobs running longer than 1 hour.
+
 * In cases where the user has an internal service providing the Google AccessToken, a custom implementation
   can be done, creating only the AccessToken and providing its TTL. Token refresh will re-generate a new token. In order
   to use this, implement the

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryCredentialsSupplier.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryCredentialsSupplier.java
@@ -64,17 +64,25 @@ public class BigQueryCredentialsSupplier {
       Optional<String> proxyUsername,
       Optional<String> proxyPassword) {
     GoogleCredentials credentials;
-    if (accessTokenProviderFQCN.isPresent()) {
+    Optional<String> effectiveAccessTokenProviderFQCN =
+        accessTokenProviderFQCN.isPresent()
+            ? accessTokenProviderFQCN
+            : (accessTokenProviderConfig.isPresent()
+                ? Optional.of(FileCredentialsAccessTokenProvider.class.getName())
+                : Optional.empty());
+    if (effectiveAccessTokenProviderFQCN.isPresent()) {
       AccessTokenProvider accessTokenProvider =
           accessTokenProviderConfig
               .map(
                   config ->
                       createVerifiedInstance(
-                          accessTokenProviderFQCN.get(), AccessTokenProvider.class, config))
+                          effectiveAccessTokenProviderFQCN.get(),
+                          AccessTokenProvider.class,
+                          config))
               .orElseGet(
                   () ->
                       createVerifiedInstance(
-                          accessTokenProviderFQCN.get(), AccessTokenProvider.class));
+                          effectiveAccessTokenProviderFQCN.get(), AccessTokenProvider.class));
       credentials = new AccessTokenProviderCredentials(verifySerialization(accessTokenProvider));
     } else if (accessToken.isPresent()) {
       credentials = createCredentialsFromAccessToken(accessToken.get());

--- a/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/FileCredentialsAccessTokenProvider.java
+++ b/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/FileCredentialsAccessTokenProvider.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigquery.connector.common;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+/**
+ * An {@link AccessTokenProvider} implementation that loads credentials dynamically from a local
+ * file path (such as a Workload Identity Federation or Service Account JSON key file).
+ *
+ * <p>This provider is fully serializable across Spark Executors because it only stores the
+ * credentials file path as a String. Credentials parsing and token refreshes occur dynamically on
+ * demand inside {@link #getAccessToken()}.
+ */
+public class FileCredentialsAccessTokenProvider implements AccessTokenProvider {
+
+  private static final long serialVersionUID = 1L;
+  private final String credentialsPath;
+
+  public FileCredentialsAccessTokenProvider() {
+    this(null);
+  }
+
+  /**
+   * Constructs the provider using the specified file path.
+   *
+   * @param credentialsPath Path to the credentials file passed via gcpAccessTokenProviderConfig.
+   */
+  public FileCredentialsAccessTokenProvider(String credentialsPath) {
+    this.credentialsPath = credentialsPath;
+  }
+
+  @Override
+  public AccessToken getAccessToken() throws IOException {
+    if (credentialsPath == null || credentialsPath.trim().isEmpty()) {
+      throw new IllegalArgumentException("credentialsPath must not be null or empty");
+    }
+    try (FileInputStream fis = new FileInputStream(credentialsPath)) {
+      GoogleCredentials credentials = GoogleCredentials.fromStream(fis);
+      credentials.refreshIfExpired();
+
+      com.google.auth.oauth2.AccessToken token = credentials.getAccessToken();
+      if (token == null) {
+        credentials.refresh();
+        token = credentials.getAccessToken();
+      }
+      return new AccessToken(token.getTokenValue(), token.getExpirationTime());
+    }
+  }
+
+  public String getCredentialsPath() {
+    return credentialsPath;
+  }
+}

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryCredentialsSupplierTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryCredentialsSupplierTest.java
@@ -300,6 +300,34 @@ public class BigQueryCredentialsSupplierTest {
   }
 
   @Test
+  public void testAccessTokenProviderConfigDefaultFallback() {
+    Credentials credentials =
+        new BigQueryCredentialsSupplier(
+                Optional.empty(),
+                Optional.of("/dummy/credentials/path.json"),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                null,
+                null,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty())
+            .getCredentials();
+
+    assertThat(credentials).isInstanceOf(AccessTokenProviderCredentials.class);
+    AccessTokenProvider provider =
+        ((AccessTokenProviderCredentials) credentials).getAccessTokenProvider();
+    assertThat(provider).isInstanceOf(FileCredentialsAccessTokenProvider.class);
+    assertThat(((FileCredentialsAccessTokenProvider) provider).getCredentialsPath())
+        .isEqualTo("/dummy/credentials/path.json");
+  }
+
+  @Test
   public void testCredentialsFromFileWithErrors() throws Exception {
     String json = createServiceAccountJson("file");
     File credentialsFile = File.createTempFile("dummy-credentials", ".json");

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/FileCredentialsAccessTokenProviderTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/FileCredentialsAccessTokenProviderTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.bigquery.connector.common;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import org.junit.Test;
+
+public class FileCredentialsAccessTokenProviderTest {
+
+  @Test
+  public void testSerialization() {
+    String path = "/path/to/credentials.json";
+    FileCredentialsAccessTokenProvider provider = new FileCredentialsAccessTokenProvider(path);
+    assertThat(provider.getCredentialsPath()).isEqualTo(path);
+
+    FileCredentialsAccessTokenProvider deserialized = BigQueryUtil.verifySerialization(provider);
+    assertThat(deserialized.getCredentialsPath()).isEqualTo(path);
+  }
+
+  @Test
+  public void testNullCredentialsPathThrows() {
+    FileCredentialsAccessTokenProvider provider = new FileCredentialsAccessTokenProvider();
+    assertThrows(IllegalArgumentException.class, provider::getAccessToken);
+  }
+
+  @Test
+  public void testEmptyCredentialsPathThrows() {
+    FileCredentialsAccessTokenProvider provider = new FileCredentialsAccessTokenProvider("  ");
+    assertThrows(IllegalArgumentException.class, provider::getAccessToken);
+  }
+
+  @Test
+  public void testNonExistentFileThrows() {
+    FileCredentialsAccessTokenProvider provider =
+        new FileCredentialsAccessTokenProvider("/non/existent/path/credentials.json");
+    assertThrows(FileNotFoundException.class, provider::getAccessToken);
+  }
+
+  @Test
+  public void testInvalidJsonCredentialsFileThrows() throws IOException {
+    File tempFile = File.createTempFile("invalid-credentials", ".json");
+    tempFile.deleteOnExit();
+    Files.write(tempFile.toPath(), "invalid json".getBytes(StandardCharsets.UTF_8));
+
+    FileCredentialsAccessTokenProvider provider =
+        new FileCredentialsAccessTokenProvider(tempFile.getAbsolutePath());
+    assertThrows(IOException.class, provider::getAccessToken);
+  }
+}

--- a/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/integration/CustomCredentialsIntegrationTest.java
+++ b/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/integration/CustomCredentialsIntegrationTest.java
@@ -22,8 +22,10 @@ import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.Table;
 import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.connector.common.AccessTokenProvider;
 import com.google.cloud.bigquery.connector.common.AccessTokenProviderCredentials;
 import com.google.cloud.bigquery.connector.common.BigQueryCredentialsSupplier;
+import com.google.cloud.bigquery.connector.common.FileCredentialsAccessTokenProvider;
 import java.util.Optional;
 import org.junit.Test;
 
@@ -104,5 +106,40 @@ public class CustomCredentialsIntegrationTest {
     table = bigQuery.getTable(TABLE_ID);
     assertThat(table).isNotNull();
     assertThat(accessTokenProvider.getCallCount()).isEqualTo(2);
+  }
+
+  @Test
+  public void testAccessTokenProviderConfigOnly_defaultsToFileCredentialsAccessTokenProvider() {
+    String credentialsPath = System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
+    if (credentialsPath != null && !credentialsPath.isEmpty()) {
+      BigQueryCredentialsSupplier credentialsSupplier =
+          new BigQueryCredentialsSupplier(
+              Optional.empty(),
+              Optional.of(credentialsPath),
+              Optional.empty(),
+              Optional.empty(),
+              Optional.empty(),
+              null,
+              null,
+              Optional.empty(),
+              Optional.empty(),
+              Optional.empty(),
+              Optional.empty(),
+              Optional.empty(),
+              Optional.empty(),
+              Optional.empty());
+      Credentials credentials = credentialsSupplier.getCredentials();
+      assertThat(credentials).isInstanceOf(AccessTokenProviderCredentials.class);
+      AccessTokenProvider provider =
+          ((AccessTokenProviderCredentials) credentials).getAccessTokenProvider();
+      assertThat(provider).isInstanceOf(FileCredentialsAccessTokenProvider.class);
+      assertThat(((FileCredentialsAccessTokenProvider) provider).getCredentialsPath())
+          .isEqualTo(credentialsPath);
+
+      BigQueryOptions options = BigQueryOptions.newBuilder().setCredentials(credentials).build();
+      BigQuery bigQuery = options.getService();
+      Table table = bigQuery.getTable(TABLE_ID);
+      assertThat(table).isNotNull();
+    }
   }
 }

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/ReadIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/ReadIntegrationTestBase.java
@@ -971,6 +971,26 @@ public class ReadIntegrationTestBase extends SparkBigQueryIntegrationTestBaseV2 
     return result;
   }
 
+  @SuppressWarnings("resource")
+  protected static JsonObject readAccessTokenProviderConfigOnlyApp(
+      String testDataset, String testTable, Map<String, String> parameters) throws Exception {
+    String credentialsPath = System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
+    SparkSession spark =
+        IntegrationTestUtils.createSparkSessionBuilder("readAccessTokenProviderConfigOnlyApp")
+            .getOrCreate()
+            .newSession();
+    org.apache.spark.sql.DataFrameReader reader = spark.read().format("bigquery");
+    if (credentialsPath != null && !credentialsPath.isEmpty()) {
+      reader = reader.option("gcpAccessTokenProviderConfig", credentialsPath);
+    }
+    Dataset<Row> df = reader.load(TestConstants.SHAKESPEARE_TABLE);
+
+    JsonObject result = new JsonObject();
+    result.addProperty("status", "success");
+    result.addProperty("count", df.count());
+    return result;
+  }
+
   // =========================================================================
   // JUNIT TEST CASES DELEGATION MAPPINGS
   // =========================================================================
@@ -1593,5 +1613,21 @@ public class ReadIntegrationTestBase extends SparkBigQueryIntegrationTestBaseV2 
             ReadIntegrationTestBase::readCustomAccessTokenProviderApp, "", "", ImmutableMap.of());
     assertThat(result.get("status").getAsString()).isEqualTo("success");
     assertThat(result.get("count").getAsLong()).isEqualTo(TestConstants.SHAKESPEARE_TABLE_NUM_ROWS);
+  }
+
+  @Test
+  public void testAccessTokenProviderConfigOnly() throws Exception {
+    String credentialsPath = System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
+    if (credentialsPath != null && !credentialsPath.isEmpty()) {
+      JsonObject result =
+          testRunner.run(
+              ReadIntegrationTestBase::readAccessTokenProviderConfigOnlyApp,
+              "",
+              "",
+              ImmutableMap.of());
+      assertThat(result.get("status").getAsString()).isEqualTo("success");
+      assertThat(result.get("count").getAsLong())
+          .isEqualTo(TestConstants.SHAKESPEARE_TABLE_NUM_ROWS);
+    }
   }
 }


### PR DESCRIPTION
# Executive Summary of Changes

## 1. Problem & Root Cause Analysis (b/536912904 & b/393231014)

* **Symptom 1 — `NotSerializableException` in Direct Write Mode:**
  When configuring `credentialsFile` with Workload Identity Federation (WIF) JSON key files, `GoogleCredentials.fromStream(...)` instantiates a `PluggableAuthCredentials` object on the Spark Driver. In Direct Write Mode (Storage Write API), Spark serializes write tasks across network executors. Because `PluggableAuthHandler` is not serializable, Spark fails with:
  `java.io.NotSerializableException: com.google.auth.oauth2.PluggableAuthHandler`

* **Symptom 2 — `401 Unauthorized` Expiration in Long-Running Jobs:**
  Passing a raw token via `gcpAccessToken` bypasses serialization (strings are serializable), but static OAuth strings expire in 3600 seconds (1 hour) without a refresh mechanism, causing multi-hour jobs to fail mid-flight.

---

## 2. Solution Architecture

We created **[`FileCredentialsAccessTokenProvider`](file:///usr/local/google/home/yalimu/Documents/github/workspace/spark-bigquery-connector/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/FileCredentialsAccessTokenProvider.java)** implementing `AccessTokenProvider`:

1. **Fixes Symptom 1 (Serialization):** Stores **only** the `credentialsPath` (`String`) as an instance field. Because `String` is natively serializable in Java, Spark task distribution across executors succeeds.
2. **Fixes Symptom 2 (Expiration):** Credentials parsing (`GoogleCredentials.fromStream(...)`) and token refreshes occur dynamically on-demand inside `getAccessToken()` on executor nodes whenever a token expires.

---

## 3. Detailed Summary of Code & Documentation Changes

### A. New Classes & Logic
* **[`FileCredentialsAccessTokenProvider.java`](file:///usr/local/google/home/yalimu/Documents/github/workspace/spark-bigquery-connector/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/FileCredentialsAccessTokenProvider.java#L31-L69)**
  - Implements `AccessTokenProvider` (extends `Serializable`).
  - Reads credentials from `credentialsPath` dynamically on call to `getAccessToken()`.

* **[`BigQueryCredentialsSupplier.java`](file:///usr/local/google/home/yalimu/Documents/github/workspace/spark-bigquery-connector/bigquery-connector-common/src/main/java/com/google/cloud/bigquery/connector/common/BigQueryCredentialsSupplier.java#L67-L72)**
  - Added automatic default fallback: If `gcpAccessTokenProviderConfig` is specified (e.g. set to a JSON key path) and `gcpAccessTokenProvider` is omitted, it automatically defaults to `FileCredentialsAccessTokenProvider`.

### B. Unit Test Coverage
* **[`FileCredentialsAccessTokenProviderTest.java`](file:///usr/local/google/home/yalimu/Documents/github/workspace/spark-bigquery-connector/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/FileCredentialsAccessTokenProviderTest.java#L29-L70)**
  - Tests Java serialization/deserialization via `BigQueryUtil.verifySerialization`.
  - Tests validation for `null`, empty paths, missing files, and invalid JSON content.

* **[`BigQueryCredentialsSupplierTest.java`](file:///usr/local/google/home/yalimu/Documents/github/workspace/spark-bigquery-connector/bigquery-connector-common/src/test/java/com/google/cloud/bigquery/connector/common/BigQueryCredentialsSupplierTest.java#L302-L325)**
  - Added `testAccessTokenProviderConfigDefaultFallback()` to verify that supplying `gcpAccessTokenProviderConfig` alone correctly instantiates `FileCredentialsAccessTokenProvider`.

### C. Documentation
* **[`README.md`](file:///usr/local/google/home/yalimu/Documents/github/workspace/spark-bigquery-connector/README.md#L1436-L1445) & [`README-template.md`](file:///usr/local/google/home/yalimu/Documents/github/workspace/spark-bigquery-connector/README-template.md#L1463-L1472)**
  - Documented WIF credentials usage with `gcpAccessTokenProviderConfig` and explained the automatic fallback mechanism.

---

## 4. Usage Example for Users

Users can now simply configure:

```python
# In PySpark / Spark SQL
spark.conf.set(
    "gcpAccessTokenProviderConfig", "/path/to/wif-credentials.json"
)

# Direct Write Mode in PySpark
df.write.format("bigquery").option(
    "gcpAccessTokenProviderConfig", "/path/to/wif-credentials.json"
).option("writeMethod", "direct").save()
```

---

## 5. Verification Results

| Check | Result |
| :--- | :--- |
| **Spotless Code Format** | `BUILD SUCCESS` (0 violations) |
| **Checkstyle Audit** | `BUILD SUCCESS` (0 violations) |
| **Unit Test Suite** | `BUILD SUCCESS` across all reactor modules |