### PR TITLE
Add estimated bytes scanned metric

### DIFF
--- a/README-template.md
+++ b/README-template.md
@@ -1409,7 +1409,7 @@ word-break:break-word
 
 `bqEstimatedBytesScanned` is a BigQuery Storage Read Session estimate, not the exact `scanned_bytes` value from BigQuery audit logs or a billing guarantee. Spark aggregates the repeated per-task estimate using the maximum, so partitions, retries, and speculative attempts do not multiply it. The metric is not emitted for optimized empty-projection/count reads because they do not create a Read Session.
 
-**Note:** To use the metrics in the Spark UI page, you need to make sure the `spark-bigquery-metrics-${next-release-tag}.jar` is the class path before starting the history-server and the connector version is `spark-3.2` or above.
+**Note:** To use the metrics in the Spark UI page, you need to make sure the matching `spark-bigquery-metrics-${next-release-tag}.jar` is on the class path before starting the history-server and the connector version is `spark-3.2` or above.
 
 ## FAQ
 

--- a/README-template.md
+++ b/README-template.md
@@ -1386,6 +1386,10 @@ word-break:break-word
    <td>number of BigQuery bytes read</td>
   </tr>
   <tr valign="top">
+   <td><code>bqEstimatedBytesScanned</code></td>
+   <td>Read Session estimate of logical bytes scanned if all streams are consumed</td>
+  </tr>
+  <tr valign="top">
    <td><code>rows read</code></td>
    <td>number of BigQuery rows read</td>
   </tr>
@@ -1403,6 +1407,7 @@ word-break:break-word
   </tr>
 </table>
 
+`bqEstimatedBytesScanned` is a BigQuery Storage Read Session estimate, not the exact `scanned_bytes` value from BigQuery audit logs or a billing guarantee. Spark aggregates the repeated per-task estimate using the maximum, so partitions, retries, and speculative attempts do not multiply it. The metric is not emitted for optimized empty-projection/count reads because they do not create a Read Session.
 
 **Note:** To use the metrics in the Spark UI page, you need to make sure the `spark-bigquery-metrics-${next-release-tag}.jar` is the class path before starting the history-server and the connector version is `spark-3.2` or above.
 

--- a/README.md
+++ b/README.md
@@ -1380,6 +1380,10 @@ word-break:break-word
    <td>number of BigQuery bytes read</td>
   </tr>
   <tr valign="top">
+   <td><code>bqEstimatedBytesScanned</code></td>
+   <td>Read Session estimate of logical bytes scanned if all streams are consumed</td>
+  </tr>
+  <tr valign="top">
    <td><code>rows read</code></td>
    <td>number of BigQuery rows read</td>
   </tr>
@@ -1397,6 +1401,7 @@ word-break:break-word
   </tr>
 </table>
 
+`bqEstimatedBytesScanned` is a BigQuery Storage Read Session estimate, not the exact `scanned_bytes` value from BigQuery audit logs or a billing guarantee. Spark aggregates the repeated per-task estimate using the maximum, so partitions, retries, and speculative attempts do not multiply it. The metric is not emitted for optimized empty-projection/count reads because they do not create a Read Session.
 
 **Note:** To use the metrics in the Spark UI page, you need to make sure the `spark-bigquery-metrics-0.45.0.jar` is the class path before starting the history-server and the connector version is `spark-3.2` or above.
 

--- a/README.md
+++ b/README.md
@@ -1403,7 +1403,7 @@ word-break:break-word
 
 `bqEstimatedBytesScanned` is a BigQuery Storage Read Session estimate, not the exact `scanned_bytes` value from BigQuery audit logs or a billing guarantee. Spark aggregates the repeated per-task estimate using the maximum, so partitions, retries, and speculative attempts do not multiply it. The metric is not emitted for optimized empty-projection/count reads because they do not create a Read Session.
 
-**Note:** To use the metrics in the Spark UI page, you need to make sure the `spark-bigquery-metrics-0.45.0.jar` is the class path before starting the history-server and the connector version is `spark-3.2` or above.
+**Note:** To use the metrics in the Spark UI page, you need to make sure the matching `spark-bigquery-metrics-0.45.0.jar` is on the class path before starting the history-server and the connector version is `spark-3.2` or above.
 
 ## FAQ
 

