### PR TITLE
Add Spark 4.2 connector support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+* Added new connector, `spark-4.2-bigquery`, aimed to be used with Spark 4.2. Like Spark 4.2, this connector requires at
+  least a Java 17 runtime. It is currently in preview mode.
 * BigQuery API has been upgraded to version 2.68.0
 * BigQuery Storage API has been upgraded to version 3.30.0
 * GAX has been upgraded to version 2.82.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,8 +69,9 @@ DSv2 (Java) connectors under `spark-bigquery-dsv2/`:
   `spark-bigquery-metrics` — shared infrastructure.
 * `spark-3.1-bigquery`, `spark-3.2-bigquery`, `spark-3.3-bigquery`,
   `spark-3.4-bigquery`, `spark-3.5-bigquery`, `spark-4.0-bigquery`,
-  `spark-4.1-bigquery` — the per-Spark-version connector jars, each backed by
-  a `*-bigquery-lib` module reused by the next-version connector.
+  `spark-4.1-bigquery`, `spark-4.2-bigquery` — the per-Spark-version connector
+  jars, each backed by a `*-bigquery-lib` module reused by the next-version
+  connector.
 
 Pushdown variants under `spark-bigquery-pushdown/` add query pushdown support
 per Spark+Scala combination. They are built separately and are **not** driven
@@ -94,7 +95,7 @@ to scope the build. The profiles defined in the root POM are:
 * `dsv1_2.12`, `dsv1_2.13` — one supported Scala variant of the DSv1
   connector.
 * `dsv2_3.1`, `dsv2_3.2`, `dsv2_3.3`, `dsv2_3.4`, `dsv2_3.5`, `dsv2_4.0`,
-  `dsv2_4.1` — one Spark version of the DSv2 connector.
+  `dsv2_4.1`, `dsv2_4.2` — one Spark version of the DSv2 connector.
 * `dsv1`, `dsv2`, `all` — aggregates for the whole DSv1 / DSv2 / both worlds.
 * `coverage` — adds the `coverage/` aggregator for Jacoco reports.
 * `dsv1_2.11`, `dsv2_2.4` — legacy profiles retained in the build but omitted
@@ -114,19 +115,19 @@ artifacts are produced.
 ### JDK requirements
 
 Most connector artifacts are compiled to Java 8 bytecode
-(`maven.compiler.release=8`). The Spark 4.0 and 4.1 artifacts override this
+(`maven.compiler.release=8`). The Spark 4.0, 4.1, and 4.2 artifacts override this
 setting and compile to Java 17 bytecode. At runtime, the JDK you need depends
 on which Spark version your connector targets:
 
 * Connectors for Spark 3.1 – 3.5: Java 8 supported (Java 11 / 17 also work
   where the underlying Spark distribution supports them).
-* Connectors for Spark 4.0 / 4.1: **Java 17 required**, matching Spark 4.x's
+* Connectors for Spark 4.0 / 4.1 / 4.2: **Java 17 required**, matching Spark 4.x's
   own JDK requirement.
 
 The CI test matrix uses both JDKs:
 
 * **Java 17** — initial install, all unit tests, and integration tests for
-  Spark 3.3, 3.4, 3.5, 4.0, and 4.1.
+  Spark 3.3, 3.4, 3.5, 4.0, 4.1, and 4.2.
 * **Java 8** — integration tests for `dsv1_2.12`, `dsv1_2.13`, `dsv2_3.1`,
   and `dsv2_3.2`.
 

