### PR TITLE
Handle Arrow StructVectors with 0 child vectors in ArrowColumnBatchPartitionReaderContext

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * PR #1494: Added Support for Change Data Capture (CDC)
 * Issue #1501: Preserved detailed row errors from failed direct writes
 * Issue #1503: Corrected the documented billing project option to `parentProject`.
+* PR #1510: Handle Arrow StructVectors with 0 child vectors in ArrowColumnBatchPartitionReaderContext
 
 ## 0.44.2 - 2026-05-20
 

--- a/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/ReadByFormatIntegrationTestBase.java
+++ b/spark-bigquery-connector-common/src/test/java/com/google/cloud/spark/bigquery/integration/ReadByFormatIntegrationTestBase.java
@@ -745,7 +745,6 @@ public class ReadByFormatIntegrationTestBase extends SparkBigQueryIntegrationTes
 
   @Test
   public void testWindowFunctionPartitionByWithArray() throws Exception {
-    assumeTrue("This test only works for AVRO dataformat", dataFormat.equals("AVRO"));
     JsonObject result =
         testRunner.run(
             ReadByFormatIntegrationTestBase::readGA4WindowFunctionApp,

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/ArrowColumnBatchPartitionReaderContext.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/ArrowColumnBatchPartitionReaderContext.java
@@ -63,32 +63,45 @@ public class ArrowColumnBatchPartitionReaderContext
     implements InputPartitionReaderContext<ColumnarBatch> {
   private static final long maxAllocation = 500 * 1024 * 1024;
 
-  private static void ensureStructVectorsHaveChildren(VectorSchemaRoot root) {
-    if (root == null) {
+  static void ensureStructVectorsHaveChildren(VectorSchemaRoot root) {
+    if (root == null || root.getSchema() == null) {
       return;
     }
-    for (FieldVector vector : root.getFieldVectors()) {
-      ensureStructVectorsHaveChildren(vector);
+    List<Field> fields = root.getSchema().getFields();
+    List<FieldVector> vectors = root.getFieldVectors();
+    ensureStructVectorsHaveChildren(fields, vectors);
+  }
+
+  static void ensureStructVectorsHaveChildren(List<Field> fields, List<FieldVector> vectors) {
+    if (fields == null || vectors == null) {
+      return;
+    }
+    int count = Math.min(fields.size(), vectors.size());
+    for (int i = 0; i < count; i++) {
+      ensureStructVectorsHaveChildren(fields.get(i), vectors.get(i));
     }
   }
 
-  private static void ensureStructVectorsHaveChildren(FieldVector vector) {
+  static void ensureStructVectorsHaveChildren(Field field, FieldVector vector) {
+    if (field == null || vector == null) {
+      return;
+    }
     if (vector instanceof StructVector) {
       StructVector structVector = (StructVector) vector;
       if (structVector.getChildrenFromFields().isEmpty()) {
-        List<Field> children = structVector.getField().getChildren();
+        List<Field> children = field.getChildren();
         if (children != null && !children.isEmpty()) {
           structVector.initializeChildrenFromFields(children);
         }
       }
-      for (FieldVector child : structVector.getChildrenFromFields()) {
-        ensureStructVectorsHaveChildren(child);
-      }
+      List<Field> childFields = field.getChildren();
+      List<FieldVector> childVectors = structVector.getChildrenFromFields();
+      ensureStructVectorsHaveChildren(childFields, childVectors);
     } else if (vector instanceof ListVector) {
       ListVector listVector = (ListVector) vector;
       FieldVector dataVector = listVector.getDataVector();
-      if (dataVector != null) {
-        ensureStructVectorsHaveChildren(dataVector);
+      if (dataVector != null && field.getChildren() != null && !field.getChildren().isEmpty()) {
+        ensureStructVectorsHaveChildren(field.getChildren().get(0), dataVector);
       }
     }
   }

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/ArrowColumnBatchPartitionReaderContext.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/ArrowColumnBatchPartitionReaderContext.java
@@ -45,10 +45,14 @@ import java.util.stream.Collectors;
 import org.apache.arrow.compression.CommonsCompressionFactory;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.AutoCloseables;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorLoader;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.ipc.ArrowStreamReader;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -58,6 +62,36 @@ import org.apache.spark.sql.vectorized.ColumnarBatch;
 public class ArrowColumnBatchPartitionReaderContext
     implements InputPartitionReaderContext<ColumnarBatch> {
   private static final long maxAllocation = 500 * 1024 * 1024;
+
+  private static void ensureStructVectorsHaveChildren(VectorSchemaRoot root) {
+    if (root == null) {
+      return;
+    }
+    for (FieldVector vector : root.getFieldVectors()) {
+      ensureStructVectorsHaveChildren(vector);
+    }
+  }
+
+  private static void ensureStructVectorsHaveChildren(FieldVector vector) {
+    if (vector instanceof StructVector) {
+      StructVector structVector = (StructVector) vector;
+      if (structVector.getChildrenFromFields().isEmpty()) {
+        List<Field> children = structVector.getField().getChildren();
+        if (children != null && !children.isEmpty()) {
+          structVector.initializeChildrenFromFields(children);
+        }
+      }
+      for (FieldVector child : structVector.getChildrenFromFields()) {
+        ensureStructVectorsHaveChildren(child);
+      }
+    } else if (vector instanceof ListVector) {
+      ListVector listVector = (ListVector) vector;
+      FieldVector dataVector = listVector.getDataVector();
+      if (dataVector != null) {
+        ensureStructVectorsHaveChildren(dataVector);
+      }
+    }
+  }
 
   interface ArrowReaderAdapter extends AutoCloseable {
     boolean loadNextBatch() throws IOException;
@@ -70,6 +104,10 @@ public class ArrowColumnBatchPartitionReaderContext
 
     SimpleAdapter(ArrowReader reader) {
       this.reader = reader;
+      try {
+        ensureStructVectorsHaveChildren(reader.getVectorSchemaRoot());
+      } catch (IOException ignored) {
+      }
     }
 
     @Override
@@ -121,6 +159,13 @@ public class ArrowColumnBatchPartitionReaderContext
           allocator.newChildAllocator("ParallelReaderAllocator", 0, maxAllocation);
       root = VectorSchemaRoot.create(schema, readerAllocator);
       closeables.add(root);
+      ensureStructVectorsHaveChildren(root);
+      for (ArrowReader reader : readers) {
+        try {
+          ensureStructVectorsHaveChildren(reader.getVectorSchemaRoot());
+        } catch (IOException ignored) {
+        }
+      }
       loader = new VectorLoader(root);
       this.reader = new ParallelArrowReader(readers, executor, loader, tracer);
       closeables.add(0, reader);

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/test/java/com/google/cloud/spark/bigquery/v2/context/ArrowColumnBatchPartitionReaderContextTest.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/test/java/com/google/cloud/spark/bigquery/v2/context/ArrowColumnBatchPartitionReaderContextTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.v2.context;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.bigquery.connector.common.ArrowUtil;
+import com.google.common.collect.ImmutableList;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VectorLoader;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.VectorUnloader;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ArrowColumnBatchPartitionReaderContextTest {
+
+  private BufferAllocator allocator;
+
+  @Before
+  public void setUp() {
+    allocator = ArrowUtil.newRootAllocator(Long.MAX_VALUE);
+  }
+
+  @After
+  public void tearDown() {
+    allocator.close();
+  }
+
+  @Test
+  public void testEnsureStructVectorsHaveChildrenPopulatesChildVectors() throws Exception {
+    Field intChildField =
+        new Field("int_val", FieldType.nullable(Types.MinorType.INT.getType()), null);
+    Field structField =
+        new Field(
+            "struct_col",
+            FieldType.nullable(ArrowType.Struct.INSTANCE),
+            ImmutableList.of(intChildField));
+    Schema schema = new Schema(ImmutableList.of(structField));
+
+    // Create a record batch with full data (struct_col + int_val)
+    ArrowRecordBatch recordBatch;
+    try (VectorSchemaRoot sourceRoot = VectorSchemaRoot.create(schema, allocator)) {
+      StructVector structVec = (StructVector) sourceRoot.getVector("struct_col");
+      IntVector intVec =
+          structVec.addOrGet(
+              "int_val", FieldType.nullable(Types.MinorType.INT.getType()), IntVector.class);
+      structVec.allocateNew();
+      intVec.set(0, 42);
+      structVec.setValueCount(1);
+      sourceRoot.setRowCount(1);
+
+      VectorUnloader unloader = new VectorUnloader(sourceRoot);
+      recordBatch = unloader.getRecordBatch();
+    }
+
+    // Create a target StructVector empty without children initially
+    try (StructVector targetStructVec = StructVector.empty("struct_col", allocator);
+        ArrowRecordBatch batchToLoad = recordBatch) {
+      assertThat(targetStructVec.getChildrenFromFields()).isEmpty();
+
+      // Initialize children matching the schema fields
+      targetStructVec.initializeChildrenFromFields(structField.getChildren());
+      assertThat(targetStructVec.getChildrenFromFields()).hasSize(1);
+
+      FieldVector targetFieldVec = targetStructVec;
+      VectorSchemaRoot targetRoot =
+          new VectorSchemaRoot(
+              ImmutableList.of(targetFieldVec.getField()), ImmutableList.of(targetFieldVec));
+
+      VectorLoader loader = new VectorLoader(targetRoot);
+      loader.load(batchToLoad);
+
+      assertThat(targetRoot.getRowCount()).isEqualTo(1);
+      StructVector loadedStruct = (StructVector) targetRoot.getVector("struct_col");
+      IntVector loadedInt = (IntVector) loadedStruct.getChild("int_val");
+      assertThat(loadedInt.get(0)).isEqualTo(42);
+    }
+  }
+}

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/test/java/com/google/cloud/spark/bigquery/v2/context/ArrowColumnBatchPartitionReaderContextTest.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/test/java/com/google/cloud/spark/bigquery/v2/context/ArrowColumnBatchPartitionReaderContextTest.java
@@ -82,14 +82,13 @@ public class ArrowColumnBatchPartitionReaderContextTest {
         ArrowRecordBatch batchToLoad = recordBatch) {
       assertThat(targetStructVec.getChildrenFromFields()).isEmpty();
 
-      // Initialize children matching the schema fields
-      targetStructVec.initializeChildrenFromFields(structField.getChildren());
-      assertThat(targetStructVec.getChildrenFromFields()).hasSize(1);
-
-      FieldVector targetFieldVec = targetStructVec;
       VectorSchemaRoot targetRoot =
           new VectorSchemaRoot(
-              ImmutableList.of(targetFieldVec.getField()), ImmutableList.of(targetFieldVec));
+              ImmutableList.of(structField), ImmutableList.of((FieldVector) targetStructVec));
+
+      // Test package-private method ensureStructVectorsHaveChildren using Schema metadata
+      ArrowColumnBatchPartitionReaderContext.ensureStructVectorsHaveChildren(targetRoot);
+      assertThat(targetStructVec.getChildrenFromFields()).hasSize(1);
 
       VectorLoader loader = new VectorLoader(targetRoot);
       loader.load(batchToLoad);


### PR DESCRIPTION
When reading Arrow record batches from BigQuery Storage API, there are scenarios (such as field pruning or when deserializing Arrow schema headers) where an incoming Arrow StructVector in a VectorSchemaRoot has 0 child vectors (structVector.getChildrenFromFields().isEmpty()).

When VectorLoader.load(ArrowRecordBatch) is invoked on VectorSchemaRoot, VectorLoader iterates through existing child vectors in getChildrenFromFields(). If a StructVector has 0 child vectors, VectorLoader skips loading children for that struct. However, the incoming ArrowRecordBatch still contains FieldNodes and ArrowBuf buffers for those child fields. This causes VectorLoader to get out of sync with the record batch's buffer stream, leading to buffer misalignment errors or data corruption when reading subsequent columns.

Implement helper methods ensureStructVectorsHaveChildren to traverse a VectorSchemaRoot and populate empty null child vectors for any StructVector whose getChildrenFromFields() is empty.


https://buganizer.corp.google.com/issues/540282714