--- a/spark-bigquery-dsv2/spark-3.2-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark32BigQueryPartitionReader.java
+++ b/spark-bigquery-dsv2/spark-3.2-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark32BigQueryPartitionReader.java
@@ -4,6 +4,9 @@ import static com.google.cloud.spark.bigquery.v2.customMetrics.SparkBigQueryCust
 
 import com.google.cloud.spark.bigquery.v2.context.InputPartitionReaderContext;
 import com.google.cloud.spark.bigquery.v2.customMetrics.SparkBigQueryTaskMetric;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalLong;
 import org.apache.spark.sql.connector.metric.CustomTaskMetric;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,36 +15,49 @@ public class Spark32BigQueryPartitionReader<T> extends BigQueryPartitionReader {
 
   public Logger log = LoggerFactory.getLogger(this.getClass());
   private InputPartitionReaderContext<T> context;
+  private final OptionalLong estimatedBytesScanned;
 
   public Spark32BigQueryPartitionReader(InputPartitionReaderContext context) {
+    this(context, OptionalLong.empty());
+  }
+
+  public Spark32BigQueryPartitionReader(
+      InputPartitionReaderContext context, OptionalLong estimatedBytesScanned) {
     super(context);
     this.context = context;
+    this.estimatedBytesScanned = estimatedBytesScanned;
   }
 
   @Override
   public CustomTaskMetric[] currentMetricsValues() {
     log.trace("in current metric values");
-    return context
+    List<CustomTaskMetric> metrics = new ArrayList<>();
+    context
         .getBigQueryStorageReadRowsTracer()
-        .map(
-            bigQueryStorageReadRowsTracer ->
-                new SparkBigQueryTaskMetric[] {
+        .ifPresent(
+            tracer -> {
+              metrics.add(
                   new SparkBigQueryTaskMetric(
-                      BIG_QUERY_BYTES_READ_METRIC_NAME,
-                      bigQueryStorageReadRowsTracer.getBytesRead()),
+                      BIG_QUERY_BYTES_READ_METRIC_NAME, tracer.getBytesRead()));
+              metrics.add(
                   new SparkBigQueryTaskMetric(
-                      BIG_QUERY_ROWS_READ_METRIC_NAME, bigQueryStorageReadRowsTracer.getRowsRead()),
+                      BIG_QUERY_ROWS_READ_METRIC_NAME, tracer.getRowsRead()));
+              metrics.add(
                   new SparkBigQueryTaskMetric(
-                      BIG_QUERY_SCAN_TIME_METRIC_NAME,
-                      bigQueryStorageReadRowsTracer.getScanTimeInMilliSec()),
+                      BIG_QUERY_SCAN_TIME_METRIC_NAME, tracer.getScanTimeInMilliSec()));
+              metrics.add(
                   new SparkBigQueryTaskMetric(
-                      BIG_QUERY_PARSE_TIME_METRIC_NAME,
-                      bigQueryStorageReadRowsTracer.getParseTimeInMilliSec()),
+                      BIG_QUERY_PARSE_TIME_METRIC_NAME, tracer.getParseTimeInMilliSec()));
+              metrics.add(
                   new SparkBigQueryTaskMetric(
-                      BIG_QUERY_TIME_IN_SPARK_METRIC_NAME,
-                      bigQueryStorageReadRowsTracer.getTimeInSparkInMilliSec()),
-                  new SparkBigQueryTaskMetric(BIG_QUERY_NUMBER_OF_READ_STREAMS_METRIC_NAME, 1)
-                })
-        .orElse(new SparkBigQueryTaskMetric[] {});
+                      BIG_QUERY_TIME_IN_SPARK_METRIC_NAME, tracer.getTimeInSparkInMilliSec()));
+              metrics.add(
+                  new SparkBigQueryTaskMetric(BIG_QUERY_NUMBER_OF_READ_STREAMS_METRIC_NAME, 1));
+            });
+    estimatedBytesScanned.ifPresent(
+        value ->
+            metrics.add(
+                new SparkBigQueryTaskMetric(BIG_QUERY_ESTIMATED_BYTES_SCANNED_METRIC_NAME, value)));
+    return metrics.toArray(new CustomTaskMetric[0]);
   }
 }