--- a/README-template.md
+++ b/README-template.md
@@ -63,6 +63,7 @@ The latest version of the connector is publicly available in the following links
 
 | version    | Link                                                                                                                                                                                                                   |
 |------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Spark 4.2  | `gs://spark-lib/bigquery/spark-4.2-bigquery-${next-release-tag}-preview.jar`([HTTP link](https://storage.googleapis.com/spark-lib/bigquery/spark-4.2-bigquery-${next-release-tag}-preview.jar))                        |
 | Spark 4.1  | `gs://spark-lib/bigquery/spark-4.1-bigquery-${next-release-tag}-preview.jar`([HTTP link](https://storage.googleapis.com/spark-lib/bigquery/spark-4.1-bigquery-${next-release-tag}-preview.jar))                        |
 | Spark 4.0  | `gs://spark-lib/bigquery/spark-4.0-bigquery-${next-release-tag}.jar`([HTTP link](https://storage.googleapis.com/spark-lib/bigquery/spark-4.0-bigquery-${next-release-tag}.jar))                                        |
 | Spark 3.5  | `gs://spark-lib/bigquery/spark-3.5-bigquery-${next-release-tag}.jar`([HTTP link](https://storage.googleapis.com/spark-lib/bigquery/spark-3.5-bigquery-${next-release-tag}.jar))                                        |
@@ -81,23 +82,25 @@ Source V1; choose the artifact matching your Spark installation's Scala binary
 version as outlined below.
 
 ### Connector to Spark Compatibility Matrix
-| Connector \ Spark                     | 2.3     | 2.4     | 3.0     | 3.1     | 3.2     | 3.3     | 3.4     | 3.5     | 4.0     | 4.1     |
-|---------------------------------------|---------|---------|---------|---------|---------|---------|---------|---------|---------|---------|
-| spark-4.1-bigquery                    |         |         |         |         |         |         |         |         |         | &check; |
-| spark-4.0-bigquery                    |         |         |         |         |         |         |         |         | &check; |         |
-| spark-3.5-bigquery                    |         |         |         |         |         |         |         | &check; |         |         |
-| spark-3.4-bigquery                    |         |         |         |         |         |         | &check; | &check; |         |         |
-| spark-3.3-bigquery                    |         |         |         |         |         | &check; | &check; | &check; |         |         |
-| spark-3.2-bigquery                    |         |         |         |         | &check; | &check; | &check; | &check; |         |         |
-| spark-3.1-bigquery                    |         |         |         | &check; | &check; | &check; | &check; | &check; |         |         |
-| spark-2.4-bigquery                    |         | &check; |         |         |         |         |         |         |         |         |
-| spark-bigquery-with-dependencies_2.13 |         |         |         |         | &check; | &check; | &check; | &check; |         |         |
-| spark-bigquery-with-dependencies_2.12 |         | &check; | &check; | &check; | &check; | &check; | &check; | &check; |         |         |
-| spark-bigquery-with-dependencies_2.11 | &check; | &check; |         |         |         |         |         |         |         |         |
+| Connector \ Spark                     | 2.3     | 2.4     | 3.0     | 3.1     | 3.2     | 3.3     | 3.4     | 3.5     | 4.0     | 4.1     | 4.2     |
+|---------------------------------------|---------|---------|---------|---------|---------|---------|---------|---------|---------|---------|---------|
+| spark-4.2-bigquery                    |         |         |         |         |         |         |         |         |         |         | &check; |
+| spark-4.1-bigquery                    |         |         |         |         |         |         |         |         |         | &check; |         |
+| spark-4.0-bigquery                    |         |         |         |         |         |         |         |         | &check; |         |         |
+| spark-3.5-bigquery                    |         |         |         |         |         |         |         | &check; |         |         |         |
+| spark-3.4-bigquery                    |         |         |         |         |         |         | &check; | &check; |         |         |         |
+| spark-3.3-bigquery                    |         |         |         |         |         | &check; | &check; | &check; |         |         |         |
+| spark-3.2-bigquery                    |         |         |         |         | &check; | &check; | &check; | &check; |         |         |         |
+| spark-3.1-bigquery                    |         |         |         | &check; | &check; | &check; | &check; | &check; |         |         |         |
+| spark-2.4-bigquery                    |         | &check; |         |         |         |         |         |         |         |         |         |
+| spark-bigquery-with-dependencies_2.13 |         |         |         |         | &check; | &check; | &check; | &check; |         |         |         |
+| spark-bigquery-with-dependencies_2.12 |         | &check; | &check; | &check; | &check; | &check; | &check; | &check; |         |         |         |
+| spark-bigquery-with-dependencies_2.11 | &check; | &check; |         |         |         |         |         |         |         |         |         |
 
 ### Connector to Dataproc Image Compatibility Matrix
 | Connector \ Dataproc Image            | 1.3     | 1.4     | 1.5     | 2.0     | 2.1     | 2.2     | 3.0     | Serverless<br>Runtime 1.0 | Serverless<br>Runtime 2.0 | Serverless<br>Runtime 2.1 | Serverless<br>Runtime 2.2 | Serverless<br>Runtime 3.0 |
 |---------------------------------------|---------|---------|---------|---------|---------|---------|---------|-------------------------|-------------------------|-------------------------|-------------------------|-------------------------|
+| spark-4.2-bigquery                    |         |         |         |         |         |         |         |                         |                         |                         |                         |                         |
 | spark-4.1-bigquery                    |         |         |         |         |         |         | &check; |                         |                         |                         |                         |                         |
 | spark-4.0-bigquery                    |         |         |         |         |         |         |         |                         |                         |                         |                         | &check;                 |
 | spark-3.5-bigquery                    |         |         |         |         |         | &check; |         |                         |                         |                         | &check;                 |                         |
@@ -125,6 +128,7 @@ repository. It can be used using the `--packages` option or the
 
 | version    | Connector Artifact                                                                 |
 |------------|------------------------------------------------------------------------------------|
+| Spark 4.2  | `com.google.cloud.spark:spark-4.2-bigquery:${next-release-tag}-preview`            |
 | Spark 4.1  | `com.google.cloud.spark:spark-4.1-bigquery:${next-release-tag}-preview`            |
 | Spark 4.0  | `com.google.cloud.spark:spark-4.0-bigquery:${next-release-tag}`                    |
 | Spark 3.5  | `com.google.cloud.spark:spark-3.5-bigquery:${next-release-tag}`                    |

--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -130,10 +130,22 @@ steps:
       - 'BIGLAKE_CONNECTION_ID=${_BIGLAKE_CONNECTION_ID}'
       - 'BIGQUERY_KMS_KEY_NAME=${_BIGQUERY_KMS_KEY_NAME}'
 
+  # 4j. Run integration tests concurrently with unit tests (DSv2, Spark 4.2)
+  - name: 'gcr.io/$PROJECT_ID/dataproc-spark-bigquery-connector-presubmit'
+    id: 'integration-tests-4.2'
+    waitFor: ['integration-tests-4.0']
+    entrypoint: 'bash'
+    args: ['/workspace/cloudbuild/presubmit.sh', 'integrationtest-4.2']
+    env:
+      - 'GOOGLE_CLOUD_PROJECT=${_GOOGLE_CLOUD_PROJECT}'
+      - 'TEMPORARY_GCS_BUCKET=${_TEMPORARY_GCS_BUCKET}'
+      - 'BIGLAKE_CONNECTION_ID=${_BIGLAKE_CONNECTION_ID}'
+      - 'BIGQUERY_KMS_KEY_NAME=${_BIGQUERY_KMS_KEY_NAME}'
+
   # 5. Upload coverage to CodeCov
   - name: 'gcr.io/$PROJECT_ID/dataproc-spark-bigquery-connector-presubmit'
     id: 'upload-it-to-codecov'
-    waitFor: ['integration-tests-2.12','integration-tests-2.13','integration-tests-3.1','integration-tests-3.2','integration-tests-3.3', 'integration-tests-3.4', 'integration-tests-3.5', 'integration-tests-4.0', 'integration-tests-4.1']
+    waitFor: ['integration-tests-2.12','integration-tests-2.13','integration-tests-3.1','integration-tests-3.2','integration-tests-3.3', 'integration-tests-3.4', 'integration-tests-3.5', 'integration-tests-4.0', 'integration-tests-4.1', 'integration-tests-4.2']
     entrypoint: 'bash'
     args: ['/workspace/cloudbuild/presubmit.sh', 'upload-it-to-codecov']
     env:

--- a/cloudbuild/nightly.sh
+++ b/cloudbuild/nightly.sh
@@ -43,17 +43,17 @@ case $STEP in
     cat toolchains.xml
     # Build
     export JAVA_HOME=${JAVA17_HOME}
-    $MVN -T 1C install -DskipTests -Pdsv1_2.12,dsv1_2.13,dsv2_3.1,dsv2_3.2,dsv2_3.3,dsv2_3.4,dsv2_3.5,dsv2_4.0,dsv2_4.1
+    $MVN -T 1C install -DskipTests -Pdsv1_2.12,dsv1_2.13,dsv2_3.1,dsv2_3.2,dsv2_3.3,dsv2_3.4,dsv2_3.5,dsv2_4.0,dsv2_4.1,dsv2_4.2
     #coverage report
     export JAVA_HOME=${JAVA17_HOME}
-    $MVN -T 1C test jacoco:report jacoco:report-aggregate -Pcoverage,dsv1_2.12,dsv1_2.13,dsv2_3.1,dsv2_3.2,dsv2_3.3,dsv2_3.4,dsv2_3.5,dsv2_4.0,dsv2_4.1
+    $MVN -T 1C test jacoco:report jacoco:report-aggregate -Pcoverage,dsv1_2.12,dsv1_2.13,dsv2_3.1,dsv2_3.2,dsv2_3.3,dsv2_3.4,dsv2_3.5,dsv2_4.0,dsv2_4.1,dsv2_4.2
     # Run integration tests
     unset MAVEN_OPTS
     export JAVA_HOME=${JAVA17_HOME}
-    $MVN failsafe:integration-test failsafe:verify jacoco:report jacoco:report-aggregate -Pcoverage,integration,dsv1_2.12,dsv1_2.13,dsv2_3.1,dsv2_3.2,dsv2_3.3,dsv2_3.4,dsv2_3.5,dsv2_4.0,dsv2_4.1
+    $MVN failsafe:integration-test failsafe:verify jacoco:report jacoco:report-aggregate -Pcoverage,integration,dsv1_2.12,dsv1_2.13,dsv2_3.1,dsv2_3.2,dsv2_3.3,dsv2_3.4,dsv2_3.5,dsv2_4.0,dsv2_4.1,dsv2_4.2
     # Run acceptance tests
     export JAVA_HOME=${JAVA17_HOME}
-    $MVN failsafe:integration-test failsafe:verify jacoco:report jacoco:report-aggregate -Pcoverage,acceptance,dsv1_2.12,dsv1_2.13,dsv2_3.1,dsv2_3.2,dsv2_3.3,dsv2_3.4,dsv2_3.5,dsv2_4.0,dsv2_4.1
+    $MVN failsafe:integration-test failsafe:verify jacoco:report jacoco:report-aggregate -Pcoverage,acceptance,dsv1_2.12,dsv1_2.13,dsv2_3.1,dsv2_3.2,dsv2_3.3,dsv2_3.4,dsv2_3.5,dsv2_4.0,dsv2_4.1,dsv2_4.2
     # Upload test coverage report to Codecov
     bash <(curl -s https://codecov.io/bash) -K -F "nightly"
 
@@ -94,6 +94,9 @@ case $STEP in
     gsutil cp "${M2REPO}/com/google/cloud/spark/spark-4.1-bigquery/${BUILD_REVISION}-preview/spark-4.1-bigquery-${BUILD_REVISION}-preview.jar" "gs://${BUCKET}"
     gsutil cp "gs://${BUCKET}/spark-4.1-bigquery-${BUILD_REVISION}-preview.jar" "gs://${BUCKET}/spark-4.1-bigquery-nightly-snapshot.jar"
 
+    gsutil cp "${M2REPO}/com/google/cloud/spark/spark-4.2-bigquery/${BUILD_REVISION}-preview/spark-4.2-bigquery-${BUILD_REVISION}-preview.jar" "gs://${BUCKET}"
+    gsutil cp "gs://${BUCKET}/spark-4.2-bigquery-${BUILD_REVISION}-preview.jar" "gs://${BUCKET}/spark-4.2-bigquery-nightly-snapshot.jar"
+
     gsutil cp "${M2REPO}/com/google/cloud/spark/spark-bigquery-metrics/${BUILD_REVISION}/spark-bigquery-metrics-${BUILD_REVISION}.jar" "gs://${BUCKET}"
     gsutil cp "gs://${BUCKET}/spark-bigquery-metrics-${BUILD_REVISION}.jar" "gs://${BUCKET}/spark-bigquery-metrics-nightly-snapshot.jar"
 
@@ -102,7 +105,7 @@ case $STEP in
 
   deploy)
     # TODO: Re-enable deployment for nightly builds.
-    # $MVN deploy:deploy -DskipTests -Dscala.skipTests=true -Prelease-nightly,dsv1_2.12,dsv1_2.13,dsv2_3.1,dsv2_3.2,dsv2_3.3,dsv2_3.4,dsv2_3.5,dsv2_4.0,dsv2_4.1
+    # $MVN deploy:deploy -DskipTests -Dscala.skipTests=true -Prelease-nightly,dsv1_2.12,dsv1_2.13,dsv2_3.1,dsv2_3.2,dsv2_3.3,dsv2_3.4,dsv2_3.5,dsv2_4.0,dsv2_4.1,dsv2_4.2
     exit
     ;;
 
@@ -111,4 +114,3 @@ case $STEP in
     exit 1
     ;;
 esac
-

--- a/cloudbuild/presubmit.sh
+++ b/cloudbuild/presubmit.sh
@@ -41,7 +41,7 @@ case $STEP in
 
     export MAVEN_OPTS=${BUILD_OPTS}
     export JAVA_HOME=${JAVA17_HOME}
-    $MVN -T 1C install -DskipTests -Pdsv1_2.12,dsv1_2.13,dsv2_3.1,dsv2_3.2,dsv2_3.3,dsv2_3.4,dsv2_3.5,dsv2_4.0,dsv2_4.1
+    $MVN -T 1C install -DskipTests -Pdsv1_2.12,dsv1_2.13,dsv2_3.1,dsv2_3.2,dsv2_3.3,dsv2_3.4,dsv2_3.5,dsv2_4.0,dsv2_4.1,dsv2_4.2
     exit
     ;;
 
@@ -49,7 +49,7 @@ case $STEP in
   unittest)
     export MAVEN_OPTS=${BUILD_OPTS}
     export JAVA_HOME=${JAVA17_HOME}
-    $MVN -T 1C test jacoco:report jacoco:report-aggregate -Pcoverage,dsv1_2.12,dsv1_2.13,dsv2_3.1,dsv2_3.2,dsv2_3.3,dsv2_3.4,dsv2_3.5,dsv2_4.0,dsv2_4.1
+    $MVN -T 1C test jacoco:report jacoco:report-aggregate -Pcoverage,dsv1_2.12,dsv1_2.13,dsv2_3.1,dsv2_3.2,dsv2_3.3,dsv2_3.4,dsv2_3.5,dsv2_4.0,dsv2_4.1,dsv2_4.2
     # Upload test coverage report to Codecov
     bash <(curl -s https://codecov.io/bash) -K -F "${STEP}"
     ;;
@@ -101,6 +101,11 @@ case $STEP in
   # Run integration tests
   integrationtest-4.1)
     $MVN failsafe:integration-test failsafe:verify jacoco:report jacoco:report-aggregate -Pcoverage,integration,dsv2_4.1
+    ;;
+
+  # Run integration tests
+  integrationtest-4.2)
+    $MVN failsafe:integration-test failsafe:verify jacoco:report jacoco:report-aggregate -Pcoverage,integration,dsv2_4.2
     ;;
 
   upload-it-to-codecov)

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -246,6 +246,11 @@
           <artifactId>spark-4.1-bigquery</artifactId>
           <version>${project.version}-preview</version>
         </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>spark-4.2-bigquery</artifactId>
+          <version>${project.version}-preview</version>
+        </dependency>
       </dependencies>
     </profile>
     <profile>
@@ -510,6 +515,64 @@
         <dependency>
           <groupId>${project.groupId}</groupId>
           <artifactId>spark-4.1-bigquery</artifactId>
+          <version>${project.version}-preview</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>dsv2_4.2</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>spark-bigquery-dsv2-common</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>spark-3.1-bigquery-lib</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>spark-3.2-bigquery-lib</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>spark-3.3-bigquery-lib</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>spark-3.4-bigquery-lib</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>spark-3.5-bigquery-lib</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>spark-4.0-bigquery-lib</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>spark-4.1-bigquery-lib</artifactId>
+          <version>${project.version}-preview</version>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>spark-4.2-bigquery-lib</artifactId>
+          <version>${project.version}-preview</version>
+        </dependency>
+        <dependency>
+          <groupId>${project.groupId}</groupId>
+          <artifactId>spark-4.2-bigquery</artifactId>
           <version>${project.version}-preview</version>
         </dependency>
       </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,26 @@
       </modules>
     </profile>
     <profile>
+      <id>dsv2_4.2</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <modules>
+        <module>spark-bigquery-dsv2/spark-bigquery-dsv2-common</module>
+        <module>spark-bigquery-dsv2/spark-bigquery-dsv2-parent</module>
+        <module>spark-bigquery-dsv2/spark-3.1-bigquery-lib</module>
+        <module>spark-bigquery-dsv2/spark-bigquery-metrics</module>
+        <module>spark-bigquery-dsv2/spark-3.2-bigquery-lib</module>
+        <module>spark-bigquery-dsv2/spark-3.3-bigquery-lib</module>
+        <module>spark-bigquery-dsv2/spark-3.4-bigquery-lib</module>
+        <module>spark-bigquery-dsv2/spark-3.5-bigquery-lib</module>
+        <module>spark-bigquery-dsv2/spark-4.0-bigquery-lib</module>
+        <module>spark-bigquery-dsv2/spark-4.1-bigquery-lib</module>
+        <module>spark-bigquery-dsv2/spark-4.2-bigquery-lib</module>
+        <module>spark-bigquery-dsv2/spark-4.2-bigquery</module>
+      </modules>
+    </profile>
+    <profile>
       <id>coverage</id>
       <activation>
         <activeByDefault>false</activeByDefault>

--- a/spark-bigquery-dsv2/pom.xml
+++ b/spark-bigquery-dsv2/pom.xml
@@ -30,5 +30,7 @@
     <module>spark-4.0-bigquery</module>
     <module>spark-4.1-bigquery-lib</module>
     <module>spark-4.1-bigquery</module>
+    <module>spark-4.2-bigquery-lib</module>
+    <module>spark-4.2-bigquery</module>
   </modules>
 </project>

--- a/spark-bigquery-dsv2/spark-4.2-bigquery-lib/pom.xml
+++ b/spark-bigquery-dsv2/spark-4.2-bigquery-lib/pom.xml
@@ -1,0 +1,59 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.google.cloud.spark</groupId>
+    <artifactId>spark-bigquery-dsv2-parent</artifactId>
+    <version>${revision}</version>
+    <relativePath>../spark-bigquery-dsv2-parent</relativePath>
+  </parent>
+
+  <artifactId>spark-4.2-bigquery-lib</artifactId>
+  <version>${revision}-preview</version>
+  <name>Connector code for BigQuery DataSource v2 for Spark 4.2</name>
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+    <spark.version>4.2.0</spark.version>
+    <scala.binary.version>2.13</scala.binary.version>
+    <shade.skip>true</shade.skip>
+    <toolchain.jdk.version>[17,18)</toolchain.jdk.version>
+    <argLine>${jdk11plus.argLine}</argLine>
+  </properties>
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.arrow</groupId>
+        <artifactId>arrow-bom</artifactId>
+        <version>${arrow.spark4.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.arrow</groupId>
+        <artifactId>arrow-memory-netty-buffer-patch</artifactId>
+        <version>${arrow.spark4.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>spark-4.1-bigquery-lib</artifactId>
+      <version>${project.parent.version}-preview</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-avro_2.13</artifactId>
+      <version>${spark.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/spark-bigquery-dsv2/spark-4.2-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark42BigQueryTable.java
+++ b/spark-bigquery-dsv2/spark-4.2-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark42BigQueryTable.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.v2;
+
+import com.google.inject.Injector;
+import java.util.function.Supplier;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.WriteBuilder;
+import org.apache.spark.sql.types.StructType;
+
+public class Spark42BigQueryTable extends Spark41BigQueryTable {
+  public Spark42BigQueryTable(Injector injector, Supplier<StructType> schemaSupplier) {
+    super(injector, schemaSupplier);
+  }
+
+  @Override
+  public WriteBuilder newWriteBuilder(LogicalWriteInfo info) {
+    // SaveMode is not provided by Spark DSv2, it is handled by the DataFrameWriter.
+    // SaveMode.Ignore is handled by Spark, so Append is the correct default context here.
+    return new Spark42BigQueryWriteBuilder(injector, info, SaveMode.Append);
+  }
+}

--- a/spark-bigquery-dsv2/spark-4.2-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark42BigQueryTableProvider.java
+++ b/spark-bigquery-dsv2/spark-4.2-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark42BigQueryTableProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.v2;
+
+import java.util.Map;
+import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.types.StructType;
+
+public class Spark42BigQueryTableProvider extends Spark41BigQueryTableProvider {
+  @Override
+  public Table getTable(
+      StructType schema, Transform[] partitioning, Map<String, String> properties) {
+    return Spark3Util.createBigQueryTableInstance(Spark42BigQueryTable::new, schema, properties);
+  }
+
+  @Override
+  protected Table getBigQueryTableInternal(Map<String, String> properties) {
+    return Spark3Util.createBigQueryTableInstance(Spark42BigQueryTable::new, null, properties);
+  }
+}

--- a/spark-bigquery-dsv2/spark-4.2-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark42BigQueryWriteBuilder.java
+++ b/spark-bigquery-dsv2/spark-4.2-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark42BigQueryWriteBuilder.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.v2;
+
+import com.google.inject.Injector;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.connector.write.LogicalWriteInfo;
+import org.apache.spark.sql.connector.write.V1Write;
+import org.apache.spark.sql.connector.write.Write;
+
+public class Spark42BigQueryWriteBuilder extends Spark41BigQueryWriteBuilder
+    implements Write, V1Write {
+
+  public Spark42BigQueryWriteBuilder(Injector injector, LogicalWriteInfo info, SaveMode mode) {
+    super(injector, info, mode);
+  }
+}

--- a/spark-bigquery-dsv2/spark-4.2-bigquery-lib/src/main/resources/META-INF/services/com.google.cloud.spark.bigquery.TypeConverter
+++ b/spark-bigquery-dsv2/spark-4.2-bigquery-lib/src/main/resources/META-INF/services/com.google.cloud.spark.bigquery.TypeConverter
@@ -1,0 +1,1 @@
+com.google.cloud.spark.bigquery.v2.TimestampNTZTypeConverter

--- a/spark-bigquery-dsv2/spark-4.2-bigquery-lib/src/test/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/spark-bigquery-dsv2/spark-4.2-bigquery-lib/src/test/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,0 +1,1 @@
+com.google.cloud.spark.bigquery.v2.Spark42BigQueryTableProvider

--- a/spark-bigquery-dsv2/spark-4.2-bigquery/pom.xml
+++ b/spark-bigquery-dsv2/spark-4.2-bigquery/pom.xml
@@ -1,0 +1,59 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>com.google.cloud.spark</groupId>
+    <artifactId>spark-bigquery-dsv2-parent</artifactId>
+    <version>${revision}</version>
+    <relativePath>../spark-bigquery-dsv2-parent</relativePath>
+  </parent>
+
+  <artifactId>spark-4.2-bigquery</artifactId>
+  <version>${revision}-preview</version>
+  <name>BigQuery DataSource v2 for Spark 4.2</name>
+  <properties>
+    <maven.compiler.release>17</maven.compiler.release>
+    <scala.binary.version>2.13</scala.binary.version>
+    <spark.version>4.2.0</spark.version>
+    <shade.skip>false</shade.skip>
+    <toolchain.jdk.version>[17,18)</toolchain.jdk.version>
+    <argLine>${jdk11plus.argLine}</argLine>
+  </properties>
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.arrow</groupId>
+        <artifactId>arrow-bom</artifactId>
+        <version>${arrow.spark4.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.arrow</groupId>
+        <artifactId>arrow-memory-netty-buffer-patch</artifactId>
+        <version>${arrow.spark4.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>spark-4.2-bigquery-lib</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-avro_2.13</artifactId>
+      <version>${spark.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/spark-bigquery-dsv2/spark-4.2-bigquery/src/build/resources/spark-bigquery-connector.properties
+++ b/spark-bigquery-dsv2/spark-4.2-bigquery/src/build/resources/spark-bigquery-connector.properties
@@ -1,0 +1,1 @@
+connector.version=${project.version}

--- a/spark-bigquery-dsv2/spark-4.2-bigquery/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/spark-bigquery-dsv2/spark-4.2-bigquery/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,0 +1,1 @@
+com.google.cloud.spark.bigquery.v2.Spark42BigQueryTableProvider

--- a/spark-bigquery-dsv2/spark-4.2-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark42CatalogIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-4.2-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark42CatalogIntegrationTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration;
+
+public class Spark42CatalogIntegrationTest extends CatalogIntegrationTestBase {
+  // all tests from superclass
+}

--- a/spark-bigquery-dsv2/spark-4.2-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark42DirectWriteIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-4.2-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark42DirectWriteIntegrationTest.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration;
+
+import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
+import org.apache.spark.sql.types.DataTypes;
+
+public class Spark42DirectWriteIntegrationTest extends WriteIntegrationTestBase {
+
+  public Spark42DirectWriteIntegrationTest() {
+    super(SparkBigQueryConfig.WriteMethod.DIRECT, DataTypes.TimestampNTZType);
+  }
+
+  // tests from superclass
+}

--- a/spark-bigquery-dsv2/spark-4.2-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark42IndirectWriteIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-4.2-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark42IndirectWriteIntegrationTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration;
+
+import com.google.cloud.spark.bigquery.SparkBigQueryConfig;
+import org.apache.spark.sql.types.DataTypes;
+import org.junit.Before;
+
+public class Spark42IndirectWriteIntegrationTest extends WriteIntegrationTestBase {
+
+  public Spark42IndirectWriteIntegrationTest() {
+    super(SparkBigQueryConfig.WriteMethod.INDIRECT, DataTypes.TimestampNTZType);
+  }
+
+  @Before
+  public void setParquetLoadBehaviour() {
+    // TODO: make this the default value
+    spark.conf().set("enableListInference", "true");
+  }
+
+  // tests from superclass
+}

--- a/spark-bigquery-dsv2/spark-4.2-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark42OpenLineageIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-4.2-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark42OpenLineageIntegrationTest.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2026 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration;
+
+public class Spark42OpenLineageIntegrationTest extends OpenLineageIntegrationTestBase {}

--- a/spark-bigquery-dsv2/spark-4.2-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark42ReadByFormatIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-4.2-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark42ReadByFormatIntegrationTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration;
+
+import org.apache.spark.sql.types.DataTypes;
+
+public class Spark42ReadByFormatIntegrationTest extends ReadByFormatIntegrationTestBase {
+
+  public Spark42ReadByFormatIntegrationTest() {
+    super("ARROW", /* userProvidedSchemaAllowed */ false, DataTypes.TimestampNTZType);
+  }
+
+  // tests are from the super-class
+}

--- a/spark-bigquery-dsv2/spark-4.2-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark42ReadFromQueryIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-4.2-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark42ReadFromQueryIntegrationTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration;
+
+public class Spark42ReadFromQueryIntegrationTest extends ReadFromQueryIntegrationTestBase {
+
+  public Spark42ReadFromQueryIntegrationTest() {
+    super(true);
+  }
+
+  // tests are from the super-class
+}

--- a/spark-bigquery-dsv2/spark-4.2-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark42ReadIntegrationTest.java
+++ b/spark-bigquery-dsv2/spark-4.2-bigquery/src/test/java/com/google/cloud/spark/bigquery/integration/Spark42ReadIntegrationTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.integration;
+
+import org.apache.spark.sql.types.DataTypes;
+
+public class Spark42ReadIntegrationTest extends ReadIntegrationTestBase {
+
+  public Spark42ReadIntegrationTest() {
+    super(/* userProvidedSchemaAllowed */ false, DataTypes.TimestampNTZType);
+  }
+
+  // tests are from the super-class
+}

--- a/spark-bigquery-dsv2/spark-4.2-bigquery/src/test/java/com/google/cloud/spark/bigquery/v2/Spark42CompatibilityTest.java
+++ b/spark-bigquery-dsv2/spark-4.2-bigquery/src/test/java/com/google/cloud/spark/bigquery/v2/Spark42CompatibilityTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.v2;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.ServiceLoader;
+import org.apache.spark.package$;
+import org.apache.spark.sql.sources.DataSourceRegister;
+import org.junit.Test;
+
+public class Spark42CompatibilityTest {
+
+  @Test
+  public void compiledAgainstSpark42() {
+    assertThat(package$.MODULE$.SPARK_VERSION()).isEqualTo("4.2.0");
+  }
+
+  @Test
+  public void discoversSpark42TableProvider() {
+    boolean foundSpark42Provider = false;
+    for (DataSourceRegister provider : ServiceLoader.load(DataSourceRegister.class)) {
+      foundSpark42Provider |= provider.getClass().equals(Spark42BigQueryTableProvider.class);
+    }
+    assertThat(foundSpark42Provider).isTrue();
+  }
+}


### PR DESCRIPTION
This PR is LLM generated using Codex w/gpt-5.6-sol. This seemed like an appropriate use of LLM code generation given the mechanistic nature of the addition. Please do let me know if this sort of contribution is not desired, however.

Closes #1508

