### PR TITLE
Dependency upgrades

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 ## Next
 
+* BigQuery API has been upgraded to version 2.68.0
+* BigQuery Storage API has been upgraded to version 3.30.0
+* GAX has been upgraded to version 2.82.0
+* gRPC has been upgraded to version 1.83.1
+* Guava has been upgraded to version 33.6.0-jre
+* Netty has been upgraded to version 4.2.17.Final
+* Protocol Buffers has been upgraded to version 4.35.1
 * PR #1494: Added Support for Change Data Capture (CDC)
 * Issue #1501: Preserved detailed row errors from failed direct writes
 * Issue #1503: Corrected the documented billing project option to `parentProject`.

--- a/spark-bigquery-parent/pom.xml
+++ b/spark-bigquery-parent/pom.xml
@@ -45,23 +45,21 @@
         <!-- arrow 18.0.0 removed the support for java 8 -->
         <arrow.version>17.0.0</arrow.version>
         <arrow.spark4.version>18.3.0</arrow.spark4.version>
-        <gax.version>2.75.0</gax.version>
+        <gax.version>2.82.0</gax.version>
         <google-api-client.version>2.9.0</google-api-client.version>
-        <google-auth.version>1.43.0</google-auth.version>
-        <google-cloud-bigquery.version>2.60.0</google-cloud-bigquery.version>
-        <google-cloud-bigquerystorage.version>3.22.1</google-cloud-bigquerystorage.version>
-        <google-cloud-dataproc.version>4.83.0</google-cloud-dataproc.version>
-        <google-cloud-storage.version>2.64.0</google-cloud-storage.version>
+        <google-auth.version>1.49.0</google-auth.version>
+        <google-cloud-bigquery.version>2.68.0</google-cloud-bigquery.version>
+        <google-cloud-bigquerystorage.version>3.30.0</google-cloud-bigquerystorage.version>
+        <google-cloud-dataproc.version>4.91.0</google-cloud-dataproc.version>
+        <google-cloud-storage.version>2.70.0</google-cloud-storage.version>
         <google-truth.version>1.4.5</google-truth.version>
-        <grpc.version>1.79.0</grpc.version>
-        <guava.version>33.5.0-jre</guava.version>
+        <grpc.version>1.83.1</grpc.version>
+        <guava.version>33.6.0-jre</guava.version>
         <jackson.version>2.22.1</jackson.version>
-        <netty.version>4.2.10.Final</netty.version>
+        <netty.version>4.2.17.Final</netty.version>
         <openlineage-spark.version>1.37.0</openlineage-spark.version>
         <paranamer.version>2.8.3</paranamer.version>
-        <!-- Don't upgrade protobuf until bigquerystorage is compatible with 4.x version of proto.
-        Ref : https://github.com/protocolbuffers/protobuf/issues/16452-->
-        <protobuf.version>4.34.0</protobuf.version>
+        <protobuf.version>4.35.1</protobuf.version>
         <deploy.skip>true</deploy.skip>
         <nexus.remote.skip>false</nexus.remote.skip>
         <shade.skip>true</shade.skip>
@@ -184,7 +182,7 @@
             <dependency>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_annotations</artifactId>
-                <version>2.48.0</version>
+                <version>2.50.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>
@@ -218,7 +216,7 @@
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
-                <version>1.21.0</version>
+                <version>1.22.1</version>
             </dependency>
             <dependency>
                 <groupId>commons-lang</groupId>
@@ -297,7 +295,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.21.0</version>
+                <version>2.22.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Updates connector dependencies following the maintenance pattern from #1443.

Key updates:

- BigQuery 2.68.0
- BigQuery Storage 3.30.0
- GAX 2.82.0
- gRPC 1.83.1
- Guava 33.6.0-jre
- Netty 4.2.17.Final
- Protobuf 4.35.1

The Google Cloud libraries use the coordinated GAX 2.82.0 release train. GAX 2.83.0 introduces runtime JSpecify annotations that are incompatible with Guice reflection on Java 8; using 2.82.0 keeps this a dependency-only change while Java 8 remains supported.

Validation:

- Full Maven test matrix passed
- Packaging and shaded-artifact verification passed for all supported Spark profiles