--- a/spark-bigquery-dsv2/spark-3.2-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark32BigQueryPartitionReader.java
+++ b/spark-bigquery-dsv2/spark-3.2-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark32BigQueryPartitionReader.java
@@ -17,12 +17,12 @@ public class Spark32BigQueryPartitionReader<T> extends BigQueryPartitionReader {
   private InputPartitionReaderContext<T> context;
   private final OptionalLong estimatedBytesScanned;
 
-  public Spark32BigQueryPartitionReader(InputPartitionReaderContext context) {
+  public Spark32BigQueryPartitionReader(InputPartitionReaderContext<T> context) {
     this(context, OptionalLong.empty());
   }
 
   public Spark32BigQueryPartitionReader(
-      InputPartitionReaderContext context, OptionalLong estimatedBytesScanned) {
+      InputPartitionReaderContext<T> context, OptionalLong estimatedBytesScanned) {
     super(context);
     this.context = context;
     this.estimatedBytesScanned = estimatedBytesScanned;

--- a/spark-bigquery-dsv2/spark-3.2-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark32BigQueryPartitionReaderFactory.java
+++ b/spark-bigquery-dsv2/spark-3.2-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark32BigQueryPartitionReaderFactory.java
@@ -12,13 +12,15 @@ public class Spark32BigQueryPartitionReaderFactory implements PartitionReaderFac
   @Override
   public PartitionReader<InternalRow> createReader(InputPartition partition) {
     InputPartitionContext<InternalRow> ctx = ((BigQueryInputPartition) partition).getContext();
-    return new Spark32BigQueryPartitionReader<>(ctx.createPartitionReaderContext());
+    return new Spark32BigQueryPartitionReader<>(
+        ctx.createPartitionReaderContext(), ctx.getEstimatedBytesScanned());
   }
 
   @Override
   public PartitionReader<ColumnarBatch> createColumnarReader(InputPartition partition) {
     InputPartitionContext<ColumnarBatch> ctx = ((BigQueryInputPartition) partition).getContext();
-    return new Spark32BigQueryPartitionReader<>(ctx.createPartitionReaderContext());
+    return new Spark32BigQueryPartitionReader<>(
+        ctx.createPartitionReaderContext(), ctx.getEstimatedBytesScanned());
   }
 
   @Override

--- a/spark-bigquery-dsv2/spark-3.2-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark32BigQueryScanBuilder.java
+++ b/spark-bigquery-dsv2/spark-3.2-bigquery-lib/src/main/java/com/google/cloud/spark/bigquery/v2/Spark32BigQueryScanBuilder.java
@@ -74,7 +74,8 @@ public class Spark32BigQueryScanBuilder extends Spark31BigQueryScanBuilder
       new SparkBigQueryScanTimeMetric(),
       new SparkBigQueryParseTimeMetric(),
       new SparkBigQueryTimeInSparkMetric(),
-      new SparkBigQueryNumberOfReadStreamsMetric()
+      new SparkBigQueryNumberOfReadStreamsMetric(),
+      new SparkBigQueryEstimatedBytesScannedMetric()
     };
   }
 

--- a/spark-bigquery-dsv2/spark-3.2-bigquery-lib/src/test/java/com/google/cloud/spark/bigquery/v2/Spark32BigQueryPartitionReaderTest.java
+++ b/spark-bigquery-dsv2/spark-3.2-bigquery-lib/src/test/java/com/google/cloud/spark/bigquery/v2/Spark32BigQueryPartitionReaderTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spark.bigquery.v2;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.bigquery.connector.common.BigQueryStorageReadRowsTracer;
+import com.google.cloud.spark.bigquery.v2.context.InputPartitionContext;
+import com.google.cloud.spark.bigquery.v2.context.InputPartitionReaderContext;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.stream.Collectors;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.metric.CustomTaskMetric;
+import org.apache.spark.sql.connector.read.PartitionReader;
+import org.junit.Test;
+
+public class Spark32BigQueryPartitionReaderTest {
+
+  @Test
+  public void currentMetricsValuesWithoutTracerContainsEstimate() {
+    CustomTaskMetric[] metrics = currentMetricsValues(Optional.empty(), OptionalLong.of(1024L));
+
+    assertThat(metrics).hasLength(1);
+    assertThat(metrics[0].name()).isEqualTo("bqEstimatedBytesScanned");
+    assertThat(metrics[0].value()).isEqualTo(1024L);
+  }
+
+  @Test
+  public void currentMetricsValuesWithTracerContainsExistingMetricsAndEstimate() {
+    CustomTaskMetric[] metrics =
+        currentMetricsValues(Optional.of(new TestTracer()), OptionalLong.of(1024L));
+
+    assertThat(metricsByName(metrics))
+        .containsExactly(
+            "bqBytesRead", 11L,
+            "bqRowsRead", 12L,
+            "bqScanTime", 13L,
+            "bqParseTime", 14L,
+            "bqTimeInSpark", 15L,
+            "bqNumReadStreams", 1L,
+            "bqEstimatedBytesScanned", 1024L);
+  }
+
+  @Test
+  public void currentMetricsValuesWithoutReadSessionDoesNotContainEstimate() {
+    assertThat(currentMetricsValues(Optional.empty(), OptionalLong.empty())).isEmpty();
+  }
+
+  private static CustomTaskMetric[] currentMetricsValues(
+      Optional<BigQueryStorageReadRowsTracer> tracer, OptionalLong estimatedBytesScanned) {
+    TestPartitionReaderContext readerContext = new TestPartitionReaderContext(tracer);
+    TestInputPartitionContext partitionContext =
+        new TestInputPartitionContext(readerContext, estimatedBytesScanned);
+    PartitionReader<InternalRow> reader =
+        new Spark32BigQueryPartitionReaderFactory()
+            .createReader(new BigQueryInputPartition(partitionContext));
+    return ((Spark32BigQueryPartitionReader<?>) reader).currentMetricsValues();
+  }
+
+  private static Map<String, Long> metricsByName(CustomTaskMetric[] metrics) {
+    return Arrays.stream(metrics)
+        .collect(Collectors.toMap(CustomTaskMetric::name, CustomTaskMetric::value));
+  }
+
+  private static class TestInputPartitionContext implements InputPartitionContext<InternalRow> {
+    private final TestPartitionReaderContext readerContext;
+    private final OptionalLong estimatedBytesScanned;
+
+    TestInputPartitionContext(
+        TestPartitionReaderContext readerContext, OptionalLong estimatedBytesScanned) {
+      this.readerContext = readerContext;
+      this.estimatedBytesScanned = estimatedBytesScanned;
+    }
+
+    @Override
+    public InputPartitionReaderContext<InternalRow> createPartitionReaderContext() {
+      return readerContext;
+    }
+
+    @Override
+    public boolean supportColumnarReads() {
+      return false;
+    }
+
+    @Override
+    public OptionalLong getEstimatedBytesScanned() {
+      return estimatedBytesScanned;
+    }
+  }
+
+  private static class TestPartitionReaderContext
+      implements InputPartitionReaderContext<InternalRow> {
+    private final Optional<BigQueryStorageReadRowsTracer> tracer;
+
+    TestPartitionReaderContext(Optional<BigQueryStorageReadRowsTracer> tracer) {
+      this.tracer = tracer;
+    }
+
+    @Override
+    public boolean next() {
+      return false;
+    }
+
+    @Override
+    public InternalRow get() {
+      return null;
+    }
+
+    @Override
+    public Optional<BigQueryStorageReadRowsTracer> getBigQueryStorageReadRowsTracer() {
+      return tracer;
+    }
+
+    @Override
+    public void close() throws IOException {}
+  }
+
+  private static class TestTracer implements BigQueryStorageReadRowsTracer {
+
+    @Override
+    public void startStream() {}
+
+    @Override
+    public void rowsParseStarted() {}
+
+    @Override
+    public void rowsParseFinished(long rowsParsed) {}
+
+    @Override
+    public void readRowsResponseRequested() {}
+
+    @Override
+    public void readRowsResponseObtained(long bytesReceived) {}
+
+    @Override
+    public void finished() {}
+
+    @Override
+    public void nextBatchNeeded() {}
+
+    @Override
+    public BigQueryStorageReadRowsTracer forkWithPrefix(String id) {
+      return this;
+    }
+
+    @Override
+    public long getBytesRead() {
+      return 11L;
+    }
+
+    @Override
+    public long getRowsRead() {
+      return 12L;
+    }
+
+    @Override
+    public long getScanTimeInMilliSec() {
+      return 13L;
+    }
+
+    @Override
+    public long getParseTimeInMilliSec() {
+      return 14L;
+    }
+
+    @Override
+    public long getTimeInSparkInMilliSec() {
+      return 15L;
+    }
+  }
+}

--- a/spark-bigquery-dsv2/spark-3.2-bigquery-lib/src/test/java/com/google/cloud/spark/bigquery/v2/Spark32BigQueryScanBuilderTest.java
+++ b/spark-bigquery-dsv2/spark-3.2-bigquery-lib/src/test/java/com/google/cloud/spark/bigquery/v2/Spark32BigQueryScanBuilderTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spark.bigquery.v2;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.bigquery.connector.common.ReadRowsHelper;
+import com.google.cloud.bigquery.connector.common.ReadSessionResponse;
+import com.google.cloud.bigquery.storage.v1.ReadSession;
+import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions.ResponseCompressionCodec;
+import com.google.cloud.spark.bigquery.v2.context.ArrowInputPartitionContext;
+import com.google.cloud.spark.bigquery.v2.context.BigQueryDataSourceReaderContext;
+import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.spark.sql.connector.metric.CustomMetric;
+import org.apache.spark.sql.connector.read.InputPartition;
+import org.apache.spark.sql.sources.Filter;
+import org.junit.Test;
+
+public class Spark32BigQueryScanBuilderTest {
+
+  @Test
+  public void supportedCustomMetricsIncludesEstimatedBytesScanned() {
+    Spark32BigQueryScanBuilder scanBuilder = new Spark32BigQueryScanBuilder(null);
+
+    assertThat(
+            Arrays.stream(scanBuilder.supportedCustomMetrics())
+                .map(CustomMetric::name)
+                .collect(Collectors.toList()))
+        .containsExactly(
+            "bqBytesRead",
+            "bqRowsRead",
+            "bqScanTime",
+            "bqParseTime",
+            "bqTimeInSpark",
+            "bqNumReadStreams",
+            "bqEstimatedBytesScanned")
+        .inOrder();
+  }
+
+  @Test
+  public void runtimeFilteringUsesReplacementSessionEstimate() {
+    BigQueryDataSourceReaderContext context = mock(BigQueryDataSourceReaderContext.class);
+    ArrowInputPartitionContext replacementPartition = arrowPartition(2048L);
+    when(context.filter(any(Filter[].class)))
+        .thenReturn(Optional.of(ImmutableList.of(replacementPartition)));
+    Spark32BigQueryScanBuilder scanBuilder = new Spark32BigQueryScanBuilder(context);
+
+    scanBuilder.filter(new Filter[] {});
+    InputPartition[] partitions = scanBuilder.planInputPartitions();
+
+    assertThat(((BigQueryInputPartition) partitions[0]).getContext().getEstimatedBytesScanned())
+        .hasValue(2048L);
+  }
+
+  private static ArrowInputPartitionContext arrowPartition(long estimatedBytesScanned) {
+    ReadSession readSession =
+        ReadSession.newBuilder().setEstimatedTotalBytesScanned(estimatedBytesScanned).build();
+    return new ArrowInputPartitionContext(
+        /* bigQueryClientFactory= */ null,
+        /* tracerFactory= */ null,
+        ImmutableList.of("streamName"),
+        new ReadRowsHelper.Options(
+            /* maxRetries= */ 5,
+            Optional.of("endpoint"),
+            /* backgroundParsingThreads= */ 5,
+            /* prebufferResponses= */ 1),
+        ImmutableList.of(),
+        new ReadSessionResponse(readSession, null),
+        Optional.empty(),
+        /* sparkBigQueryReadSessionMetrics= */ null,
+        ResponseCompressionCodec.RESPONSE_COMPRESSION_CODEC_UNSPECIFIED);
+  }
+}

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/ArrowInputPartitionContext.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/ArrowInputPartitionContext.java
@@ -33,6 +33,7 @@ import com.google.protobuf.ByteString;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.stream.Collectors;
 import org.apache.spark.SparkEnv;
 import org.apache.spark.TaskContext;
@@ -53,6 +54,7 @@ public class ArrowInputPartitionContext implements InputPartitionContext<Columna
   private final SparkBigQueryReadSessionMetrics sparkBigQueryReadSessionMetrics;
   private final ResponseCompressionCodec responseCompressionCodec;
   private final boolean enableTimestampRebase;
+  private final long estimatedBytesScanned;
 
   public ArrowInputPartitionContext(
       BigQueryClientFactory bigQueryReadClientFactory,
@@ -94,6 +96,8 @@ public class ArrowInputPartitionContext implements InputPartitionContext<Columna
     this.selectedFields = selectedFields;
     this.serializedArrowSchema =
         readSessionResponse.getReadSession().getArrowSchema().getSerializedSchema();
+    this.estimatedBytesScanned =
+        readSessionResponse.getReadSession().getEstimatedTotalBytesScanned();
     this.tracerFactory = tracerFactory;
     this.userProvidedSchema = fromJavaUtil(userProvidedSchema);
     this.sparkBigQueryReadSessionMetrics = sparkBigQueryReadSessionMetrics;
@@ -141,5 +145,10 @@ public class ArrowInputPartitionContext implements InputPartitionContext<Columna
   @Override
   public boolean supportColumnarReads() {
     return true;
+  }
+
+  @Override
+  public OptionalLong getEstimatedBytesScanned() {
+    return OptionalLong.of(estimatedBytesScanned);
   }
 }

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryDataSourceReaderContext.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryDataSourceReaderContext.java
@@ -202,8 +202,8 @@ public class BigQueryDataSourceReaderContext {
                     bigQueryReadClientFactory,
                     stream.getName(),
                     readSessionCreatorConfig.toReadRowsHelperOptions(),
-                    createConverter(
-                        selectedFields, readSessionResponse.get(), userProvidedSchema)));
+                    createConverter(selectedFields, readSessionResponse.get(), userProvidedSchema),
+                    readSession.getEstimatedTotalBytesScanned()));
   }
 
   public Optional<String> getCombinedFilter() {

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryInputPartitionContext.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/BigQueryInputPartitionContext.java
@@ -22,6 +22,7 @@ import com.google.cloud.bigquery.storage.v1.ReadRowsResponse;
 import com.google.cloud.spark.bigquery.ReadRowsResponseToInternalRowIteratorConverter;
 import java.util.Iterator;
 import java.util.Optional;
+import java.util.OptionalLong;
 import org.apache.spark.sql.catalyst.InternalRow;
 
 public class BigQueryInputPartitionContext implements InputPartitionContext<InternalRow> {
@@ -30,16 +31,19 @@ public class BigQueryInputPartitionContext implements InputPartitionContext<Inte
   private final String streamName;
   private final ReadRowsHelper.Options options;
   private final ReadRowsResponseToInternalRowIteratorConverter converter;
+  private final long estimatedBytesScanned;
 
   public BigQueryInputPartitionContext(
       BigQueryClientFactory bigQueryReadClientFactory,
       String streamName,
       ReadRowsHelper.Options options,
-      ReadRowsResponseToInternalRowIteratorConverter converter) {
+      ReadRowsResponseToInternalRowIteratorConverter converter,
+      long estimatedBytesScanned) {
     this.bigQueryReadClientFactory = bigQueryReadClientFactory;
     this.streamName = streamName;
     this.options = options;
     this.converter = converter;
+    this.estimatedBytesScanned = estimatedBytesScanned;
   }
 
   @Override
@@ -55,5 +59,10 @@ public class BigQueryInputPartitionContext implements InputPartitionContext<Inte
   @Override
   public boolean supportColumnarReads() {
     return false;
+  }
+
+  @Override
+  public OptionalLong getEstimatedBytesScanned() {
+    return OptionalLong.of(estimatedBytesScanned);
   }
 }

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/InputPartitionContext.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/main/java/com/google/cloud/spark/bigquery/v2/context/InputPartitionContext.java
@@ -16,10 +16,15 @@
 package com.google.cloud.spark.bigquery.v2.context;
 
 import java.io.Serializable;
+import java.util.OptionalLong;
 
 public interface InputPartitionContext<T> extends Serializable {
 
   InputPartitionReaderContext<T> createPartitionReaderContext();
 
   boolean supportColumnarReads();
+
+  default OptionalLong getEstimatedBytesScanned() {
+    return OptionalLong.empty();
+  }
 }

--- a/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/test/java/com/google/cloud/spark/bigquery/v2/context/InputPartitionContextTest.java
+++ b/spark-bigquery-dsv2/spark-bigquery-dsv2-common/src/test/java/com/google/cloud/spark/bigquery/v2/context/InputPartitionContextTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spark.bigquery.v2.context;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.bigquery.connector.common.ReadRowsHelper;
+import com.google.cloud.bigquery.connector.common.ReadSessionResponse;
+import com.google.cloud.bigquery.storage.v1.ReadSession;
+import com.google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions.ResponseCompressionCodec;
+import com.google.common.collect.ImmutableList;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Optional;
+import org.junit.Test;
+
+public class InputPartitionContextTest {
+
+  private static final long ESTIMATED_BYTES_SCANNED = 4096L;
+
+  @Test
+  public void arrowContextRetainsEstimateWhenSerialized() throws Exception {
+    ArrowInputPartitionContext context =
+        new ArrowInputPartitionContext(
+            /* bigQueryClientFactory= */ null,
+            /* tracerFactory= */ null,
+            ImmutableList.of("streamName"),
+            readRowsOptions(),
+            ImmutableList.of(),
+            readSessionResponse(),
+            Optional.empty(),
+            /* sparkBigQueryReadSessionMetrics= */ null,
+            ResponseCompressionCodec.RESPONSE_COMPRESSION_CODEC_UNSPECIFIED);
+
+    ArrowInputPartitionContext deserialized = serializeAndDeserialize(context);
+
+    assertThat(deserialized.getEstimatedBytesScanned()).hasValue(ESTIMATED_BYTES_SCANNED);
+  }
+
+  @Test
+  public void avroContextRetainsEstimateWhenSerialized() throws Exception {
+    BigQueryInputPartitionContext context =
+        new BigQueryInputPartitionContext(
+            /* bigQueryReadClientFactory= */ null,
+            "streamName",
+            readRowsOptions(),
+            /* converter= */ null,
+            ESTIMATED_BYTES_SCANNED);
+
+    BigQueryInputPartitionContext deserialized = serializeAndDeserialize(context);
+
+    assertThat(deserialized.getEstimatedBytesScanned()).hasValue(ESTIMATED_BYTES_SCANNED);
+  }
+
+  @Test
+  public void emptyProjectionContextHasNoEstimate() {
+    assertThat(new EmptyProjectionInputPartitionContext(1).getEstimatedBytesScanned()).isEmpty();
+  }
+
+  private static ReadRowsHelper.Options readRowsOptions() {
+    return new ReadRowsHelper.Options(
+        /* maxRetries= */ 5,
+        Optional.of("endpoint"),
+        /* backgroundParsingThreads= */ 5,
+        /* prebufferResponses= */ 1);
+  }
+
+  private static ReadSessionResponse readSessionResponse() {
+    ReadSession readSession =
+        ReadSession.newBuilder().setEstimatedTotalBytesScanned(ESTIMATED_BYTES_SCANNED).build();
+    return new ReadSessionResponse(readSession, null);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends Serializable> T serializeAndDeserialize(T value)
+      throws IOException, ClassNotFoundException {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+      output.writeObject(value);
+    }
+    try (ObjectInputStream input =
+        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      return (T) input.readObject();
+    }
+  }
+}

--- a/spark-bigquery-dsv2/spark-bigquery-metrics/src/main/java/com/google/cloud/spark/bigquery/v2/customMetrics/MetricUtils.java
+++ b/spark-bigquery-dsv2/spark-bigquery-metrics/src/main/java/com/google/cloud/spark/bigquery/v2/customMetrics/MetricUtils.java
@@ -31,6 +31,10 @@ class MetricUtils {
     return bytesToString(Arrays.stream(taskMetrics).sum());
   }
 
+  static String formatMaxSizeMetric(long[] taskMetrics) {
+    return bytesToString(Arrays.stream(taskMetrics).max().orElse(0));
+  }
+
   static String formatSumMetrics(long[] taskMetrics) {
     return NUMBER_FORMAT_US.format(Arrays.stream(taskMetrics).sum());
   }

--- a/spark-bigquery-dsv2/spark-bigquery-metrics/src/main/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryCustomMetricConstants.java
+++ b/spark-bigquery-dsv2/spark-bigquery-metrics/src/main/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryCustomMetricConstants.java
@@ -3,6 +3,10 @@ package com.google.cloud.spark.bigquery.v2.customMetrics;
 public class SparkBigQueryCustomMetricConstants {
   public static final String BIG_QUERY_BYTES_READ_METRIC_NAME = "bqBytesRead";
   static final String BIG_QUERY_BYTES_READ_METRIC_DESCRIPTION = "number of BQ bytes read";
+  public static final String BIG_QUERY_ESTIMATED_BYTES_SCANNED_METRIC_NAME =
+      "bqEstimatedBytesScanned";
+  static final String BIG_QUERY_ESTIMATED_BYTES_SCANNED_METRIC_DESCRIPTION =
+      "estimated logical bytes scanned by BigQuery Storage API";
   public static final String BIG_QUERY_ROWS_READ_METRIC_NAME = "bqRowsRead";
   static final String BIG_QUERY_ROWS_READ_METRIC_DESCRIPTION = "number of BQ rows read";
   public static final String BIG_QUERY_SCAN_TIME_METRIC_NAME = "bqScanTime";

--- a/spark-bigquery-dsv2/spark-bigquery-metrics/src/main/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryEstimatedBytesScannedMetric.java
+++ b/spark-bigquery-dsv2/spark-bigquery-metrics/src/main/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryEstimatedBytesScannedMetric.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.spark.bigquery.v2.customMetrics;
+
+import static com.google.cloud.spark.bigquery.v2.customMetrics.SparkBigQueryCustomMetricConstants.BIG_QUERY_ESTIMATED_BYTES_SCANNED_METRIC_DESCRIPTION;
+import static com.google.cloud.spark.bigquery.v2.customMetrics.SparkBigQueryCustomMetricConstants.BIG_QUERY_ESTIMATED_BYTES_SCANNED_METRIC_NAME;
+
+import org.apache.spark.sql.connector.metric.CustomMetric;
+
+public class SparkBigQueryEstimatedBytesScannedMetric implements CustomMetric {
+
+  @Override
+  public String name() {
+    return BIG_QUERY_ESTIMATED_BYTES_SCANNED_METRIC_NAME;
+  }
+
+  @Override
+  public String description() {
+    return BIG_QUERY_ESTIMATED_BYTES_SCANNED_METRIC_DESCRIPTION;
+  }
+
+  @Override
+  public String aggregateTaskMetrics(long[] taskMetrics) {
+    return MetricUtils.formatMaxSizeMetric(taskMetrics);
+  }
+}

--- a/spark-bigquery-dsv2/spark-bigquery-metrics/src/test/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryEstimatedBytesScannedMetricTest.java
+++ b/spark-bigquery-dsv2/spark-bigquery-metrics/src/test/java/com/google/cloud/spark/bigquery/v2/customMetrics/SparkBigQueryEstimatedBytesScannedMetricTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.spark.bigquery.v2.customMetrics;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+public class SparkBigQueryEstimatedBytesScannedMetricTest {
+  private final SparkBigQueryEstimatedBytesScannedMetric metric =
+      new SparkBigQueryEstimatedBytesScannedMetric();
+
+  @Test
+  public void testName() {
+    assertThat(metric.name()).isEqualTo("bqEstimatedBytesScanned");
+  }
+
+  @Test
+  public void testDescription() {
+    assertThat(metric.description())
+        .isEqualTo("estimated logical bytes scanned by BigQuery Storage API");
+  }
+
+  @Test
+  public void testAggregateMetricsUsesMaximum() {
+    assertThat(metric.aggregateTaskMetrics(new long[] {1024L, 4096L, 2048L})).isEqualTo("4.0 KiB");
+  }
+
+  @Test
+  public void testAggregateMetricsDoesNotMultiplyRepeatedSessionEstimate() {
+    assertThat(metric.aggregateTaskMetrics(new long[] {4096L, 4096L, 4096L})).isEqualTo("4.0 KiB");
+  }
+
+  @Test
+  public void testAggregateMetricsWithNoTasksIsZero() {
+    assertThat(metric.aggregateTaskMetrics(new long[] {})).isEqualTo("0.0 B");
+  }
+}


### PR DESCRIPTION
## Summary

- Add the `bqEstimatedBytesScanned` custom metric for Spark 3.2+ DataSource V2 reads.
- Propagate the BigQuery Storage API Read Session estimate through Arrow and Avro partition contexts to Spark task metrics.
- Aggregate the repeated session-level estimate with the maximum value so partitions, retries, and speculative attempts do not inflate it.
- Document that this is an estimate of logical bytes scanned if all streams are consumed, not the exact audit-log `scanned_bytes` value or a billing guarantee. Optimized empty-projection/count reads do not emit it because they do not create a Read Session.

## Testing

- Add unit coverage for metric registration, formatting, and max aggregation.
- Verify partition readers emit the estimate with and without existing read metrics.
- Verify Arrow and Avro partition contexts preserve the estimate through serialization.
- Verify runtime filtering uses the replacement Read Session estimate and empty-projection reads omit the metric.